### PR TITLE
update path in server contributing guide

### DIFF
--- a/server/CONTRIBUTING.md
+++ b/server/CONTRIBUTING.md
@@ -17,6 +17,7 @@ own machine, and how to contribute.
 
 ### Compile
 - `cd graphql-engine`
+- `stack init`
 - `stack build --fast`
 
 ### Run

--- a/server/CONTRIBUTING.md
+++ b/server/CONTRIBUTING.md
@@ -16,8 +16,7 @@ own machine, and how to contribute.
 - Clone your forked repo: `git clone https://github.com/<your-username>/graphql-engine`
 
 ### Compile
-- `cd graphql-engine`
-- `stack init`
+- `cd graphql-engine/server`
 - `stack build --fast`
 
 ### Run


### PR DESCRIPTION
Following the compile instructions, I got this:

```
[estsauver@dirac graphql-engine]$ stack build --fast
Error parsing targets: The specified targets matched no packages.
Perhaps you need to run 'stack init'?
```