### PR TITLE
Convert function expression to an arrow function

### DIFF
--- a/console/webpack/webpack-isomorphic-tools.js
+++ b/console/webpack/webpack-isomorphic-tools.js
@@ -53,7 +53,7 @@ module.exports = {
 
     style_modules: {
       extensions: ['scss'],
-      filter: function(module, regex, options, log) {
+      filter: (module, regex, options, log) => {
         if (options.development) {
           // in development mode there's webpack "style-loader",
           // so the module.name is not equal to module.name
@@ -69,7 +69,7 @@ module.exports = {
           return regex.test(module.name);
         }
       },
-      path: function(module, options, log) {
+      path: (module, options, log) => {
         if (options.development) {
           // in development mode there's webpack "style-loader",
           // so the module.name is not equal to module.name
@@ -84,7 +84,7 @@ module.exports = {
           return module.name;
         }
       },
-      parser: function(module, options, log) {
+      parser: (module, options, log) => {
         if (options.development) {
           return WebpackIsomorphicToolsPlugin.css_modules_loader_parser(
             module,


### PR DESCRIPTION
Just a few cases of converting a traditional function to ES6 arrow functions. Pure refactoring.