### PR TITLE
filter schema identifiers to conform to GraphQL naming scheme (close #134)

### DIFF
--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -118,6 +118,9 @@ library
                      , base64-bytestring >= 1.0
                      , auto-update
 
+                     -- regex related
+                     , regex-compat
+
   exposed-modules:     Hasura.Server.App
                      , Hasura.Server.Auth
                      , Hasura.Server.Init

--- a/server/src-lib/Hasura/GraphQL/Schema.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema.hs
@@ -91,15 +91,15 @@ qualTableToName = G.Name <$> \case
   QualifiedTable sn tn -> getSchemaTxt sn <> "_" <> getTableTxt tn
 
 isTableEligible :: QualifiedTable -> Bool
-isTableEligible = isGraphQLConform . qualTableToName
+isTableEligible = isValidName . qualTableToName
 
 fieldFltr :: FieldInfo -> Bool
 fieldFltr = \case
   FIColumn (PGColInfo col _) -> isColEligible col
   FIRelationship (RelInfo rn _ _ remTab _) -> isRelEligible rn remTab
   where
-    isColEligible = isGraphQLConform . G.Name . getPGColTxt
-    isRelEligible rn rt = isGraphQLConform (G.Name $ getRelTxt rn)
+    isColEligible = isValidName . G.Name . getPGColTxt
+    isRelEligible rn rt = isValidName (G.Name $ getRelTxt rn)
                           && isTableEligible rt
 
 toSafeFieldInfos :: FieldInfoMap -> [FieldInfo]
@@ -112,7 +112,7 @@ mkSafeConstraints :: [TableConstraint] -> [TableConstraint]
 mkSafeConstraints = filter isSafe
   where
     isSafe (TableConstraint _ n) =
-      isGraphQLConform $ G.Name $ getConstraintTxt n
+      isValidName $ G.Name $ getConstraintTxt n
 
 mkCompExpName :: PGColType -> G.Name
 mkCompExpName pgColTy =

--- a/server/src-lib/Hasura/GraphQL/Utils.hs
+++ b/server/src-lib/Hasura/GraphQL/Utils.hs
@@ -15,6 +15,7 @@ module Hasura.GraphQL.Utils
   , mkMapWith
   , onLeft
   , showNames
+  , isGraphQLConform
   ) where
 
 import           Hasura.RQL.Types
@@ -24,6 +25,7 @@ import qualified Data.HashMap.Strict           as Map
 import qualified Data.List.NonEmpty            as NE
 import qualified Data.Text                     as T
 import qualified Language.GraphQL.Draft.Syntax as G
+import qualified Text.Regex                    as R
 
 showName :: G.Name -> Text
 showName name = "\"" <> G.unName name <> "\""
@@ -87,3 +89,10 @@ onLeft e f = either f return e
 showNames :: (Foldable t) => t G.Name -> Text
 showNames names =
   T.intercalate ", " $ map G.unName $ toList names
+
+-- Ref: http://facebook.github.io/graphql/June2018/#sec-Names
+isGraphQLConform :: G.Name -> Bool
+isGraphQLConform =
+  isJust . R.matchRegex regex . T.unpack . G.unName
+  where
+    regex = R.mkRegex "^[_a-zA-Z][_a-zA-Z0-9]*$"

--- a/server/src-lib/Hasura/GraphQL/Utils.hs
+++ b/server/src-lib/Hasura/GraphQL/Utils.hs
@@ -15,7 +15,7 @@ module Hasura.GraphQL.Utils
   , mkMapWith
   , onLeft
   , showNames
-  , isGraphQLConform
+  , isValidName
   ) where
 
 import           Hasura.RQL.Types
@@ -91,8 +91,8 @@ showNames names =
   T.intercalate ", " $ map G.unName $ toList names
 
 -- Ref: http://facebook.github.io/graphql/June2018/#sec-Names
-isGraphQLConform :: G.Name -> Bool
-isGraphQLConform =
+isValidName :: G.Name -> Bool
+isValidName =
   isJust . R.matchRegex regex . T.unpack . G.unName
   where
     regex = R.mkRegex "^[_a-zA-Z][_a-zA-Z0-9]*$"

--- a/server/test/testcases/create_tables.yaml
+++ b/server/test/testcases/create_tables.yaml
@@ -25,3 +25,10 @@ query:
             id SERIAL PRIMARY KEY,
             details JSONB NOT NULL
           )
+    - type: run_sql
+      args:
+        sql: |
+          CREATE TABLE dollar$test (
+            id SERIAL PRIMARY KEY,
+            name TEXT NOT NULL
+          )

--- a/server/test/testcases/track_tables.yaml
+++ b/server/test/testcases/track_tables.yaml
@@ -16,3 +16,7 @@ query:
       args:
         schema: public
         name: person
+    - type: track_table
+      args:
+        schema: public
+        name: dollar$test


### PR DESCRIPTION
Filter out tables, columns, relationships etc which does not conform to
GraphQL naming scheme. This ensures GraphiQL initialisation works properly for existing
databases.

Reference: http://facebook.github.io/graphql/June2018/#sec-Names
