### PR TITLE
template queries in graphiql from query params

### DIFF
--- a/console/src/components/ApiExplorer/Actions.js
+++ b/console/src/components/ApiExplorer/Actions.js
@@ -398,6 +398,12 @@ const getStateAfterClearingHistory = state => {
   };
 };
 
+const getRemoteQueries = (queryUrl, cb) => {
+  fetch(queryUrl)
+    .then(resp => resp.text().then(cb))
+    .catch(e => console.log('Invalid query URL: ', e));
+};
+
 const apiExplorerReducer = (state = defaultState, action) => {
   switch (action.type) {
     case CHANGE_TAB:
@@ -625,4 +631,5 @@ export {
   createWsClient,
   focusHeaderTextbox,
   unfocusTypingHeader,
+  getRemoteQueries,
 };

--- a/console/src/components/ApiExplorer/ApiExplorer.js
+++ b/console/src/components/ApiExplorer/ApiExplorer.js
@@ -67,6 +67,7 @@ class ApiExplorer extends Component {
         dataHeaders={this.props.dataHeaders}
         numberOfTables={this.props.tables.length}
         headerFocus={this.props.headerFocus}
+        queryParams={this.props.location.query}
       />
     );
 
@@ -86,6 +87,7 @@ ApiExplorer.propTypes = {
   route: PropTypes.object.isRequired,
   tables: PropTypes.array.isRequierd,
   headerFocus: PropTypes.bool.isRequired,
+  location: PropTypes.object.isRequired,
 };
 
 export default ApiExplorer;

--- a/console/src/components/ApiExplorer/ApiRequest.js
+++ b/console/src/components/ApiExplorer/ApiRequest.js
@@ -349,6 +349,7 @@ class ApiRequest extends Component {
             numberOfTables={this.props.numberOfTables}
             dispatch={this.props.dispatch}
             headerFocus={this.props.headerFocus}
+            queryParams={this.props.queryParams}
           />
         );
       default:
@@ -395,6 +396,7 @@ ApiRequest.propTypes = {
   route: PropTypes.object.isRequired,
   numberOfTables: PropTypes.number.isRequired,
   headerFocus: PropTypes.bool.isRequired,
+  queryParams: PropTypes.object.isRequired,
 };
 
 export default ApiRequest;

--- a/console/src/components/ApiExplorer/ApiRequestWrapper.js
+++ b/console/src/components/ApiExplorer/ApiRequestWrapper.js
@@ -40,6 +40,7 @@ class ApiRequestWrapper extends Component {
           dataHeaders={this.props.dataHeaders}
           numberOfTables={this.props.numberOfTables}
           headerFocus={this.props.headerFocus}
+          queryParams={this.props.queryParams}
         />
         {this.props.request.bodyType !== 'graphql' ? (
           <ApiResponse
@@ -70,6 +71,7 @@ ApiRequestWrapper.propTypes = {
   dispatch: PropTypes.func,
   numberOfTables: PropTypes.number,
   headerFocus: PropTypes.bool.isRequired,
+  queryParams: PropTypes.bool.isRequired,
 };
 
 export default ApiRequestWrapper;

--- a/console/src/components/ApiExplorer/GraphiQLWrapper.js
+++ b/console/src/components/ApiExplorer/GraphiQLWrapper.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import GraphiQL from 'hasura-console-graphiql';
 import PropTypes from 'prop-types';
 import ErrorBoundary from './ErrorBoundary';
-import { graphQLFetcherFinal } from './Actions';
+import { graphQLFetcherFinal, getRemoteQueries } from './Actions';
 
 import './GraphiQL.css';
 
@@ -14,7 +14,17 @@ class GraphiQLWrapper extends Component {
       error: false,
       noSchema: false,
       onBoardingEnabled: false,
+      queries: null,
     };
+  }
+
+  componentWillMount() {
+    const queryFile = this.props.queryParams.query_file;
+    if (queryFile) {
+      getRemoteQueries(queryFile, queries =>
+        this.setState({ ...this.state, queries })
+      );
+    }
   }
 
   shouldComponentUpdate(nextProps) {
@@ -40,7 +50,13 @@ class GraphiQLWrapper extends Component {
     );
 
     if (!this.state.error && this.props.numberOfTables !== 0) {
-      content = <GraphiQL fetcher={graphQLFetcher} />;
+      if (this.state.queries) {
+        content = (
+          <GraphiQL fetcher={graphQLFetcher} query={this.state.queries} />
+        );
+      } else {
+        content = <GraphiQL fetcher={graphQLFetcher} />;
+      }
     } else if (this.props.numberOfTables === 0) {
       content = (
         <GraphiQL

--- a/console/src/components/ApiExplorer/GraphiQLWrapper.js
+++ b/console/src/components/ApiExplorer/GraphiQLWrapper.js
@@ -16,9 +16,6 @@ class GraphiQLWrapper extends Component {
       onBoardingEnabled: false,
       queries: null,
     };
-  }
-
-  componentWillMount() {
     const queryFile = this.props.queryParams.query_file;
     if (queryFile) {
       getRemoteQueries(queryFile, queries =>


### PR DESCRIPTION
If there are a bunch of queries at a file path, say: `https://raw.githubusercontent.com/wawhal/test-repo/master/queries.graphql`, you can template GraphiQL with those queries by passing the URL in query params.

For example: if the console is running at `https://wofoo.herokuapp.com/console`, to template the queries, the URL would be: `https://wofoo.herokuapp.com/console?query_file=https://raw.githubusercontent.com/wawhal/test-repo/master/queries.graphql`