### PR TITLE
console: handle non access key errors

### DIFF
--- a/console/src/components/Services/Data/DataRouter.js
+++ b/console/src/components/Services/Data/DataRouter.js
@@ -194,12 +194,16 @@ const dataRouter = (connect, store, composeOnEnterHooks) => {
         },
         error => {
           console.error(JSON.stringify(error));
-          Promise.all([
-            store.dispatch({ type: ACCESS_KEY_ERROR, data: true }),
-          ]).then(() => {
-            replaceState('/login');
-            cb();
-          });
+          if (error.code === 'access-denied') {
+            Promise.all([
+              store.dispatch({ type: ACCESS_KEY_ERROR, data: true }),
+            ]).then(() => {
+              replaceState('/login');
+              cb();
+            });
+          } else {
+            alert(JSON.stringify(error));
+          }
         }
       );
     }


### PR DESCRIPTION
Fixes #235 
Currently redirects to login for all errors. Now handled to show the actual error as alert.