### PR TITLE
quote constraint name for non-admin inserts (fix #494)

### DIFF
--- a/server/src-lib/Hasura/RQL/DDL/Permission/Triggers.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Permission/Triggers.hs
@@ -49,9 +49,10 @@ buildInsTrigFn fn tn be =
   , BB.string7 " VALUES (NEW.*) ON CONFLICT DO NOTHING RETURNING * INTO r; RETURN r; "
   , BB.string7 "WHEN action = 'ignore'::text AND constraint_name is NOT NULL THEN "
   , BB.string7 "EXECUTE 'INSERT INTO " <> toSQL tn
-  , BB.string7 " VALUES ($1.*) ON CONFLICT ON CONSTRAINT ' || constraint_name || ' DO NOTHING RETURNING *' INTO r USING NEW; RETURN r; "
+  , BB.string7 " VALUES ($1.*) ON CONFLICT ON CONSTRAINT ' || quote_ident(constraint_name) || ' DO NOTHING RETURNING *'"
+  , BB.string7 " INTO r USING NEW; RETURN r; "
   , BB.string7 "ELSE EXECUTE 'INSERT INTO " <> toSQL tn
-  , BB.string7 " VALUES ($1.*) ON CONFLICT ON CONSTRAINT ' || constraint_name || ' DO UPDATE ' || set_expression || "
+  , BB.string7 " VALUES ($1.*) ON CONFLICT ON CONSTRAINT ' || quote_ident(constraint_name) || ' DO UPDATE ' || set_expression || "
   , BB.string7 "' RETURNING *' INTO r USING NEW; RETURN r; "
   , BB.string7 "END CASE; "
   , BB.string7 "ELSE RAISE internal_error using message = 'action is not found'; RETURN NULL; "


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
#494 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
Use `quote_ident()` SQL function over `constraint_name` in insert trigger function definition.

### Tests
<!-- Please describe in detail how you tested your changes. -->
<!-- Each component has it's own testing framework, check it out and add your tests to the mix -->

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
