### PR TITLE
take access key from redux state

### DIFF
--- a/console/src/components/Services/Data/Metadata/ExportMetadata.js
+++ b/console/src/components/Services/Data/Metadata/ExportMetadata.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Endpoints, { globalCookiePolicy } from '../../../../Endpoints';
-import globals from '../../../../Globals';
 
 import {
   showSuccessNotification,
@@ -33,7 +33,7 @@ class ExportMetadata extends Component {
               method: 'POST',
               credentials: globalCookiePolicy,
               headers: {
-                'X-Hasura-Access-Key': globals.accessKey,
+                ...this.props.dataHeaders,
               },
               body: JSON.stringify(requestBody),
             };
@@ -88,5 +88,10 @@ class ExportMetadata extends Component {
     );
   }
 }
+
+ExportMetadata.propTypes = {
+  dispatch: PropTypes.func.isRequired,
+  dataHeaders: PropTypes.object.isRequired,
+};
 
 export default ExportMetadata;

--- a/console/src/components/Services/Data/Metadata/ImportMetadata.js
+++ b/console/src/components/Services/Data/Metadata/ImportMetadata.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Endpoints, { globalCookiePolicy } from '../../../../Endpoints';
-import globals from '../../../../Globals';
 
 import {
   showSuccessNotification,
@@ -45,7 +44,7 @@ class ImportMetadata extends Component {
       method: 'POST',
       credentials: globalCookiePolicy,
       headers: {
-        'X-Hasura-Access-Key': globals.accessKey,
+        ...this.props.dataHeaders,
       },
       body: JSON.stringify(requestBody),
     };
@@ -121,6 +120,7 @@ class ImportMetadata extends Component {
 
 ImportMetadata.propTypes = {
   dispatch: PropTypes.func.isRequired,
+  dataHeaders: PropTypes.object.isRequired,
 };
 
 export default ImportMetadata;

--- a/console/src/components/Services/Data/Metadata/Metadata.js
+++ b/console/src/components/Services/Data/Metadata/Metadata.js
@@ -82,17 +82,17 @@ class Metadata extends Component {
 
         {this.state.showMetadata
           ? [
-            <div key="meta_data_1" className={metaDataStyles.intro_note}>
-              <h4>Reload metadata</h4>
-              <div className={metaDataStyles.content_width}>
+              <div key="meta_data_1" className={metaDataStyles.intro_note}>
+                <h4>Reload metadata</h4>
+                <div className={metaDataStyles.content_width}>
                   Refresh Hasura metadata, typically required if you have
                   changed the underlying postgres.
-              </div>
-            </div>,
-            <div key="meta_data_2">
-              <ReloadMetadata {...this.props} />
-            </div>,
-          ]
+                </div>
+              </div>,
+              <div key="meta_data_2">
+                <ReloadMetadata {...this.props} />
+              </div>,
+            ]
           : null}
       </div>
     );
@@ -106,7 +106,7 @@ Metadata.propTypes = {
 const mapStateToProps = state => {
   return {
     ...state.main,
-    dataHeaders: state.tables.dataHeaders,
+    dataHeaders: { ...state.tables.dataHeaders },
   };
 };
 

--- a/console/src/components/Services/Data/Metadata/Metadata.js
+++ b/console/src/components/Services/Data/Metadata/Metadata.js
@@ -106,6 +106,7 @@ Metadata.propTypes = {
 const mapStateToProps = state => {
   return {
     ...state.main,
+    dataHeaders: state.tables.dataHeaders,
   };
 };
 

--- a/console/src/components/Services/Data/Metadata/ReloadMetadata.js
+++ b/console/src/components/Services/Data/Metadata/ReloadMetadata.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Endpoints, { globalCookiePolicy } from '../../../../Endpoints';
-import globals from '../../../../Globals';
 
 import {
   showSuccessNotification,
@@ -33,7 +33,7 @@ class ReloadMetadata extends Component {
               method: 'POST',
               credentials: globalCookiePolicy,
               headers: {
-                'X-Hasura-Access-Key': globals.accessKey,
+                ...this.props.dataHeaders,
               },
               body: JSON.stringify(requestBody),
             };
@@ -78,5 +78,10 @@ class ReloadMetadata extends Component {
     );
   }
 }
+
+ReloadMetadata.propTypes = {
+  dispatch: PropTypes.func.isRequired,
+  dataHeaders: PropTypes.object.isRequired,
+};
 
 export default ReloadMetadata;


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->
Metadata tab used to read access key from environment variable since that was the previous flow. We changed it post #481 fix. Now it reads from the redux state.

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
The issue is fixed by reading the headers state from the redux state as that is the primary source of information for all the data.

### Tests
<!-- Please describe in detail how you tested your changes. -->
<!-- Each component has it's own testing framework, check it out and add your tests to the mix -->

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
