### PR TITLE
remove 's' unit from query_execution_time in logs (close #509)

### DIFF
--- a/server/src-lib/Hasura/Server/Logging.hs
+++ b/server/src-lib/Hasura/Server/Logging.hs
@@ -82,7 +82,7 @@ data AccessLog
   , alHasuraMetadata :: !(Maybe Value)
   , alQueryHash      :: !(Maybe T.Text)
   , alResponseSize   :: !(Maybe Int64)
-  , alResponseTime   :: !(Maybe T.Text)
+  , alResponseTime   :: !(Maybe Double)
   } deriving (Show, Eq)
 
 instance L.ToEngineLog AccessLog where
@@ -171,7 +171,7 @@ mkAccessLog req r mTimeT =
   , alHasuraRole  = bsToTxt <$> getHasuraRole req
   , alHasuraMetadata = getHasuraMetadata req
   , alResponseSize = size
-  , alResponseTime = T.pack . show <$> diffTime
+  , alResponseTime = realToFrac <$> diffTime
   , alQueryHash = queryHash
   }
   where


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->
Removes the seconds unit (trailing `s`) from `query_execution_time` in logs.

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [x] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
#509 
### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
It was a string before, changed to double.

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [x] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [ ] I have added required tests.

#### Docs change
Docs should mention the type/unit of `query_execution_time` is numeric/double.