### PR TITLE
validate the directory before executing migrate create (fix #585)

### DIFF
--- a/cli/commands/migrate_create.go
+++ b/cli/commands/migrate_create.go
@@ -7,9 +7,11 @@ import (
 	mig "github.com/hasura/graphql-engine/cli/migrate/cmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func newMigrateCreateCmd(ec *cli.ExecutionContext) *cobra.Command {
+	v := viper.New()
 	opts := &migrateCreateOptions{
 		EC: ec,
 	}
@@ -20,6 +22,10 @@ func newMigrateCreateCmd(ec *cli.ExecutionContext) *cobra.Command {
 		Long:         "Create sql and yaml files required for a migration",
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			ec.Viper = v
+			return ec.Validate()
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.run()


### PR DESCRIPTION
### Description

The recent bugfix to accept `--project` flag had resulted in some refactoring and the validate function is not being called from `migrate create` command anymore. Tests did not capture this as the tests are run after the initialisation step. Need to refactor tests to mimic the exact execution.

What component does this PR affect? 

- [ ] Server
- [ ] Console
- [x] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

No

### Related Issue

#585 

### Solution and Design

The validate function has been explicitly added to create command. Earlier it was part of the parent command, but that had been refactored recently.

### Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:

- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [ ] I have added required tests.
