### PR TITLE
fix typo in proptypes validation (fixes #604)

### DIFF
--- a/console/src/components/ApiExplorer/ApiExplorer.js
+++ b/console/src/components/ApiExplorer/ApiExplorer.js
@@ -58,8 +58,8 @@ class ApiExplorer extends Component {
       <ApiRequestWrapper
         credentials={this.props.credentials}
         explorerData={this.props.explorerData}
-        details={this.props.displayedApi.details}
-        request={this.props.displayedApi.request}
+        details={displayedApi.details}
+        request={displayedApi.request}
         requestStyles={requestStyles}
         dispatch={this.props.dispatch}
         wdStyles={wdClass}
@@ -85,7 +85,7 @@ ApiExplorer.propTypes = {
   displayedApi: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired,
   route: PropTypes.object.isRequired,
-  tables: PropTypes.array.isRequierd,
+  tables: PropTypes.array.isRequired,
   headerFocus: PropTypes.bool.isRequired,
   location: PropTypes.object.isRequired,
 };


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->
Fixes a typo in propTypes validation for ApiExplorer component, and use an otherwise useless const.

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [ ] Server
- [X] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
https://github.com/hasura/graphql-engine/issues/604

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [ ] I have added required tests.
