### PR TITLE
track connection_init error on each ws connection (closes #682)

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
@@ -55,7 +55,7 @@ type OperationMap
 data WSConnData
   = WSConnData
   -- the role and headers are set only on connection_init message
-  { _wscUser  :: !(IORef.IORef (Maybe UserInfo))
+  { _wscUser  :: !(IORef.IORef (Maybe (Either Text UserInfo)))
   -- we only care about subscriptions,
   -- the other operations (query/mutations)
   -- are not tracked here
@@ -164,7 +164,9 @@ onStart serverEnv wsConn msg@(StartMsg opId q) = catchAndSend $ do
 
   userInfoM <- liftIO $ IORef.readIORef userInfoR
   userInfo <- case userInfoM of
-    Just userInfo -> return userInfo
+    Just (Right userInfo) -> return userInfo
+    Just (Left initErr) -> throwError $ SMConnErr $ ConnErrMsg $
+      "cannot start as connection_init failed with : " <> initErr
     Nothing       -> do
       let err = "start received before the connection is initialised"
       liftIO $ logger $ WSLog wsId $
@@ -261,10 +263,13 @@ onConnInit
 onConnInit (L.Logger logger) manager wsConn authMode connParamsM = do
   res <- runExceptT $ getUserInfo logger manager headers authMode
   case res of
-    Left e  ->
+    Left e  -> do
+      liftIO $ IORef.writeIORef (_wscUser $ WS.getData wsConn) $
+        Just $ Left $ qeError e
       sendMsg wsConn $ SMConnErr $ ConnErrMsg $ qeError e
     Right userInfo -> do
-      liftIO $ IORef.writeIORef (_wscUser $ WS.getData wsConn) $ Just userInfo
+      liftIO $ IORef.writeIORef (_wscUser $ WS.getData wsConn) $
+        Just $ Right userInfo
       sendMsg wsConn SMConnAck
       -- TODO: send it periodically? Why doesn't apollo's protocol use
       -- ping/pong frames of websocket spec?


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
#682 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [ ] I have added required tests.
