### PR TITLE
set all session data in a single paramater, 'hasura.user'

### DIFF
--- a/docs/graphql/manual/guides/auditing-tables.rst
+++ b/docs/graphql/manual/guides/auditing-tables.rst
@@ -1,0 +1,22 @@
+Auditing actions on tables in Postgres
+======================================
+
+Typically audit logging is added to some of the tables to comply with various certifications.
+You may want to capture the user information (role and the session variables) for every change in Postgres that is done through graphql-engine.
+
+For every mutation, hasura roughly executes the following transaction:
+
+.. code-block:: sql
+
+   BEGIN;
+   SET local "hasura.user" = '{"x-hasura-role": "role", ... various session variables}'
+   SQL related to the mutation
+   COMMIT;
+
+This information can therefore be captured in any trigger on the underlying tables by using the ``current_setting`` function as follows:
+
+.. code-block:: sql
+
+   current_setting('hasura.user');
+
+We've set up some utility functions that'll let you quickly get started with auditing in this `repo <https://github.com/hasura/audit-trigger>`__.

--- a/docs/graphql/manual/guides/index.rst
+++ b/docs/graphql/manual/guides/index.rst
@@ -54,3 +54,4 @@ Articles:
    Sample apps <sample-apps/index>
    Integration/migration tutorials <integrations/index>
    Integrating with monitoring frameworks <monitoring/index>
+   Auditing tables <auditing-tables>

--- a/server/src-lib/Hasura/RQL/DDL/Permission/Internal.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Permission/Internal.hs
@@ -216,7 +216,7 @@ valueParser columnType = \case
   -- Typical value as Aeson's value
   val -> txtRHSBuilder columnType val
   where
-    curSess = S.SEUnsafe "current_setting('hasura.session')::json"
+    curSess = S.SEUnsafe "current_setting('hasura.user')::json"
     fromCurSess hdr =
       S.SEOpApp (S.SQLOp "->>") [curSess, S.SELit $ T.toLower hdr]
       `S.SETyAnn` (S.AnnType $ T.pack $ show columnType)

--- a/server/src-lib/Hasura/RQL/DDL/Permission/Internal.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Permission/Internal.hs
@@ -210,16 +210,16 @@ valueParser :: (MonadError QErr m) => PGColType -> Value -> m S.SQLExp
 valueParser columnType = \case
   -- When it is a special variable
   val@(String t)
-    | isXHasuraTxt t -> asCurrentSetting t
-    | isReqUserId t -> asCurrentSetting userIdHeader
-    | otherwise -> txtRHSBuilder columnType val
-
+    | isXHasuraTxt t -> return $ fromCurSess t
+    | isReqUserId t  -> return $ fromCurSess userIdHeader
+    | otherwise      -> txtRHSBuilder columnType val
   -- Typical value as Aeson's value
   val -> txtRHSBuilder columnType val
   where
-    asCurrentSetting hdr = return $ S.SEUnsafe $
-      "current_setting('hasura." <> dropAndSnakeCase hdr
-       <> "')::" <> T.pack (show columnType)
+    curSess = S.SEUnsafe "current_setting('hasura.session')::json"
+    fromCurSess hdr =
+      S.SEOpApp (S.SQLOp "->>") [curSess, S.SELit $ T.toLower hdr]
+      `S.SETyAnn` (S.AnnType $ T.pack $ show columnType)
 
 -- Convert where clause into SQL BoolExp
 convFilterExp :: (MonadError QErr m)

--- a/server/src-lib/Hasura/RQL/Types/Permission.hs
+++ b/server/src-lib/Hasura/RQL/Types/Permission.hs
@@ -65,7 +65,8 @@ $(J.deriveJSON (J.aesonDrop 4 J.camelCase){J.omitNothingFields=True}
  )
 
 adminUserInfo :: UserInfo
-adminUserInfo = UserInfo adminRole Map.empty
+adminUserInfo =
+  UserInfo adminRole $ Map.singleton "x-hasura-role" "admin"
 
 data PermType
   = PTInsert

--- a/server/src-lib/Hasura/Server/Auth.hs
+++ b/server/src-lib/Hasura/Server/Auth.hs
@@ -172,7 +172,7 @@ getUserInfo logger manager rawHeaders = \case
     userInfoFromHeaders =
       case M.lookup userRoleHeader headers of
         Just v  -> UserInfo (RoleName v) headers
-        Nothing -> UserInfo adminRole M.empty
+        Nothing -> adminUserInfo
 
     userInfoWhenAccessKey key reqKey = do
       when (reqKey /= getAccessKey key) $ throw401 $ "invalid " <> accessKeyHeader

--- a/server/src-lib/Hasura/Server/Query.hs
+++ b/server/src-lib/Hasura/Server/Query.hs
@@ -224,5 +224,5 @@ setHeadersTx userInfo =
   where
     toStrictText = LT.toStrict . AT.encodeToLazyText
     setSess = Q.fromText $
-      "SET LOCAL hasura.session = " <>
+      "SET LOCAL \"hasura.user\" = " <>
       pgFmtLit (toStrictText $ userHeaders userInfo)

--- a/server/src-lib/Hasura/Server/Query.hs
+++ b/server/src-lib/Hasura/Server/Query.hs
@@ -10,10 +10,11 @@ import           Data.Aeson.Casing
 import           Data.Aeson.TH
 import           Language.Haskell.TH.Syntax   (Lift)
 
+import qualified Data.Aeson.Text              as AT
 import qualified Data.ByteString.Builder      as BB
 import qualified Data.ByteString.Lazy         as BL
-import qualified Data.HashMap.Strict          as Map
 import qualified Data.Sequence                as Seq
+import qualified Data.Text.Lazy               as LT
 import qualified Data.Vector                  as V
 
 import           Hasura.Prelude
@@ -25,7 +26,6 @@ import           Hasura.RQL.DDL.Schema.Table
 import           Hasura.RQL.DML.QueryTemplate
 import           Hasura.RQL.DML.Returning     (encodeJSONVector)
 import           Hasura.RQL.Types
-import           Hasura.Server.Utils
 import           Hasura.SQL.Types
 
 import qualified Database.PG.Query            as Q
@@ -220,9 +220,9 @@ buildTxAny userInfo sc rq = case rq of
 
 setHeadersTx :: UserInfo -> Q.TxE QErr ()
 setHeadersTx userInfo =
-  forM_ hdrs $ \h -> Q.unitQE defaultTxErrorHandler (mkQ h) () False
+  Q.unitQE defaultTxErrorHandler setSess () False
   where
-    hdrs = Map.toList $ Map.delete accessKeyHeader
-      $ userHeaders userInfo
-    mkQ (h, v) = Q.fromText $
-      "SET LOCAL hasura." <> dropAndSnakeCase h <> " =  " <> pgFmtLit v
+    toStrictText = LT.toStrict . AT.encodeToLazyText
+    setSess = Q.fromText $
+      "SET LOCAL hasura.session = " <>
+      pgFmtLit (toStrictText $ userHeaders userInfo)

--- a/server/src-lib/Hasura/Server/Utils.hs
+++ b/server/src-lib/Hasura/Server/Utils.hs
@@ -21,16 +21,6 @@ import qualified Text.Ginger                  as TG
 
 import           Hasura.Prelude
 
-
-dropAndSnakeCase :: T.Text -> T.Text
-dropAndSnakeCase = T.drop 9 . toSnakeCase . T.toLower
-
-toSnakeCase :: T.Text -> T.Text
-toSnakeCase = T.pack . map change . T.unpack
-  where
-    change '-' = '_'
-    change c   = c
-
 isXHasuraTxt :: T.Text -> Bool
 isXHasuraTxt = T.isInfixOf "x-hasura-" . T.toLower
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
Currently each session variable is set independently. From now on, all session data is json encoded under single parameter `hasura.session`. This is extremely helpful in having an audit trail.

<!-- Describe your changes in detail -->

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
#825 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [x] I have updated the documentation accordingly.
- [ ] I have added required tests.
