### PR TITLE
add retry-after header info to event-trigger docs

### DIFF
--- a/docs/graphql/manual/event-triggers/payload.rst
+++ b/docs/graphql/manual/event-triggers/payload.rst
@@ -142,6 +142,13 @@ Webhook response structure
 --------------------------
 
 A ``2xx`` response status code is deemed to be a successful invocation of the webhook. Any other response status will be
-deemed as an unsuccessful invocation which may cause retries as per the retry configuration.
+deemed as an unsuccessful invocation which will cause retries as per the retry configuration.
 
 It is also recommended that you return a JSON object in your webhook response.
+
+Retry-After header
+^^^^^^^^^^^^^^^^^^
+
+If the webhook response contains a ``Retry-After`` header, then the event will be redelivered once more after the duration (in seconds) found in the header. Note that the header will be respected only if the response status code is ``non-2xx``.
+
+The ``Retry-After`` header can be used for retrying/rate-limiting/debouncing your webhook triggers.


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [ ] Server
- [ ] Console
- [ ] CLI
- [x] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [x] This change requires a change in the documentation. 
- [x] I have updated the documentation accordingly.
- [ ] I have added required tests.
