### PR TITLE
extract session variables from relational bool expression (fix #960)

### DIFF
--- a/server/src-lib/Hasura/RQL/DDL/Permission/Internal.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Permission/Internal.hs
@@ -201,9 +201,7 @@ getDependentHeaders boolExp = case boolExp of
         | otherwise -> []
       _ -> []
     parseObject o = flip concatMap (M.toList o) $ \(k, v) ->
-                             if isRQLOp k
-                             then parseOnlyString v
-                             else []
+                      bool (parseValue v) (parseOnlyString v) $ isRQLOp k
 
 valueParser :: (MonadError QErr m) => PGColType -> Value -> m S.SQLExp
 valueParser columnType = \case

--- a/server/tests-py/queries/graphql_query/permissions/artist_select_query_Track.yaml
+++ b/server/tests-py/queries/graphql_query/permissions/artist_select_query_Track.yaml
@@ -1,0 +1,19 @@
+description: Artist can only select his/her tracks.
+url: /v1alpha1/graphql
+status: 200
+headers:
+  X-Hasura-Role: Artist
+  X-Hasura-Artist-Id: '2'
+response:
+  data:
+    Track:
+    - id: 3
+      name: Happy
+query:
+  query: |
+    query {
+      Track {
+        id
+        name
+      }
+    }

--- a/server/tests-py/queries/graphql_query/permissions/artist_select_query_Track_fail.yaml
+++ b/server/tests-py/queries/graphql_query/permissions/artist_select_query_Track_fail.yaml
@@ -1,0 +1,18 @@
+description: Artist can only select his/her tracks. Without sending header (Error)
+url: /v1alpha1/graphql
+status: 400
+headers:
+  X-Hasura-Role: Artist
+response:
+  errors:
+  - path: "$"
+    error: '"x-hasura-artist-id" header is expected but not found'
+    code: not-found
+query:
+  query: |
+    query {
+      Track {
+        id
+        name
+      }
+    }

--- a/server/tests-py/queries/graphql_query/permissions/setup.yaml
+++ b/server/tests-py/queries/graphql_query/permissions/setup.yaml
@@ -168,3 +168,79 @@ args:
       content: Sample article content 4
       author_id: 3
       is_published: false
+
+#Create Artist table
+- type: run_sql
+  args:
+    sql: |
+      CREATE TABLE "Artist" (
+        id serial PRIMARY KEY ,
+        name text NOT NULL
+      );
+
+- type: track_table
+  args:
+    schema: public
+    name: Artist
+
+#Crete Track table
+- type: run_sql
+  args:
+    sql: |
+      CREATE TABLE "Track" (
+        id serial PRIMARY KEY,
+        name text NOT NULL,
+        artist_id integer REFERENCES "Artist"("id")
+      );
+
+- type: track_table
+  args:
+    schema: public
+    name: Track
+
+# Insert data into Artist and Track table
+- type: insert
+  args:
+    table: Artist
+    objects:
+    - name: Camilla
+      id: 1
+    - name: DSP
+      id: 2
+    - name: Akon
+      id: 3
+
+- type: insert
+  args:
+    table: Track
+    objects:
+    - name: Keepup
+      artist_id: 1
+      id: 1
+    - name: Keepdown
+      artist_id: 1
+      id: 2
+    - name: Happy
+      artist_id: 2
+      id: 3
+
+#Object relationship Track::artist_id -> Artist::id
+- type: create_object_relationship
+  args:
+    name: Artist
+    table: Track
+    using:
+      foreign_key_constraint_on: artist_id
+
+#Create select permssion on Track
+- type: create_select_permission
+  args:
+    table: Track
+    role: Artist
+    permission:
+      columns: '*'
+      filter:
+        Artist:
+          id: X-Hasura-Artist-Id
+
+

--- a/server/tests-py/queries/graphql_query/permissions/teardown.yaml
+++ b/server/tests-py/queries/graphql_query/permissions/teardown.yaml
@@ -12,3 +12,13 @@ args:
     sql: |
       drop table author
     cascade: true
+
+- type: run_sql
+  args:
+    sql: |
+      drop table "Artist"
+
+- type: run_sql
+  args:
+    sql: |
+      drop table "Track"

--- a/server/tests-py/queries/v1/metadata/export_metadata.yaml
+++ b/server/tests-py/queries/v1/metadata/export_metadata.yaml
@@ -22,7 +22,7 @@ response:
     - using:
         foreign_key_constraint_on: author_id
       name: author
-      comment: 
+      comment: null
     array_relationships: []
     insert_permissions: []
     select_permissions: []

--- a/server/tests-py/queries/v1/metadata/export_metadata.yaml
+++ b/server/tests-py/queries/v1/metadata/export_metadata.yaml
@@ -1,35 +1,35 @@
-description: Reload schema cache (metadata)
+description: Export schema cache (metadata)
 url: /v1/query
 status: 200
 response:
-  query_templates: []
   tables:
   - table: author
+    object_relationships: []
     array_relationships:
-    - name: articles
-      using:
+    - using:
         foreign_key_constraint_on:
           column: author_id
           table: article
+      name: articles
       comment: List all articles of the author
-    select_permissions: []
-    object_relationships: []
-    event_triggers: []
     insert_permissions: []
+    select_permissions: []
     update_permissions: []
     delete_permissions: []
+    event_triggers: []
   - table: article
     object_relationships:
-    - name: author
-      using:
+    - using:
         foreign_key_constraint_on: author_id
-      comment: null
-    select_permissions: []
-    event_triggers: []
+      name: author
+      comment: 
+    array_relationships: []
     insert_permissions: []
+    select_permissions: []
     update_permissions: []
     delete_permissions: []
-    array_relationships: []
+    event_triggers: []
+  query_templates: []
 
 query:
   type: export_metadata

--- a/server/tests-py/test_graphql_queries.py
+++ b/server/tests-py/test_graphql_queries.py
@@ -182,6 +182,12 @@ class TestGraphqlQueryPermissions(DefaultTestSelectQueries):
     def test_user_cannot_access_remarks_col(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + '/user_cannot_access_remarks_col.yaml')
 
+    def test_artist_select_query_Track_fail(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + '/artist_select_query_Track_fail.yaml')
+
+    def test_artist_select_query_Track(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + '/artist_select_query_Track.yaml')
+
     @classmethod
     def dir(cls):
         return 'queries/graphql_query/permissions'


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
fix #960 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [x] I have added required tests.
