### PR TITLE
Fix creating triggers on OSX

### DIFF
--- a/server/src-lib/Hasura/RQL/Types/Subscribe.hs
+++ b/server/src-lib/Hasura/RQL/Types/Subscribe.hs
@@ -29,7 +29,7 @@ import           Hasura.Prelude
 import           Hasura.SQL.Types
 import           Language.Haskell.TH.Syntax (Lift)
 import           Text.Regex                 (matchRegex, mkRegex)
-
+import           Text.Printf
 import qualified Data.Text                  as T
 
 type TriggerName = T.Text
@@ -122,11 +122,11 @@ instance FromJSON CreateEventTriggerQuery where
     webhook   <- o .: "webhook"
     headers   <- o .:? "headers"
     replace   <- o .:? "replace" .!= False
-    let regex = mkRegex "^\\w+$"
+    let regex = mkRegex "\\W"
         mName = matchRegex regex (T.unpack name)
     case mName of
-      Just _  -> return ()
-      Nothing -> fail "only alphanumeric and underscore allowed for name"
+      Just _  -> fail (printf "only alphanumeric and underscore allowed for name: '%s'" (T.unpack name))
+      Nothing -> return ()
     case insert <|> update <|> delete of
       Just _  -> return ()
       Nothing -> fail "must provide operation spec(s)"


### PR DESCRIPTION
The other version was failing on OSX, most likely because posix regex
is poorly supported there and the line-start/end characters where
not matching the strings?

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

https://github.com/hasura/graphql-engine/issues/997

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [ ] I have added required tests.