### PR TITLE
Remove 'update_columns' argument from example

### DIFF
--- a/docs/graphql/manual/mutations/upsert.rst
+++ b/docs/graphql/manual/mutations/upsert.rst
@@ -29,7 +29,6 @@ Insert into ``author`` table using unique constraint ``author_name_key``. All co
         ],
         on_conflict: {
           constraint: author_pkey,
-          update_columns: [name]
         }
       ) {
         affected_rows

--- a/docs/graphql/manual/mutations/upsert.rst
+++ b/docs/graphql/manual/mutations/upsert.rst
@@ -28,7 +28,7 @@ Insert into ``author`` table using unique constraint ``author_name_key``. All co
           {name: "John", age: 25, mobile: 9876543210}
         ],
         on_conflict: {
-          constraint: author_pkey,
+          constraint: author_pkey
         }
       ) {
         affected_rows


### PR DESCRIPTION
The example for 'Without "update_columns" argument contains an 'update_columns' parameter. This removes it.

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [ ] Server
- [ ] Console
- [ ] CLI
- [X] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [X] I have updated the documentation accordingly.
- [ ] I have added required tests.
