### PR TITLE
do not add extra s after table name when generating array relationship name

### DIFF
--- a/community/tools/json2graphql/src/import/relationships.js
+++ b/community/tools/json2graphql/src/import/relationships.js
@@ -7,7 +7,7 @@ const getObjRelationshipName = dep => {
 };
 
 const getArrayRelationshipName = (table, parent) => {
-  const relName = `${table}sBy${parent[0].toUpperCase()}`;
+  const relName = `${table}By${parent[0].toUpperCase()}`;
   return parent.length === 1 ? `${relName}Id` : `${relName}${parent.substring(1, parent.length)}Id`;
 };
 


### PR DESCRIPTION
…p name

### Description
do not add extra s after table name when generating array relationship name

What component does this PR affect? 

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue

None

### Solution and Design

Some (most) use plural when naming their tables. This make the extra added, hard coded, `s` after a table name confusing. Even if the tables are named in singular, just adding a `s` in the end is not the correct plural naming. Like `company` which in plural is `companies`. Just adding a `s` in the end would result in an incorrect naming: `companys`. 

### Type
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [x] This change requires a change in the documentation. 
- [x] I have updated the documentation accordingly.
- [x] I have added required tests.
