### PR TITLE
handle input empty array for _in and _nin operators, fix #1075

### DIFF
--- a/server/src-lib/Hasura/RQL/GBoolExp.hs
+++ b/server/src-lib/Hasura/RQL/GBoolExp.hs
@@ -267,8 +267,8 @@ mkColCompExp
 mkColCompExp qual lhsCol = \case
   AEQ val          -> equalsBoolExpBuilder lhs val
   ANE val          -> notEqualsBoolExpBuilder lhs val
-  AIN  vals        -> S.BEEqualsAny lhs vals
-  ANIN vals        -> S.BENot $ S.BEEqualsAny lhs vals
+  AIN  vals        -> handleEmptyAny vals
+  ANIN vals        -> S.BENot $ handleEmptyAny vals
   AGT val          -> S.BECompare S.SGT lhs val
   ALT val          -> S.BECompare S.SLT lhs val
   AGTE val         -> S.BECompare S.SGTE lhs val
@@ -298,6 +298,9 @@ mkColCompExp qual lhsCol = \case
 
     toTextArray arr =
       S.SETyAnn (S.SEArray $ map (txtEncoder . PGValText) arr) S.textArrType
+
+    handleEmptyAny []   = S.BELit False
+    handleEmptyAny vals = S.BEEqualsAny lhs vals
 
 getColExpDeps :: QualifiedTable -> AnnBoolExpFld a -> [SchemaDependency]
 getColExpDeps tn = \case

--- a/server/tests-py/queries/graphql_query/boolexp/basic/select_author_article_where_in_empty_array.yaml
+++ b/server/tests-py/queries/graphql_query/boolexp/basic/select_author_article_where_in_empty_array.yaml
@@ -1,0 +1,20 @@
+description: Select author and their articles (in empty array)
+url: /v1alpha1/graphql
+status: 200
+response:
+  data:
+    author: []
+query:
+  query: |
+    query {
+      author (
+      where: {name: {_in: [] }}
+      ) {
+        name
+        articles{
+          id
+          title 
+          content
+        }
+      }
+    }

--- a/server/tests-py/queries/graphql_query/boolexp/basic/select_author_article_where_nin_empty_array.yaml
+++ b/server/tests-py/queries/graphql_query/boolexp/basic/select_author_article_where_nin_empty_array.yaml
@@ -1,0 +1,39 @@
+description: Select author and their articles (not in empty array)
+url: /v1alpha1/graphql
+status: 200
+response:
+  data:
+    author:
+    - name: Author 1
+      articles:
+      - id: 1
+        title: Article 1
+        content: Sample article content 1
+      - id: 2
+        title: Article 2
+        content: Sample article content 2
+    - name: Author 2
+      articles:
+      - id: 3
+        title: Article 3
+        content: Sample article content 3
+    - name: Author 3
+      articles:
+      - id: 4
+        title: Article 4
+        content: Sample article content 4
+
+query:
+  query: |
+    query {
+      author (
+      where: {name: {_nin: [] }}
+      ) {
+        name
+        articles{
+          id
+          title 
+          content
+        }
+      }
+    }

--- a/server/tests-py/test_graphql_queries.py
+++ b/server/tests-py/test_graphql_queries.py
@@ -145,6 +145,12 @@ class TestGraphQLQueryBoolExpBasic(DefaultTestSelectQueries):
     def test_author_article_where_in(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + '/select_author_article_where_in.yaml')
 
+    def test_author_article_where_in_empty_array(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + '/select_author_article_where_in_empty_array.yaml')
+
+    def test_author_article_where_nin_empty_array(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + '/select_author_article_where_nin_empty_array.yaml')
+
     def test_author_article_where_nin(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + '/select_author_article_where_nin.yaml')
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
fix #1075 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
For `_in` operator if `empty array` is given then consider it as `false`.
Vice versa for `_nin` operator.

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [x] I have added required tests.
