### PR TITLE
use postgres IN experssion for _in operator (fix #1109)

### DIFF
--- a/server/src-lib/Hasura/RQL/GBoolExp.hs
+++ b/server/src-lib/Hasura/RQL/GBoolExp.hs
@@ -267,8 +267,8 @@ mkColCompExp
 mkColCompExp qual lhsCol = \case
   AEQ val          -> equalsBoolExpBuilder lhs val
   ANE val          -> notEqualsBoolExpBuilder lhs val
-  AIN  vals        -> handleEmptyAny vals
-  ANIN vals        -> S.BENot $ handleEmptyAny vals
+  AIN vals         -> handleEmptyIn vals
+  ANIN vals        -> S.BENot $ handleEmptyIn vals
   AGT val          -> S.BECompare S.SGT lhs val
   ALT val          -> S.BECompare S.SLT lhs val
   AGTE val         -> S.BECompare S.SGTE lhs val
@@ -299,8 +299,8 @@ mkColCompExp qual lhsCol = \case
     toTextArray arr =
       S.SETyAnn (S.SEArray $ map (txtEncoder . PGValText) arr) S.textArrType
 
-    handleEmptyAny []   = S.BELit False
-    handleEmptyAny vals = S.BEEqualsAny lhs vals
+    handleEmptyIn []   = S.BELit False
+    handleEmptyIn vals = S.BEIN lhs vals
 
 getColExpDeps :: QualifiedTable -> AnnBoolExpFld a -> [SchemaDependency]
 getColExpDeps tn = \case

--- a/server/src-lib/Hasura/SQL/DML.hs
+++ b/server/src-lib/Hasura/SQL/DML.hs
@@ -461,7 +461,7 @@ data BoolExp
   | BENull !SQLExp
   | BENotNull !SQLExp
   | BEExists !Select
-  | BEEqualsAny !SQLExp ![SQLExp]
+  | BEIN !SQLExp ![SQLExp]
   deriving (Show, Eq)
 
 -- removes extraneous 'AND true's
@@ -506,10 +506,9 @@ instance ToSQL BoolExp where
     paren (toSQL v) <-> "IS NOT NULL"
   toSQL (BEExists sel) =
     "EXISTS " <-> paren (toSQL sel)
-  -- special case to handle 'lhs = ANY(ARRAY[..])'
-  toSQL (BEEqualsAny l rhsExps) =
-    paren (toSQL l) <-> toSQL SEQ
-    <-> toSQL (SEFnApp "ANY" [SEArray rhsExps] Nothing)
+  -- special case to handle lhs IN (exp1, exp2)
+  toSQL (BEIN vl exps) =
+    toSQL vl <-> toSQL SIN <-> paren (", " <+> exps)
 
 data BinOp = AndOp
            | OrOp

--- a/server/src-lib/Hasura/SQL/DML.hs
+++ b/server/src-lib/Hasura/SQL/DML.hs
@@ -508,7 +508,7 @@ instance ToSQL BoolExp where
     "EXISTS " <-> paren (toSQL sel)
   -- special case to handle lhs IN (exp1, exp2)
   toSQL (BEIN vl exps) =
-    toSQL vl <-> toSQL SIN <-> paren (", " <+> exps)
+    paren (toSQL vl) <-> toSQL SIN <-> paren (", " <+> exps)
 
 data BinOp = AndOp
            | OrOp

--- a/server/src-lib/Hasura/SQL/Rewrite.hs
+++ b/server/src-lib/Hasura/SQL/Rewrite.hs
@@ -123,8 +123,7 @@ uBoolExp = restoringIdens . \case
   S.BENull e -> S.BENull <$> uSqlExp e
   S.BENotNull e -> S.BENotNull <$> uSqlExp e
   S.BEExists sel -> S.BEExists <$> uSelect sel
-  S.BEEqualsAny l rExps ->
-    S.BEEqualsAny <$> uSqlExp l <*> mapM uSqlExp rExps
+  S.BEIN left exps -> S.BEIN <$> uSqlExp left <*> mapM uSqlExp exps
 
 uOrderBy :: S.OrderByExp -> Uniq S.OrderByExp
 uOrderBy (S.OrderByExp ordByItems) =

--- a/server/tests-py/queries/graphql_query/boolexp/basic/select_uuid_test_in_uuid_col.yaml
+++ b/server/tests-py/queries/graphql_query/boolexp/basic/select_uuid_test_in_uuid_col.yaml
@@ -1,0 +1,30 @@
+description: Fetch data from uuid_test table using _in operator in where filter
+url: /v1alpha1/graphql
+status: 200
+response:
+  data:
+    uuid_test:
+    - id: 1
+      uuid_col: 28d6d683-1317-49f7-b1cf-7d195242e4e5
+    - id: 2
+      uuid_col: 28d6d683-1317-49f7-b1cf-7d195242e4e6
+
+query:
+  query: |
+    query {
+      uuid_test(
+        where: {
+          uuid_col: {
+            _in: [ "28d6d683-1317-49f7-b1cf-7d195242e4e5"
+                 , "28d6d683-1317-49f7-b1cf-7d195242e4e6"
+                 , "28d6d683-1317-49f7-b1cf-7d195242e4e8"
+                 ]
+          }
+        }
+      ) {
+        id
+        uuid_col
+      }
+    }
+
+

--- a/server/tests-py/queries/graphql_query/boolexp/basic/setup.yaml
+++ b/server/tests-py/queries/graphql_query/boolexp/basic/setup.yaml
@@ -209,3 +209,23 @@ args:
       - received_at: '2018-09-21T09:39:44Z'
       - received_at: '2018-09-21T09:40:44Z'
         delivered_at: '2018-09-21T09:50:44Z'
+
+- type: run_sql
+  args:
+    sql: |
+      CREATE TABLE "uuid_test" (
+        id serial primary key,
+        uuid_col UUID NOT NULL
+      )
+- type: track_table
+  args:
+    name: uuid_test
+    schema: public
+
+- type: insert
+  args:
+    table: uuid_test
+    objects:
+    - uuid_col: 28d6d683-1317-49f7-b1cf-7d195242e4e5
+    - uuid_col: 28d6d683-1317-49f7-b1cf-7d195242e4e6
+    - uuid_col: 28d6d683-1317-49f7-b1cf-7d195242e4e7

--- a/server/tests-py/queries/graphql_query/boolexp/basic/teardown.yaml
+++ b/server/tests-py/queries/graphql_query/boolexp/basic/teardown.yaml
@@ -32,3 +32,8 @@ args:
   args:
     sql: |
       drop table message
+
+- type: run_sql
+  args:
+    sql: |
+      drop table uuid_test

--- a/server/tests-py/test_graphql_queries.py
+++ b/server/tests-py/test_graphql_queries.py
@@ -154,6 +154,9 @@ class TestGraphQLQueryBoolExpBasic(DefaultTestSelectQueries):
     def test_author_article_where_nin(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + '/select_author_article_where_nin.yaml')
 
+    def test_uuid_test_in_uuid_col(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + '/select_uuid_test_in_uuid_col.yaml')
+
     def test_order_delivered_at_is_null(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + '/select_query_order_delivered_at_is_null.yaml')
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
fix #1109 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
Use Postgresql `IN` expression instead of ` = ANY(ARRAY[..])` for `_in` operator in
`where` argument.

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [x] I have added required tests.
