### PR TITLE
metadata should be backwards compatible for remote schemas (fix #1120)

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Resolve/LiveQuery.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/LiveQuery.hs
@@ -19,6 +19,7 @@ import           Control.Concurrent                     (threadDelay)
 
 import           Hasura.GraphQL.Resolve.Context         (RespTx)
 import           Hasura.GraphQL.Transport.HTTP.Protocol
+import           Hasura.GraphQL.Utils
 import           Hasura.Prelude
 import           Hasura.RQL.Types
 
@@ -86,9 +87,6 @@ removeLiveQuery lqMap liveQ k = do
           STMMap.delete liveQ lqMap
           Just <$> STM.takeTMVar threadRef
         else return Nothing
-
-onJust :: (Monad m) => Maybe a -> (a -> m ()) -> m ()
-onJust m action = maybe (return ()) action m
 
 addLiveQuery
   :: (Eq k, Hashable k)

--- a/server/src-lib/Hasura/GraphQL/Utils.hs
+++ b/server/src-lib/Hasura/GraphQL/Utils.hs
@@ -16,6 +16,7 @@ module Hasura.GraphQL.Utils
   , onLeft
   , showNames
   , isValidName
+  , onJust
   ) where
 
 import           Hasura.Prelude
@@ -33,6 +34,9 @@ showName name = "\"" <> G.unName name <> "\""
 
 onNothing :: (Monad m) => Maybe a -> m a -> m a
 onNothing m act = maybe act return m
+
+onJust :: (Monad m) => Maybe a -> (a -> m ()) -> m ()
+onJust m action = maybe (return ()) action m
 
 throwVE :: (MonadError QErr m) => Text -> m a
 throwVE = throw400 ValidationFailed


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
#1120 
### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [ ] I have added required tests.
