### PR TITLE
handle null values for input arguments (fix #1113)

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Resolve/Context.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/Context.hs
@@ -153,7 +153,9 @@ withArgM
   -> (AnnGValue -> m a)
   -> m (Maybe a)
 withArgM args arg f = prependArgsInPath $ nameAsPath arg $
-  mapM f $ Map.lookup arg args
+  mapM f $ handleNull =<< Map.lookup arg args
+  where
+    handleNull v = bool (Just v) Nothing $ hasNullVal v
 
 type PrepArgs = Seq.Seq Q.PrepArg
 

--- a/server/src-lib/Hasura/GraphQL/Resolve/InputValue.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/InputValue.hs
@@ -59,7 +59,7 @@ asPGColVal
 asPGColVal = \case
   AGScalar colTy (Just val) -> return (colTy, val)
   AGScalar colTy Nothing ->
-    throw500 $ "unexpected null for ty"
+    throw500 $ "unexpected null for ty "
     <> T.pack (show colTy)
   v            -> tyMismatch "pgvalue" v
 

--- a/server/src-lib/Hasura/GraphQL/Validate/Types.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate/Types.hs
@@ -329,11 +329,11 @@ pgColValToAnnGVal colTy colVal = AGScalar colTy $ Just colVal
 
 hasNullVal :: AnnGValue -> Bool
 hasNullVal = \case
-  AGScalar _ Nothing   -> True
+  AGScalar _ Nothing -> True
   AGEnum _ Nothing   -> True
   AGObject _ Nothing -> True
   AGArray _ Nothing  -> True
-  _ -> False
+  _                  -> False
 
 getAnnInpValKind :: AnnGValue -> Text
 getAnnInpValKind = \case

--- a/server/tests-py/queries/graphql_query/limits/select_query_article_limit_null.yaml
+++ b/server/tests-py/queries/graphql_query/limits/select_query_article_limit_null.yaml
@@ -1,0 +1,38 @@
+description: Nested select on article with limit (null)
+url: /v1alpha1/graphql
+status: 200
+response:
+  data:
+    article:
+    - id: 3
+      title: Article 3
+      content: Sample article content 3
+      author:
+        id: 2
+        name: Author 2
+    - id: 2
+      title: Article 2
+      content: Sample article content 2
+      author:
+        id: 1
+        name: Author 1
+    - id: 1
+      title: Article 1
+      content: Sample article content 1
+      author:
+        id: 1
+        name: Author 1
+
+query:
+  query: |
+    query {
+      article(limit: null, order_by: {id: desc}) {
+        id
+        title
+        content
+        author {
+          id
+          name
+        }
+      }
+    }

--- a/server/tests-py/test_graphql_queries.py
+++ b/server/tests-py/test_graphql_queries.py
@@ -92,6 +92,9 @@ class TestGraphQLQueryLimits(DefaultTestSelectQueries):
     def test_limit_2(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + '/select_query_article_limit_2.yaml')
 
+    def test_limit_null(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + '/select_query_article_limit_null.yaml')
+
     def test_err_str_limit_error(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + '/select_query_article_string_limit_error.yaml')
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->
fix #1113 

<!-- Please link to the issue here: -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
Assume input argument is absent if it's value is `null`.

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [x] I have added required tests.
