### PR TITLE
parse graphql input objects and arrays as scalar values (close #1132)

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Validate/InputValue.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate/InputValue.hs
@@ -95,7 +95,7 @@ jsonParser =
 toJValue :: (MonadError QErr m) => G.Value -> m J.Value
 toJValue = \case
   G.VVariable _                   ->
-    throwVE "variables are not accepted in scalars"
+    throwVE "variables are not allowed in scalars"
   G.VInt i                        -> return $ J.toJSON i
   G.VFloat f                      -> return $ J.toJSON f
   G.VString (G.StringValue t)     -> return $ J.toJSON t

--- a/server/src-lib/Hasura/GraphQL/Validate/InputValue.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate/InputValue.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE MultiWayIf            #-}
 {-# LANGUAGE NoImplicitPrelude     #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TupleSections         #-}
 
 module Hasura.GraphQL.Validate.InputValue
   ( validateInputValue
@@ -90,6 +92,23 @@ jsonParser =
     jScalar J.Null = pNull
     jScalar v      = pVal v
 
+toJValue :: (MonadError QErr m) => G.Value -> m J.Value
+toJValue = \case
+  G.VVariable _                   ->
+    throwVE "variables are not accepted in scalars"
+  G.VInt i                        -> return $ J.toJSON i
+  G.VFloat f                      -> return $ J.toJSON f
+  G.VString (G.StringValue t)     -> return $ J.toJSON t
+  G.VBoolean b                    -> return $ J.toJSON b
+  G.VNull                         -> return J.Null
+  G.VEnum (G.EnumValue n)         -> return $ J.toJSON n
+  G.VList (G.ListValueG vals)     ->
+    J.toJSON <$> mapM toJValue vals
+  G.VObject (G.ObjectValueG objs) ->
+    J.toJSON . Map.fromList <$> mapM toTup objs
+  where
+    toTup (G.ObjectFieldG f v) = (f,) <$> toJValue v
+
 valueParser
   :: ( MonadError QErr m
      , MonadReader ValidationCtx m)
@@ -121,8 +140,22 @@ valueParser =
     pScalar (G.VBoolean b)    = pVal $ J.Bool b
     pScalar (G.VString sv)    = pVal $ J.String $ G.unStringValue sv
     pScalar (G.VEnum _)       = throwVE "unexpected enum for a scalar"
-    pScalar (G.VObject _)     = throwVE "unexpected object for a scalar"
-    pScalar (G.VList _)       = throwVE "unexpected array for a scalar"
+    pScalar v                 = pVal =<< toJValue v
+
+toJValueC :: G.ValueConst -> J.Value
+toJValueC = \case
+  G.VCInt i                        -> J.toJSON i
+  G.VCFloat f                      -> J.toJSON f
+  G.VCString (G.StringValue t)     -> J.toJSON t
+  G.VCBoolean b                    -> J.toJSON b
+  G.VCNull                         -> J.Null
+  G.VCEnum (G.EnumValue n)         -> J.toJSON n
+  G.VCList (G.ListValueG vals)     ->
+    J.toJSON $ map toJValueC vals
+  G.VCObject (G.ObjectValueG objs) ->
+    J.toJSON . Map.fromList $ map toTup objs
+  where
+    toTup (G.ObjectFieldG f v) = (f, toJValueC v)
 
 constValueParser :: (MonadError QErr m) => InputValueParser G.ValueConst m
 constValueParser =
@@ -148,8 +181,7 @@ constValueParser =
     pScalar (G.VCBoolean b) = pVal $ J.Bool b
     pScalar (G.VCString sv) = pVal $ J.String $ G.unStringValue sv
     pScalar (G.VCEnum _)    = throwVE "unexpected enum for a scalar"
-    pScalar (G.VCObject _)  = throwVE "unexpected object for a scalar"
-    pScalar (G.VCList _)    = throwVE "unexpected array for a scalar"
+    pScalar v               = pVal $ toJValueC v
 
 validateObject
   :: ( MonadReader r m, Has TypeMap r

--- a/server/tests-py/queries/graphql_mutation/insert/basic/person_jsonb.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/basic/person_jsonb.yaml
@@ -1,0 +1,36 @@
+- description: Inserts person data via GraphQL mutation (without Variable)
+  url: /v1alpha1/graphql
+  status: 200
+  response:
+    data:
+      insert_person:
+        returning:
+        - details:
+            name:
+              last: murphy
+              first: json
+
+  query:
+    query: |
+      mutation insert_person{
+        insert_person(
+          objects: [
+            {
+              details: {name: {first: json last: murphy}}
+            }
+          ]
+        ) {
+          returning {
+            details
+          }
+        }
+      }
+- description: Delete the inserted persons
+  url: /v1/query
+  status: 200
+  query:
+    type: run_sql
+    args:
+      sql: |
+        delete from person;
+        SELECT setval('person_id_seq', 1, FALSE);

--- a/server/tests-py/queries/graphql_mutation/insert/basic/person_jsonb_array.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/basic/person_jsonb_array.yaml
@@ -1,0 +1,42 @@
+- description: Inserts persons data via GraphQL mutation (without variables)
+  url: /v1alpha1/graphql
+  status: 200
+  response:
+    data:
+      insert_person:
+        returning:
+        - details:
+          - name:
+              last: jaha
+              first: thelonious
+          - name:
+              last: griffin
+              first: clarke
+
+  query:
+    query: |
+      mutation insert_person{
+        insert_person(
+          objects: [
+            {
+              details: [
+                  {name: {first: thelonious last: jaha}},
+                  {name: {first: clarke last: griffin}}
+                ]
+            }
+          ]
+        ) {
+          returning {
+            details
+          }
+        }
+      }
+- description: Delete the inserted persons
+  url: /v1/query
+  status: 200
+  query:
+    type: run_sql
+    args:
+      sql: |
+        delete from person;
+        SELECT setval('person_id_seq', 1, FALSE);

--- a/server/tests-py/test_graphql_mutations.py
+++ b/server/tests-py/test_graphql_mutations.py
@@ -27,6 +27,14 @@ class TestGraphQLInsert(DefaultTestQueries):
         check_query_f(hge_ctx, self.dir() + "/person_jsonb_variable_array.yaml")
         hge_ctx.may_skip_test_teardown = True
 
+    def test_insert_person(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + "/person_jsonb.yaml")
+        hge_ctx.may_skip_test_teardown = True
+
+    def test_insert_person_array(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + "/person_jsonb_array.yaml")
+        hge_ctx.may_skip_test_teardown = True
+
     def test_insert_null_col_value(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + "/order_col_shipped_null.yaml")
         hge_ctx.may_skip_test_teardown = True


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->
close #1132 

<!-- Please link to the issue here: -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
For columns with `json` and `jsonb` types parse Graphql input objects and arrays as `json` values. Validation fails if those objects/arrays have variables.

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [x] I have added required tests.
