### PR TITLE
better error messages for duplicate migration versions (close #1148)

### DIFF
--- a/cli/migrate/source/file/file.go
+++ b/cli/migrate/source/file/file.go
@@ -79,8 +79,9 @@ func (f *File) Open(url string, logger *log.Logger) (source.Driver, error) {
 				continue // ignore files that we can't parse
 			}
 
-			if !nf.migrations.Append(m) {
-				return nil, fmt.Errorf("unable to parse file %v", fi.Name())
+			err = nf.migrations.Append(m)
+			if err != nil {
+				return nil, err
 			}
 		}
 	}

--- a/cli/migrate/source/migration.go
+++ b/cli/migrate/source/migration.go
@@ -59,7 +59,7 @@ func (i *Migrations) Append(m *Migration) (err error) {
 
 	// reject duplicate versions
 	if migration, dup := i.migrations[m.Version][m.Direction]; dup {
-		return fmt.Errorf("found duplicate %s for version %d\n- %s\n- %s", m.Direction, m.Version, m.Identifier, migration.Identifier)
+		return fmt.Errorf("found duplicate migrations for version %d\n- %s\n- %s", m.Version, m.Raw, migration.Raw)
 	}
 
 	i.migrations[m.Version][m.Direction] = m

--- a/cli/migrate/source/migration.go
+++ b/cli/migrate/source/migration.go
@@ -1,6 +1,7 @@
 package source
 
 import (
+	"fmt"
 	"sort"
 )
 
@@ -47,9 +48,9 @@ func NewMigrations() *Migrations {
 	}
 }
 
-func (i *Migrations) Append(m *Migration) (ok bool) {
+func (i *Migrations) Append(m *Migration) (err error) {
 	if m == nil {
-		return false
+		return fmt.Errorf("migration cannot be nill")
 	}
 
 	if i.migrations[m.Version] == nil {
@@ -57,13 +58,13 @@ func (i *Migrations) Append(m *Migration) (ok bool) {
 	}
 
 	// reject duplicate versions
-	if _, dup := i.migrations[m.Version][m.Direction]; dup {
-		return false
+	if migration, dup := i.migrations[m.Version][m.Direction]; dup {
+		return fmt.Errorf("found duplicate %s for version %d\n- %s\n- %s", m.Direction, m.Version, m.Identifier, migration.Identifier)
 	}
 
 	i.migrations[m.Version][m.Direction] = m
 	i.buildIndex()
-	return true
+	return nil
 }
 
 func (i *Migrations) buildIndex() {


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [ ] Server
- [ ] Console
- [x] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

#1148 

<!-- Please link to the issue here: -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [ ] I have added required tests.
