### PR TITLE
show only valid options in alter type dropdown on modify table page (close #544)

### DIFF
--- a/console/src/components/Services/Data/TableModify/ModifyTable.js
+++ b/console/src/components/Services/Data/TableModify/ModifyTable.js
@@ -36,6 +36,17 @@ import {
 } from '../DataActions';
 import { showErrorNotification } from '../Notification';
 import gqlPattern, { gqlColumnErrorNotif } from '../Common/GraphQLValidation';
+import {
+  INTEGER,
+  SERIAL,
+  BIGINT,
+  BIGSERIAL,
+  UUID,
+  JSON,
+  JSONB,
+  TIMESTAMP,
+  TIME,
+} from '../../../../constants';
 
 const appPrefix = '/data';
 
@@ -221,6 +232,70 @@ const ColumnEditor = ({
       </option>
     );
   }
+
+  const generateAlterOptions = datatypeOptions => {
+    return dataTypes.map(datatype => {
+      if (datatypeOptions.includes(datatype.value)) {
+        return (
+          <option
+            value={datatype.value}
+            key={datatype.name}
+            title={datatype.description}
+          >
+            {datatype.name}
+          </option>
+        );
+      }
+    });
+  };
+
+  const modifyAlterOptions = columntype => {
+    const integerOptions = [
+      'integer',
+      'serial',
+      'bigint',
+      'bigserial',
+      'numeric',
+      'text',
+    ];
+    const bigintOptions = ['bigint', 'bigserial', 'text', 'numeric'];
+    const uuidOptions = ['uuid', 'text'];
+    const jsonOptions = ['json', 'jsonb', 'text'];
+    const timestampOptions = ['timestamptz', 'text'];
+    const timeOptions = ['timetz', 'text'];
+    switch (columntype) {
+      case INTEGER:
+        return generateAlterOptions(integerOptions);
+
+      case SERIAL:
+        return generateAlterOptions(integerOptions);
+
+      case BIGINT:
+        return generateAlterOptions(bigintOptions);
+
+      case BIGSERIAL:
+        return generateAlterOptions(bigintOptions);
+
+      case UUID:
+        return generateAlterOptions(uuidOptions);
+
+      case JSON:
+        return generateAlterOptions(jsonOptions);
+
+      case JSONB:
+        return generateAlterOptions(jsonOptions);
+
+      case TIMESTAMP:
+        return generateAlterOptions(timestampOptions);
+
+      case TIME:
+        return generateAlterOptions(timeOptions);
+
+      default:
+        return generateAlterOptions([columntype, 'text']);
+    }
+  };
+
   return (
     <div className={`${styles.colEditor} container-fluid`}>
       <form
@@ -246,7 +321,7 @@ const ColumnEditor = ({
               defaultValue={finalDefaultValue}
               disabled={isPrimaryKey}
             >
-              {alterTypeOptions}
+              {modifyAlterOptions(column.data_type)}
               {additionalOptions}
             </select>
           </div>

--- a/console/src/constants.js
+++ b/console/src/constants.js
@@ -1,1 +1,11 @@
 export const SERVER_CONSOLE_MODE = 'server';
+
+export const INTEGER = 'integer';
+export const SERIAL = 'serial';
+export const BIGINT = 'bigint';
+export const BIGSERIAL = 'bigserial';
+export const UUID = 'uuid';
+export const JSON = 'json';
+export const JSONB = 'jsonb';
+export const TIMESTAMP = 'timestamp with time zone';
+export const TIME = 'time with time zone';


### PR DESCRIPTION
This commit fixes the alter type dropdown on modify page
to show only valid datatypes.

Fixes: #544

The valid datatypes are as follows:
### From integer/ integer auto increment:
1. integer auto increment
2. big int
3. big int auto increment
4. numeric
5. text

### From uuid:
1. text

### From big int/ big int auto increment:
1. big int auto increment
2. text
3. numeric

### json and jsonb  can be changed to one another.

### Don't allow change of datatype for text, ~~date, timestamp, time and boolean~~.
### Allow change of datatype to text for date, timestamp, time and boolean.

What component does this PR affect? 

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [ ] I have added required tests.
