### PR TITLE
add license information in getting started docs and do one-click guide

### DIFF
--- a/docs/graphql/manual/getting-started/docker-simple.rst
+++ b/docs/graphql/manual/getting-started/docker-simple.rst
@@ -68,3 +68,8 @@ Advanced
 This was a quickstart guide to get the Hasura GraphQL engine up and running
 quickly. For more detailed instructions on deploying using Docker, check out
 :doc:`../deployment/docker/index`.
+
+License
+-------
+The Hasura GraphQL Engine is open source. View license `here <https://github.com/hasura/graphql-engine/blob/master/LICENSE>`_.
+

--- a/docs/graphql/manual/getting-started/heroku-simple.rst
+++ b/docs/graphql/manual/getting-started/heroku-simple.rst
@@ -53,3 +53,7 @@ Advanced
 
 This was a quickstart guide to get the Hasura GraphQL engine up and running quickly. For more detailed instructions
 on deploying using Heroku, check out :doc:`../deployment/heroku/index`.
+
+License
+-------
+The Hasura GraphQL Engine is open source. View license `here <https://github.com/hasura/graphql-engine/blob/master/LICENSE>`_.

--- a/docs/graphql/manual/getting-started/index.rst
+++ b/docs/graphql/manual/getting-started/index.rst
@@ -44,3 +44,8 @@ Using an existing database
    Using an existing database <using-existing-database>
    first-graphql-query
    first-event-trigger
+
+License
+-------
+The Hasura GraphQL Engine is open source. View license `here <https://github.com/hasura/graphql-engine/blob/master/LICENSE>`_.
+

--- a/docs/graphql/manual/guides/deployment/digital-ocean-one-click.rst
+++ b/docs/graphql/manual/guides/deployment/digital-ocean-one-click.rst
@@ -307,3 +307,8 @@ Logs
 
 Where ``<container_name>`` is one of ``graphql-engine``, ``postgres`` or
 ``caddy``.
+
+License
+-------
+The Hasura GraphQL Engine is open source. View license `here <https://github.com/hasura/graphql-engine/blob/master/LICENSE>`_.
+


### PR DESCRIPTION
### Description
Add license information in some of the getting started docs and deployment guide for DO

What component does this PR affect? 

- [ ] Server
- [ ] Console
- [ ] CLI
- [x] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs update
- [ ] Community content

### Checklist:
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [ ] I have added required tests.
