### PR TITLE
diff's query should account for table having no columns

### DIFF
--- a/server/src-lib/Hasura/RQL/DDL/Schema/Diff.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Diff.hs
@@ -58,7 +58,7 @@ fetchTableMeta = do
         t.table_schema,
         t.table_name,
         t.table_oid,
-        c.columns,
+        coalesce(c.columns, '[]') as columns,
         coalesce(f.constraints, '[]') as constraints
     FROM
         (SELECT
@@ -72,7 +72,7 @@ fetchTableMeta = do
            ON
              c.relnamespace = n.oid
         ) t
-        INNER JOIN
+        LEFT OUTER JOIN
         (SELECT
              table_schema,
              table_name,

--- a/server/tests-py/queries/v1/ddl/drop_no_cols_table.yaml
+++ b/server/tests-py/queries/v1/ddl/drop_no_cols_table.yaml
@@ -1,0 +1,32 @@
+url: /v1/query
+status: 200
+response:
+- {result: null, result_type: CommandOk}
+- {message: success}
+- {result: null, result_type: CommandOk}
+- []
+query:
+  type: bulk
+  args:
+    - type: run_sql
+      args:
+        sql: |
+          create table hge_tests.t ();
+    - type: track_table
+      args:
+        schema: hge_tests
+        name: t
+    - type: run_sql
+      args:
+        sql: |
+          drop table hge_tests.t;
+    - type: select
+      args:
+        table:
+          schema: hdb_catalog
+          name: hdb_table
+        columns:
+        - table_name
+        where:
+          table_name: t
+          table_schema: hge_tests

--- a/server/tests-py/test_v1_queries.py
+++ b/server/tests-py/test_v1_queries.py
@@ -2,6 +2,9 @@ import yaml
 from validate import check_query_f
 from super_classes import DefaultTestSelectQueries, DefaultTestQueries
 
+class TestDropNoColsTable:
+    def test_drop_no_cols_table(self, hge_ctx):
+        check_query_f(hge_ctx, 'queries/v1/ddl/drop_no_cols_table.yaml')
 
 class TestV1General(DefaultTestQueries):
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
#1255 
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [x] I have added required tests.
