### PR TITLE
persist headers in graphiQL tab (close #275)

### DIFF
--- a/console/src/components/ApiExplorer/ApiRequest.js
+++ b/console/src/components/ApiExplorer/ApiRequest.js
@@ -197,7 +197,34 @@ class ApiRequest extends Component {
   }
 
   getHeaderRows() {
-    const rows = this.props.headers.map((header, i) => {
+    let headers;
+    if (localStorage.getItem('HASURA_CONSOLE_GRAPHIQL_HEADERS')) {
+      const stored_headers = JSON.parse(
+        localStorage.getItem('HASURA_CONSOLE_GRAPHIQL_HEADERS')
+      );
+      console.log(stored_headers);
+      console.log(this.props.headers);
+      //Case when user loads again.
+      if (stored_headers.length > this.props.headers.length) {
+        const input_row = this.props.headers.pop();
+        for (let i = 2; i <= stored_headers.length - 2; i++) {
+          this.props.headers.push(stored_headers[i]);
+        }
+        this.props.headers.push(input_row);
+      }
+      headers = this.props.headers;
+      localStorage.setItem(
+        'HASURA_CONSOLE_GRAPHIQL_HEADERS',
+        JSON.stringify(headers)
+      );
+    } else {
+      headers = this.props.headers;
+      localStorage.setItem(
+        'HASURA_CONSOLE_GRAPHIQL_HEADERS',
+        JSON.stringify(headers)
+      );
+    }
+    const rows = headers.map((header, i) => {
       return (
         <tr key={i}>
           {header.isNewHeader ? null : (

--- a/console/src/components/ApiExplorer/ApiRequest.js
+++ b/console/src/components/ApiExplorer/ApiRequest.js
@@ -223,7 +223,6 @@ class ApiRequest extends Component {
           i <= stored_headers.length - initHeaderCount;
           i++
         ) {
-          console.log(i);
           if (!headers_map.has(stored_headers[i].key)) {
             this.props.headers.push(stored_headers[i]);
           }

--- a/console/src/components/ApiExplorer/ApiRequest.js
+++ b/console/src/components/ApiExplorer/ApiRequest.js
@@ -23,7 +23,9 @@ const styles = require('./ApiExplorer.scss');
 class ApiRequest extends Component {
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      deletedHeader: false,
+    };
     this.state.accessKeyVisible = false;
     this.state.bodyAllowedMethods = ['POST'];
     this.state.tabIndex = 0;
@@ -66,6 +68,7 @@ class ApiRequest extends Component {
 
   onDeleteHeaderClicked(e) {
     const index = parseInt(e.target.getAttribute('data-header-id'), 10);
+    this.setState({ deletedHeader: true });
     this.props.dispatch(removeRequestHeader(index));
   }
 
@@ -198,19 +201,33 @@ class ApiRequest extends Component {
 
   getHeaderRows() {
     let headers;
+    const headers_map = new Map();
     if (localStorage.getItem('HASURA_CONSOLE_GRAPHIQL_HEADERS')) {
       const stored_headers = JSON.parse(
         localStorage.getItem('HASURA_CONSOLE_GRAPHIQL_HEADERS')
       );
-      console.log(stored_headers);
-      console.log(this.props.headers);
+      for (const s_h of this.props.headers) {
+        if (!headers_map.has(s_h.key)) {
+          headers_map.set(s_h.key, 1);
+        }
+      }
       //Case when user loads again.
-      if (stored_headers.length > this.props.headers.length) {
+      if (
+        stored_headers.length > this.props.headers.length &&
+        this.state.deletedHeader === false
+      ) {
         const input_row = this.props.headers.pop();
         for (let i = 2; i <= stored_headers.length - 2; i++) {
-          this.props.headers.push(stored_headers[i]);
+          if (!headers_map.has(stored_headers[i].key)) { this.props.headers.push(stored_headers[i]); }
         }
         this.props.headers.push(input_row);
+      }
+      //Case when user deletes a header from console.
+      if (
+        stored_headers.length > this.props.headers.length &&
+        this.state.deletedHeader === true
+      ) {
+        this.setState({ deletedHeader: false });
       }
       headers = this.props.headers;
       localStorage.setItem(

--- a/console/src/components/ApiExplorer/ApiRequest.js
+++ b/console/src/components/ApiExplorer/ApiRequest.js
@@ -216,9 +216,17 @@ class ApiRequest extends Component {
         stored_headers.length > this.props.headers.length &&
         this.state.deletedHeader === false
       ) {
+        const initHeaderCount = this.props.headers.length - 1;
         const input_row = this.props.headers.pop();
-        for (let i = 2; i <= stored_headers.length - 2; i++) {
-          if (!headers_map.has(stored_headers[i].key)) { this.props.headers.push(stored_headers[i]); }
+        for (
+          let i = initHeaderCount;
+          i <= stored_headers.length - initHeaderCount;
+          i++
+        ) {
+          console.log(i);
+          if (!headers_map.has(stored_headers[i].key)) {
+            this.props.headers.push(stored_headers[i]);
+          }
         }
         this.props.headers.push(input_row);
       }


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->
persist headers setting in graphiQL tab added.
(fix #275)
### Description
<!-- Describe your changes in detail -->
Added headers that are set into localStorage, and loaded the headers that already present from localStorage.
<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [ ] I have added required tests.
