### PR TITLE
 Multiple root fields in subscription was removed

### DIFF
--- a/docs/graphql/manual/subscriptions/index.rst
+++ b/docs/graphql/manual/subscriptions/index.rst
@@ -17,9 +17,8 @@ You can turn any query into a subscription by simply replacing ``query`` with ``
 
 .. admonition:: Caveat
 
-  The `GraphQL spec <http://facebook.github.io/graphql/June2018/#sec-Single-root-field>`_ allows for only one root
-  field in a subscription. So though Hasura GraphQL engine supports multiple root fields in subscriptions, most clients
-  will not allow it.
+  Hasura follows the `GraphQL spec <http://facebook.github.io/graphql/June2018/#sec-Single-root-field>`_ which 
+  allows for only one root field in a subscription.
 
 Use cases
 ---------


### PR DESCRIPTION
In alpha33 the support for multiple root fields in a subscription was removed. This PR updated the docs to reflect this.

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [ ] Server
- [ ] Console
- [ ] CLI
- [x] Docs
- [ ] Community Content
- [ ] Build System


### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [ ] I have added required tests.
