### PR TITLE
accept null for relational insert input and handle empty insert objects (fix #1352)

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Resolve/InputValue.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/InputValue.hs
@@ -7,6 +7,7 @@ module Hasura.GraphQL.Resolve.InputValue
   , withObject
   , asObject
   , withObjectM
+  , asObjectM
   , withArray
   , asArray
   , withArrayM
@@ -86,6 +87,11 @@ withObjectM
 withObjectM fn v = case v of
   AGObject nt objM -> fn nt objM
   _                -> tyMismatch "object" v
+
+asObjectM
+  :: (MonadError QErr m)
+  => AnnGValue -> m (Maybe AnnGObject)
+asObjectM = withObjectM (\_ o -> return o)
 
 withArrayM
   :: (MonadError QErr m)

--- a/server/tests-py/queries/graphql_mutation/insert/basic/author_article.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/basic/author_article.yaml
@@ -28,7 +28,30 @@
             name
           }
         }
-      } 
+      }
+
+#Inserting empty objects
+- description: Inserts empty objects via GraphQL mutation
+  url: /v1alpha1/graphql
+  status: 200
+  response:
+    data:
+      insert_author:
+        affected_rows: 0
+        returning: []
+  query:
+    query: |
+      mutation insert_empty_objects {
+        insert_author(
+          objects: []
+        ){
+          affected_rows
+          returning{
+            id
+            name
+          }
+        }
+      }
 
 #Inserting article data
 - description: Inserts article data via GraphQL mutation

--- a/server/tests-py/queries/graphql_mutation/insert/nested/author_with_articles_empty.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/nested/author_with_articles_empty.yaml
@@ -1,0 +1,37 @@
+description: Insert author with empty articles
+url: /v1alpha1/graphql
+status: 200
+query:
+  query: |
+    mutation {
+      insert_author(
+        objects: [
+          {
+            id: 4
+            name: "Author 4"
+            articles: {
+              data: []
+            }
+          }
+        ]
+      ){
+        affected_rows
+        returning{
+          id
+          name
+          articles{
+            id
+            title
+            content
+          }
+        }
+      }
+    }
+response:
+  data:
+    insert_author:
+      affected_rows: 1
+      returning:
+      - id: 4
+        name: Author 4
+        articles: []

--- a/server/tests-py/queries/graphql_mutation/insert/nested/author_with_articles_null.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/nested/author_with_articles_null.yaml
@@ -1,0 +1,35 @@
+description: Insert author with empty articles
+url: /v1alpha1/graphql
+status: 200
+query:
+  query: |
+    mutation {
+      insert_author(
+        objects: [
+          {
+            id: 4
+            name: "Author 4"
+            articles: null
+          }
+        ]
+      ){
+        affected_rows
+        returning{
+          id
+          name
+          articles{
+            id
+            title
+            content
+          }
+        }
+      }
+    }
+response:
+  data:
+    insert_author:
+      affected_rows: 1
+      returning:
+      - id: 4
+        name: Author 4
+        articles: []

--- a/server/tests-py/test_graphql_mutations.py
+++ b/server/tests-py/test_graphql_mutations.py
@@ -205,6 +205,12 @@ class TestGraphqlNestedInserts(DefaultTestQueries):
     def test_author_with_articles(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + "/author_with_articles.yaml")
 
+    def test_author_with_articles_empty(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + "/author_with_articles_empty.yaml")
+
+    def test_author_with_articles_null(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + "/author_with_articles_null.yaml")
+
     def test_author_with_articles_author_id_fail(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + "/author_with_articles_author_id_fail.yaml")
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
fix #1352 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
1. Ignore relational insert if `null` is given or `[]` for `data` input field for array relational insert
2. Ignore insert and return empty mutation response if `[]` is given for `objects` input field

Example query :- 

```graphql
      mutation insert_empty_objects {
        insert_author(
          objects: []
        ){
          affected_rows
          returning{
            id
            name
          }
        }
      }
```
Response:- 

```json
{
  "data": {
    "insert_author": {
      "affected_rows": 0,
      "returning": []
    }
  }
}
```


### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [x] I have added required tests.
