### PR TITLE
simplify SQL generated for _eq and _neq operators in GraphQL API

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Resolve/BoolExp.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/BoolExp.hs
@@ -26,9 +26,9 @@ parseOpExps
 parseOpExps annVal = do
   opExpsM <- flip withObjectM annVal $ \nt objM -> forM objM $ \obj ->
     forM (OMap.toList obj) $ \(k, v) -> case k of
-      "_eq"           -> fmap AEQ <$> asPGColValM v
-      "_ne"           -> fmap ANE <$> asPGColValM v
-      "_neq"          -> fmap ANE <$> asPGColValM v
+      "_eq"           -> fmap (AEQ True) <$> asPGColValM v
+      "_ne"           -> fmap (ANE True) <$> asPGColValM v
+      "_neq"          -> fmap (ANE True) <$> asPGColValM v
       "_is_null"      -> resolveIsNull v
 
       "_in"           -> fmap (AIN . catMaybes) <$> parseMany asPGColValM v
@@ -92,7 +92,7 @@ parseAsEqOp
   :: (MonadError QErr m)
   => AnnGValue -> m [OpExp]
 parseAsEqOp annVal = do
-  annValOpExp <- AEQ <$> asPGColVal annVal
+  annValOpExp <- AEQ True <$> asPGColVal annVal
   return [annValOpExp]
 
 parseColExp

--- a/server/src-lib/Hasura/GraphQL/Resolve/Insert.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/Insert.hs
@@ -205,7 +205,7 @@ mkBoolExp tn colInfoVals =
   mapM (fmap BoolFld . uncurry f) colInfoVals
   where
     f ci@(PGColInfo _ colTy _) colVal =
-      AVCol ci . pure . AEQ <$> prepare (colTy, colVal)
+      AVCol ci . pure . AEQ True <$> prepare (colTy, colVal)
 
 mkSelQ :: MonadError QErr m => QualifiedTable
        -> [PGColInfo] -> [PGColWithValue] -> m InsWithExp

--- a/server/src-lib/Hasura/RQL/Types/BoolExp.hs
+++ b/server/src-lib/Hasura/RQL/Types/BoolExp.hs
@@ -91,8 +91,8 @@ foldBoolExp f (BoolFld ce)  =
   f ce
 
 data OpExpG a
-  = AEQ !a
-  | ANE !a
+  = AEQ !Bool !a
+  | ANE !Bool !a
 
   | AIN  ![a]
   | ANIN ![a]
@@ -140,8 +140,8 @@ data OpExpG a
 
 opExpToJPair :: (a -> Value) -> OpExpG a -> (Text, Value)
 opExpToJPair f = \case
-  AEQ a          -> ("_eq", f a)
-  ANE a          -> ("_ne", f a)
+  AEQ _ a          -> ("_eq", f a)
+  ANE _ a          -> ("_ne", f a)
 
   AIN a          -> ("_in", toJSON $ map f a)
   ANIN a         -> ("_nin", toJSON $ map f a)


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
Use simple `=` for `_eq` and `<>` for `_neq` operators 

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [ ] I have added required tests.
