### PR TITLE
fix empty set object returns postgres error in update mutation (fix #1448)

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Resolve/Mutation.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/Mutation.hs
@@ -2,10 +2,13 @@ module Hasura.GraphQL.Resolve.Mutation
   ( convertUpdate
   , convertDelete
   , convertMutResp
+  , buildEmptyMutResp
   ) where
 
+import           Control.Arrow                     (second)
 import           Hasura.Prelude
 
+import qualified Data.Aeson                        as J
 import qualified Data.HashMap.Strict.InsOrd        as OMap
 import qualified Language.GraphQL.Draft.Syntax     as G
 
@@ -117,13 +120,17 @@ convertUpdate tn filterExp fld = do
   let updExpsM = [ setExpM, incExpM, appendExpM, prependExpM
                  , deleteKeyExpM, deleteElemExpM, deleteAtPathExpM
                  ]
-      updExp = concat $ catMaybes updExpsM
+      setItems = concat $ catMaybes updExpsM
   -- atleast one of update operators is expected
   unless (any isJust updExpsM) $ throwVE $
     "atleast any one of _set, _inc, _append, _prepend, _delete_key, _delete_elem and "
     <> " _delete_at_path operator is expected"
-  let p1 = RU.UpdateQueryP1 tn updExp (filterExp, whereExp) mutFlds
-  return $ RU.updateQueryToTx (p1, prepArgs)
+  let p1 = RU.UpdateQueryP1 tn setItems (filterExp, whereExp) mutFlds
+      whenNonEmptyItems = return $ RU.updateQueryToTx (p1, prepArgs)
+      whenEmptyItems = buildEmptyMutResp mutFlds
+  -- if there are not set items then do not perform
+  -- update and return empty mutation response
+  bool whenNonEmptyItems whenEmptyItems $ null setItems
   where
     args = _fArguments fld
 
@@ -138,3 +145,14 @@ convertDelete tn filterExp fld = do
   args <- get
   let p1 = RD.DeleteQueryP1 tn (filterExp, whereExp) mutFlds
   return $ RD.deleteQueryToTx (p1, args)
+
+-- | build mutation response for empty objects
+buildEmptyMutResp :: Monad m => RR.MutFlds -> m RespTx
+buildEmptyMutResp = return . mkTx
+  where
+    mkTx = return . J.encode . OMap.fromList . map (second convMutFld)
+    -- generate empty mutation response
+    convMutFld = \case
+      RR.MCount -> J.toJSON (0 :: Int)
+      RR.MExp e -> J.toJSON e
+      RR.MRet _ -> J.toJSON ([] :: [J.Value])

--- a/server/tests-py/queries/graphql_mutation/update/basic/author_empty_set.yaml
+++ b/server/tests-py/queries/graphql_mutation/update/basic/author_empty_set.yaml
@@ -1,0 +1,30 @@
+description: Update mutation on author
+url: /v1alpha1/graphql
+status: 200
+response:
+  data:
+   update_author:
+     affected_rows: 0
+     returning: []
+query:
+  variables:
+    set: {}
+  query: |
+    mutation update_author ($set: author_set_input!) {
+      update_author(
+        where: {id: {_eq: 1}},
+        _set: $set
+      ) {
+        affected_rows
+        returning{
+          id
+          name
+          articles{
+            id
+            title
+            content
+            is_published
+          }
+        }
+      }
+    }

--- a/server/tests-py/test_graphql_mutations.py
+++ b/server/tests-py/test_graphql_mutations.py
@@ -255,6 +255,10 @@ class TestGraphqlUpdateBasic(DefaultTestQueries):
     def test_set_author_name(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + "/author_set_name.yaml")
 
+    def test_empty_set_author(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + "/author_empty_set.yaml")
+        hge_ctx.may_skip_test_teardown = True
+
     def test_set_person_details(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + "/person_set_details.yaml")
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
fix #1448 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
If collection of `_set`, `_inc`, `_append`, `_prepend`, `_delete_key`, `_delete_elem` and
`_delete_at_path` input objects in update mutation is empty then server returns empty response

Ex:-
```graphql
mutation withEmptySet{
  update_author(
    _set: {}
    where: {name: {_eq: "clarke"}}
  ){
    affected_rows
    returning{
      id
      name
      age
    }
  }
}
```
Response:-
```json
{
  "data": {
    "update_author": {
      "affected_rows": 0,
      "returning": []
    }
  }
}
```

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [x] I have added required tests.
