### PR TITLE
add config for stringified hasura claims in JWT (fix #1176)

### DIFF
--- a/.circleci/test-server.sh
+++ b/.circleci/test-server.sh
@@ -165,7 +165,7 @@ unset HASURA_GRAPHQL_JWT_SECRET
 
 echo -e "\n<########## TEST GRAPHQL-ENGINE WITH ACCESS KEY AND JWT (in stringified mode) #####################################>\n"
 
-export HASURA_GRAPHQL_JWT_SECRET="$(jq -n --arg key "$(cat $OUTPUT_FOLDER/ssl/jwt_public.key)" '{ type: "RS512", key: $key , is_stringified: true}')"
+export HASURA_GRAPHQL_JWT_SECRET="$(jq -n --arg key "$(cat $OUTPUT_FOLDER/ssl/jwt_public.key)" '{ type: "RS512", key: $key , claims_format: "stringified_json"}')"
 
 "$GRAPHQL_ENGINE" serve >> "$OUTPUT_FOLDER/graphql-engine.log" & PID=$!
 

--- a/.circleci/test-server.sh
+++ b/.circleci/test-server.sh
@@ -155,7 +155,21 @@ export HASURA_GRAPHQL_JWT_SECRET="$(jq -n --arg key "$(cat $OUTPUT_FOLDER/ssl/jw
 
 "$GRAPHQL_ENGINE" serve >> "$OUTPUT_FOLDER/graphql-engine.log" & PID=$!
 
-pytest -vv --hge-url="$HGE_URL" --pg-url="$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ACCESS_KEY" --hge-jwt-key-file="$OUTPUT_FOLDER/ssl/jwt_private.key"
+pytest -vv --hge-url="$HGE_URL" --pg-url="$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ACCESS_KEY" --hge-jwt-key-file="$OUTPUT_FOLDER/ssl/jwt_private.key" --hge-jwt-conf="$HASURA_GRAPHQL_JWT_SECRET"
+
+kill -INT $PID
+sleep 4
+combine_hpc_reports
+
+unset HASURA_GRAPHQL_JWT_SECRET
+
+echo -e "\n<########## TEST GRAPHQL-ENGINE WITH ACCESS KEY AND JWT (in stringified mode) #####################################>\n"
+
+export HASURA_GRAPHQL_JWT_SECRET="$(jq -n --arg key "$(cat $OUTPUT_FOLDER/ssl/jwt_public.key)" '{ type: "RS512", key: $key , is_stringified: true}')"
+
+"$GRAPHQL_ENGINE" serve >> "$OUTPUT_FOLDER/graphql-engine.log" & PID=$!
+
+pytest -vv --hge-url="$HGE_URL" --pg-url="$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ACCESS_KEY" --hge-jwt-key-file="$OUTPUT_FOLDER/ssl/jwt_private.key" --hge-jwt-conf="$HASURA_GRAPHQL_JWT_SECRET" test_jwt.py
 
 kill -INT $PID
 sleep 4

--- a/docs/graphql/manual/auth/jwt.rst
+++ b/docs/graphql/manual/auth/jwt.rst
@@ -119,10 +119,11 @@ JSON object:
      "type": "<standard-JWT-algorithms>",
      "key": "<optional-key-as-string>",
      "jwk_url": "<optional-url-to-refresh-jwks>",
-     "claims_namespace": "<optional-key-name-in-claims>"
+     "claims_namespace": "<optional-key-name-in-claims>",
+     "is_stringified": <optional-boolean>
    }
 
-``key`` or ``jwk_url``, either of them has to be present.
+``key`` or ``jwk_url``, **one of them has to be present**.
 
 ``type``
 ^^^^^^^^
@@ -173,6 +174,52 @@ This is an optional field. You can specify the key name
 inside which the Hasura specific claims will be present. E.g. - ``https://mydomain.com/claims``.
 
 **Default value** is: ``https://hasura.io/jwt/claims``.
+
+
+``is_stringified``
+^^^^^^^^^^^^^^^^^^
+This is an optional boolean field. Default is ``false``.
+
+This is to indicate that if the hasura specific claims are stringified JSON or
+not. Even in the stringified case, the value of the string should be decodable
+as JSON.
+
+This is required because providers like AWS Cognito only allows strings in the
+JWT claims. `See #1176 <https://github.com/hasura/graphql-engine/issues/1176>`_.
+
+Example:-
+
+If ``is_stringified`` is ``false`` then JWT claims should look like:
+
+.. code-block:: json
+
+  {
+    "sub": "1234567890",
+    "name": "John Doe",
+    "admin": true,
+    "iat": 1516239022,
+    "https://hasura.io/jwt/claims": {
+      "x-hasura-allowed-roles": ["editor","user", "mod"],
+      "x-hasura-default-role": "user",
+      "x-hasura-user-id": "1234567890",
+      "x-hasura-org-id": "123",
+      "x-hasura-custom": "custom-value"
+    }
+  }
+
+
+If ``is_stringified`` is ``true`` then JWT claims should look like:
+
+.. code-block:: json
+
+  {
+    "sub": "1234567890",
+    "name": "John Doe",
+    "admin": true,
+    "iat": 1516239022,
+    "https://hasura.io/jwt/claims": "{\"x-hasura-allowed-roles\":[\"editor\",\"user\",\"mod\"],\"x-hasura-default-role\":\"user\",\"x-hasura-user-id\":\"1234567890\",\"x-hasura-org-id\":\"123\",\"x-hasura-custom\":\"custom-value\"}"
+  }
+
 
 Examples
 ^^^^^^^^

--- a/docs/graphql/manual/auth/jwt.rst
+++ b/docs/graphql/manual/auth/jwt.rst
@@ -120,7 +120,7 @@ JSON object:
      "key": "<optional-key-as-string>",
      "jwk_url": "<optional-url-to-refresh-jwks>",
      "claims_namespace": "<optional-key-name-in-claims>",
-     "is_stringified": <optional-boolean>
+     "claims_format": "json|stringified_json"
    }
 
 ``key`` or ``jwk_url``, **one of them has to be present**.
@@ -176,20 +176,23 @@ inside which the Hasura specific claims will be present. E.g. - ``https://mydoma
 **Default value** is: ``https://hasura.io/jwt/claims``.
 
 
-``is_stringified``
+``claims_format``
 ^^^^^^^^^^^^^^^^^^
-This is an optional boolean field. Default is ``false``.
+This is an optional field, with only the following possible values:
+- ``json``
+- ``stringified_json``
 
-This is to indicate that if the hasura specific claims are stringified JSON or
-not. Even in the stringified case, the value of the string should be decodable
-as JSON.
+Default is ``json``.
+
+This is to indicate that if the hasura specific claims are a regular JSON object
+or stringified JSON
 
 This is required because providers like AWS Cognito only allows strings in the
 JWT claims. `See #1176 <https://github.com/hasura/graphql-engine/issues/1176>`_.
 
 Example:-
 
-If ``is_stringified`` is ``false`` then JWT claims should look like:
+If ``claims_format`` is ``json`` then JWT claims should look like:
 
 .. code-block:: json
 
@@ -208,7 +211,7 @@ If ``is_stringified`` is ``false`` then JWT claims should look like:
   }
 
 
-If ``is_stringified`` is ``true`` then JWT claims should look like:
+If ``claims_format`` is ``stringified_json`` then JWT claims should look like:
 
 .. code-block:: json
 

--- a/server/src-lib/Hasura/Server/Auth.hs
+++ b/server/src-lib/Hasura/Server/Auth.hs
@@ -138,8 +138,8 @@ mkJwtCtx jwtConf httpManager loggerCtx = do
         Just t -> do
           jwkRefreshCtrl logger httpManager url ref t
           return ref
-  let strngfd = fromMaybe False (jcIsStringified conf)
-  return $ JWTCtx jwkRef (jcClaimNs conf) (jcAudience conf) strngfd
+  let claimsFmt = fromMaybe JCFJson (jcClaimsFormat conf)
+  return $ JWTCtx jwkRef (jcClaimNs conf) (jcAudience conf) claimsFmt
   where
     decodeErr e = throwError . T.pack $ "Fatal Error: JWT conf: " <> e
 

--- a/server/src-lib/Hasura/Server/Auth.hs
+++ b/server/src-lib/Hasura/Server/Auth.hs
@@ -138,7 +138,8 @@ mkJwtCtx jwtConf httpManager loggerCtx = do
         Just t -> do
           jwkRefreshCtrl logger httpManager url ref t
           return ref
-  return $ JWTCtx jwkRef (jcClaimNs conf) (jcAudience conf)
+  let strngfd = fromMaybe False (jcIsStringified conf)
+  return $ JWTCtx jwkRef (jcClaimNs conf) (jcAudience conf) strngfd
   where
     decodeErr e = throwError . T.pack $ "Fatal Error: JWT conf: " <> e
 

--- a/server/tests-py/conftest.py
+++ b/server/tests-py/conftest.py
@@ -23,6 +23,9 @@ def pytest_addoption(parser):
     parser.addoption(
         "--hge-jwt-key-file", metavar="HGE_JWT_KEY_FILE", help="File containting the private key used to encode jwt tokens using RS512 algorithm", required=False
     )
+    parser.addoption(
+        "--hge-jwt-conf", metavar="HGE_JWT_CONF", help="The JWT conf", required=False
+    )
 
 
 @pytest.fixture(scope='session')
@@ -34,8 +37,17 @@ def hge_ctx(request):
     hge_webhook = request.config.getoption('--hge-webhook')
     webhook_insecure = request.config.getoption('--test-webhook-insecure')
     hge_jwt_key_file = request.config.getoption('--hge-jwt-key-file')
+    hge_jwt_conf = request.config.getoption('--hge-jwt-conf')
     try:
-        hge_ctx = HGECtx(hge_url=hge_url, pg_url=pg_url, hge_key=hge_key, hge_webhook=hge_webhook, hge_jwt_key_file=hge_jwt_key_file, webhook_insecure = webhook_insecure )
+        hge_ctx = HGECtx(
+            hge_url=hge_url,
+            pg_url=pg_url,
+            hge_key=hge_key,
+            hge_webhook=hge_webhook,
+            webhook_insecure=webhook_insecure,
+            hge_jwt_key_file=hge_jwt_key_file,
+            hge_jwt_conf=hge_jwt_conf
+        )
     except HGECtxError as e:
         pytest.exit(str(e))
     yield hge_ctx  # provide the fixture value

--- a/server/tests-py/context.py
+++ b/server/tests-py/context.py
@@ -60,7 +60,7 @@ class WebhookServer(http.server.HTTPServer):
 
 
 class HGECtx:
-    def __init__(self, hge_url, pg_url, hge_key, hge_webhook, hge_jwt_key_file, webhook_insecure):
+    def __init__(self, hge_url, pg_url, hge_key, hge_webhook, webhook_insecure, hge_jwt_key_file, hge_jwt_conf):
         server_address = ('0.0.0.0', 5592)
 
         self.resp_queue = queue.Queue(maxsize=1)
@@ -83,6 +83,7 @@ class HGECtx:
         else:
             with open(hge_jwt_key_file) as f:
                 self.hge_jwt_key = f.read()
+        self.hge_jwt_conf = hge_jwt_conf
         self.webhook_insecure = webhook_insecure
         self.may_skip_test_teardown = False
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->
Add config option (`claims_format`) to indicate if the hasura specific claims in JWT are stringified.
This is required, as some providers like AWS Cognito allows only strings in custom claims.

Default : `json`. 

When `stringified_json`, Hasura will expect stringified hasura claims:

```json
  {
    "sub": "1234567890",
    "name": "John Doe",
    "admin": true,
    "iat": 1516239022,
    "https://hasura.io/jwt/claims": "{\"x-hasura-allowed-roles\":[\"editor\",\"user\",\"mod\"],\"x-hasura-default-role\":\"user\",\"x-hasura-user-id\":\"1234567890\",\"x-hasura-org-id\":\"123\",\"x-hasura-custom\":\"custom-value\"}"
  }
```

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [x] Server
- [ ] Console
- [ ] CLI
- [x] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
#1176 
### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [x] I have updated the documentation accordingly.
- [x] I have added required tests.
