### PR TITLE
Improve error message when no operation specs are provided during event trigger creation (close #998)

### DIFF
--- a/server/src-lib/Hasura/RQL/Types/Subscribe.hs
+++ b/server/src-lib/Hasura/RQL/Types/Subscribe.hs
@@ -122,7 +122,7 @@ instance FromJSON CreateEventTriggerQuery where
       else fail "only alphanumeric and underscore and hyphens allowed for name"
     case insert <|> update <|> delete of
       Just _  -> return ()
-      Nothing -> fail "must provide operation spec(s)"
+      Nothing -> fail "at least one among the insert/update/delete operation specs must be provided"
     case (webhook, webhookFromEnv) of
       (Just _, Nothing) -> return ()
       (Nothing, Just _) -> return ()

--- a/server/tests-py/queries/event_triggers/create-delete/create_trigger_operation_specs_not_provided_err.yaml
+++ b/server/tests-py/queries/event_triggers/create-delete/create_trigger_operation_specs_not_provided_err.yaml
@@ -1,0 +1,22 @@
+- description: Track table test_t1
+  url: /v1/query
+  status: 200
+  query:
+    type: track_table
+    args:
+      schema: hge_tests
+      name: test_t1
+- description: 'Create event trigger with no operation specs provider: Error'
+  url: /v1/query
+  status: 400
+  response:
+    error: at least one among the insert/update/delete operation specs must be provided
+    code: parse-failed
+    path: $
+  query:
+    type: create_event_trigger
+    args:
+      name: t1_1
+      table:
+        schema: hge_tests
+        name: test_t1

--- a/server/tests-py/test_events.py
+++ b/server/tests-py/test_events.py
@@ -66,6 +66,9 @@ class TestCreateAndDelete(DefaultTestQueries):
     def test_create_reset(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + "/create_and_reset.yaml")
 
+    def test_create_operation_spec_not_provider_err(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + "/create_trigger_operation_specs_not_provided_err.yaml")
+
     @classmethod
     def dir(cls):
         return 'queries/event_triggers/create-delete'


### PR DESCRIPTION


<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->
Improve the error message when none of the insert/update/delete operation specs are provided
<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->
#998 
<!-- Please link to the issue here: -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [x] I have added required tests.
