### PR TITLE
 don't allow altering tracked SQL functions type to VOLATILE (fix #1546)

### DIFF
--- a/server/src-lib/Hasura/RQL/DDL/Metadata.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Metadata.hs
@@ -32,7 +32,6 @@ import qualified Data.Text                      as T
 
 import           Hasura.GraphQL.Utils
 import           Hasura.Prelude
-import           Hasura.RQL.DDL.Utils
 import           Hasura.RQL.Types
 import           Hasura.SQL.Types
 

--- a/server/src-lib/Hasura/RQL/DDL/Schema/Diff.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Diff.hs
@@ -251,6 +251,10 @@ fetchFunctionMeta = do
     FROM
       hdb_catalog.hdb_function_agg f
       JOIN pg_catalog.pg_proc p ON (p.proname = f.function_name)
+      JOIN pg_catalog.pg_namespace pn ON (
+        pn.oid = p.pronamespace
+        AND pn.nspname = f.function_schema
+      )
     WHERE
       f.function_schema <> 'hdb_catalog'
     |] () False

--- a/server/src-lib/Hasura/RQL/DDL/Schema/Table.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Table.hs
@@ -440,8 +440,8 @@ execWithMDCheck (RunSQL t cascade _) = do
       oldMeta = flip filter oldMetaU $ \tm -> tmTable tm `elem` existingTables
       schemaDiff = getSchemaDiff oldMeta newMeta
       existingFuncs = M.keys $ scFunctions sc
-      oldFuncMeta = flip filter oldFuncMetaU $ \fm -> fmFunction fm `elem` existingFuncs
-      droppedFuncs = getDroppedFuncs oldFuncMeta newFuncMeta
+      oldFuncMeta = flip filter oldFuncMetaU $ \fm -> funcFromMeta fm `elem` existingFuncs
+      FunctionDiff droppedFuncs alteredFuncs = getFuncDiff oldFuncMeta newFuncMeta
 
   indirectDeps <- getSchemaChangeDeps schemaDiff
 
@@ -460,6 +460,12 @@ execWithMDCheck (RunSQL t cascade _) = do
   forM_ (droppedFuncs \\ purgedFuncs) $ \qf -> do
     liftTx $ delFunctionFromCatalog qf
     delFunctionFromCache qf
+
+  -- Process altered functions
+  forM_ alteredFuncs $ \(qf, newTy) ->
+    when (newTy == FTVOLATILE) $
+      throw400 NotSupported $
+      "type of function " <> qf <<> " is altered to \"VOLATILE\" which is not supported now"
 
   -- update the schema cache with the changes
   processSchemaChanges schemaDiff

--- a/server/tests-py/queries/graphql_query/functions/alter_function_error.yaml
+++ b/server/tests-py/queries/graphql_query/functions/alter_function_error.yaml
@@ -1,0 +1,17 @@
+description: Alter SQL function to type VOLATILE (error)
+url: /v1/query
+status: 400
+reponse:
+  path: "$.args"
+  error: type of function "search_posts" is altered to "VOLATILE" which is not supported
+    now
+  code: not-supported
+query:
+  type: run_sql
+  args:
+    sql: |
+      create or replace function search_posts(search text)
+      returns setof post as $$
+          insert into post (title, content) values (search, search)
+          returning *
+      $$ language sql volatile;

--- a/server/tests-py/test_graphql_queries.py
+++ b/server/tests-py/test_graphql_queries.py
@@ -339,6 +339,9 @@ class TestGraphQLQueryFunctions(DefaultTestSelectQueries):
     def test_search_posts_aggregate(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + "/query_search_posts_aggregate.yaml")
 
+    def test_alter_function_error(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + '/alter_function_error.yaml')
+
     @classmethod
     def dir(cls):
         return 'queries/graphql_query/functions'


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
fix #1546 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
In `run_sql` query (`/v1/query`), raise API exception if any function type is altered to
`VOLATILE`

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [x] I have added required tests.
