### PR TITLE
Fix incorrect schema templating in permissions location for setoff table

### DIFF
--- a/console/src/components/Services/Data/Function/Permission/Permission.js
+++ b/console/src/components/Services/Data/Function/Permission/Permission.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Helmet from 'react-helmet';
 import CommonTabLayout from '../../../Layout/CommonTabLayout/CommonTabLayout';
-import { Link } from 'react-router';
+// import { Link } from 'react-router';
 import { push } from 'react-router-redux';
 
 import { pageTitle, appPrefix } from '../Modify/constants';
@@ -16,11 +16,13 @@ import { fetchCustomFunction } from '../customFunctionReducer';
 
 class Permission extends React.Component {
   componentDidMount() {
-    const { functionName } = this.props.params;
+    const { functionName, schema } = this.props.params;
     if (!functionName) {
       this.props.dispatch(push(prefixUrl));
     }
-    Promise.all([this.props.dispatch(fetchCustomFunction(functionName))]);
+    Promise.all([
+      this.props.dispatch(fetchCustomFunction(functionName, schema)),
+    ]);
   }
   render() {
     const styles = require('../Modify/ModifyCustomFunction.scss');
@@ -28,9 +30,11 @@ class Permission extends React.Component {
       functionSchema: schema,
       functionName,
       setOffTable,
+      setOffTableSchema,
     } = this.props.functions;
+
     const baseUrl = `${appPrefix}/schema/${schema}/functions/${functionName}`;
-    const permissionTableUrl = `${appPrefix}/schema/${schema}/tables/${setOffTable}/permissions`;
+    const permissionTableUrl = `${prefixUrl}/schema/${setOffTableSchema}/tables/${setOffTable}/permissions`;
 
     const breadCrumbs = [
       {
@@ -78,14 +82,14 @@ class Permission extends React.Component {
           applicable to the data returned by this function
         </p>
         <div className={styles.commonBtn}>
-          <Link to={permissionTableUrl}>
+          <a href={permissionTableUrl}>
             <button
               className={styles.yellow_button}
               data-test={'custom-function-permission-btn'}
             >
               {`${setOffTable} Permissions`}
             </button>
-          </Link>
+          </a>
         </div>
       </div>
     );

--- a/console/src/components/Services/Data/Function/customFunctionReducer.js
+++ b/console/src/components/Services/Data/Function/customFunctionReducer.js
@@ -318,6 +318,7 @@ const customFunctionReducer = (state = functionData, action) => {
         functionSchema: action.data[0][0].function_schema || null,
         functionDefinition: action.data[1][0].function_definition || null,
         setOffTable: action.data[1][0].return_type_name || null,
+        setOffTableSchema: action.data[1][0].return_type_schema || null,
         isFetching: false,
         isFetchError: null,
       };

--- a/console/src/components/Services/Data/Function/customFunctionState.js
+++ b/console/src/components/Services/Data/Function/customFunctionState.js
@@ -12,6 +12,7 @@ const functionData = {
   functionSchema: '',
   functionDefinition: '',
   setOffTable: '',
+  setOffTableSchema: '',
   ...asyncState,
 };
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->
Fix #1549 
### Description
<!-- Describe your changes in detail -->
Templates correct return_type_schema in the permission tab 
<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [ ] I have added required tests.
