### PR TITLE
Refetch function info when the url changes

### DIFF
--- a/console/src/components/Services/Data/Function/Modify/ModifyCustomFunction.js
+++ b/console/src/components/Services/Data/Function/Modify/ModifyCustomFunction.js
@@ -31,12 +31,20 @@ class ModifyCustomFunction extends React.Component {
   }
   componentDidMount() {
     const { functionName, schema } = this.props.params;
-    if (!functionName) {
+    if (!functionName || !schema) {
       this.props.dispatch(push(prefixUrl));
     }
     Promise.all([
       this.props.dispatch(fetchCustomFunction(functionName, schema)),
     ]);
+  }
+  componentWillReceiveProps(nextProps) {
+    const { functionName, schema } = this.props.params;
+    if (functionName !== nextProps.params.functionName || schema !== nextProps.params.schema) {
+      Promise.all([
+        this.props.dispatch(fetchCustomFunction(nextProps.params.functionName, nextProps.params.schema)),
+      ]);
+    }
   }
   loadRunSQLAndLoadPage() {
     const { functionDefinition } = this.props.functions;


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->
Fix #1561 
### Description
<!-- Describe your changes in detail -->
Add to component lifecycle method to fetch info again when functionName or schema changes.
<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [ ] I have added required tests.
