### PR TITLE
Documenting how to use Hasura Access Key option within NuxtJS sample app

### DIFF
--- a/community/sample-apps/nuxtjs-postgres-graphql/README.md
+++ b/community/sample-apps/nuxtjs-postgres-graphql/README.md
@@ -50,6 +50,10 @@ columns: `id`, `title`, `content`, `author_id` (foreign key to `author` table's 
       return {
             httpLinkOptions: {
                 uri: 'https://my-app.herokuapp.com/v1alpha1/graphql',
+                // if you have secured the Hasura GraphQL endpoint
+                // headers: {
+                //   'x-hasura-access-key': '<YOUR_SECRET_KEY>'
+                // },
                 credentials: 'same-origin'
             },
             cache: new InMemoryCache(),

--- a/community/sample-apps/nuxtjs-postgres-graphql/apollo/clientConfig.js
+++ b/community/sample-apps/nuxtjs-postgres-graphql/apollo/clientConfig.js
@@ -1,16 +1,16 @@
 import { InMemoryCache } from "apollo-cache-inmemory";
 export default function(context){
   return {
-  	httpLinkOptions: {
+    httpLinkOptions: {
       // uri: 'https://my-app.herokuapp.com/v1alpha1/graphql',
       uri: 'http://localhost:8080/v1alpha1/graphql',
       // headers: {
       //   'x-hasura-access-key': '<YOUR_SECRET_KEY>'
       // },
-    	credentials: 'same-origin'
-  	},
-  	cache: new InMemoryCache(),
+      credentials: 'same-origin'
+    },
+    cache: new InMemoryCache(),
     // wsEndpoint: 'wss://my-app.herokuapp.com/v1alpha1/graphql',
-	  wsEndpoint: 'ws://localhost:8080/v1alpha1/graphql',
+    wsEndpoint: 'ws://localhost:8080/v1alpha1/graphql',
   }
 }

--- a/community/sample-apps/nuxtjs-postgres-graphql/apollo/clientConfig.js
+++ b/community/sample-apps/nuxtjs-postgres-graphql/apollo/clientConfig.js
@@ -1,11 +1,16 @@
 import { InMemoryCache } from "apollo-cache-inmemory";
 export default function(context){
   return {
-  		httpLinkOptions: {
-    		uri: 'http://localhost:8080/v1alpha1/graphql',
-    		credentials: 'same-origin'
-  		},
-  		cache: new InMemoryCache(),
-	    wsEndpoint: 'ws://localhost:8080/v1alpha1/graphql',
-  	}
+  	httpLinkOptions: {
+      // uri: 'https://my-app.herokuapp.com/v1alpha1/graphql',
+      uri: 'http://localhost:8080/v1alpha1/graphql',
+      // headers: {
+      //   'x-hasura-access-key': '<YOUR_SECRET_KEY>'
+      // },
+    	credentials: 'same-origin'
+  	},
+  	cache: new InMemoryCache(),
+    // wsEndpoint: 'wss://my-app.herokuapp.com/v1alpha1/graphql',
+	  wsEndpoint: 'ws://localhost:8080/v1alpha1/graphql',
+  }
 }


### PR DESCRIPTION
### Description

Simple update of the NuxtJS [`nuxtjs-postgres-graphql`] sample app, where I have added information on how to add the required headers after having secured the Hasura console with `HASURA_GRAPHQL_ACCESS_KEY` as per [Securing the GraphQL endpoint (Heroku)](https://docs.hasura.io/1.0/graphql/manual/deployment/heroku/securing-graphql-endpoint.html).

Updated the README contents and added commented out config code in the `apollo/clientConfig.js`.

What component does this PR affect? 

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [x] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue

None

### Solution and Design


### Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [x] Community content

### Checklist:
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [x] I have updated the documentation accordingly.
- [ ] I have added required tests.
