### PR TITLE
Update Docker DNS config for Docker for Mac setup

### DIFF
--- a/docs/graphql/manual/deployment/docker/index.rst
+++ b/docs/graphql/manual/deployment/docker/index.rst
@@ -88,7 +88,7 @@ command to allow the Docker container to access the host's network:
 
   .. tab:: Docker for Mac
 
-     Use ``host.docker.internal`` as hostname to access the host's Postgres service.
+     Use ``docker.for.mac.host.internal`` as hostname to access the host's Postgres service.
 
      This is what your command should look like:
 
@@ -96,7 +96,7 @@ command to allow the Docker container to access the host's network:
         :emphasize-lines: 2
 
         docker run -d -p 8080:8080 \
-          -e HASURA_GRAPHQL_DATABASE_URL=postgres://username:password@host.docker.internal:port/dbname \
+          -e HASURA_GRAPHQL_DATABASE_URL=postgres://username:password@docker.for.mac.host.internal/dbname \
           -e HASURA_GRAPHQL_ENABLE_CONSOLE=true \
           hasura/graphql-engine:latest
 


### PR DESCRIPTION
This PR updates the docker localhost setup in the docker-run script.

### Description
Updated use of 'docker.for.mac.host.internal' instead of 'host.docker.internal' as localhost

What component does this PR affect? 

- [ ] Server
- [ ] Console
- [ ] CLI
- [x] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
This references Issue #1612 

### Solution and Design
Update the localhost DNS as per updated docker API

### Type
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs update
- [ ] Community content

### Checklist:
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [x] I have updated the documentation accordingly.
- [ ] I have added required tests.
