### PR TITLE
make button texts consistent across event trigger and remote schemas (close #1634)

### DIFF
--- a/console/src/components/Services/EventTrigger/Add/AddTrigger.js
+++ b/console/src/components/Services/EventTrigger/Add/AddTrigger.js
@@ -233,7 +233,7 @@ class AddTrigger extends Component {
     const { supportColumnChangeFeature, supportRetryTimeout } = this.state;
 
     const styles = require('../TableCommon/Table.scss');
-    let createBtnText = 'Create';
+    let createBtnText = 'Add Event Trigger';
     if (ongoingRequest) {
       createBtnText = 'Creating...';
     } else if (lastError) {
@@ -476,7 +476,7 @@ class AddTrigger extends Component {
       >
         <Helmet title="Add Trigger - Events | Hasura" />
         <div className={styles.subHeader}>
-          <h2 className={styles.heading_text}>Add a new trigger</h2>
+          <h2 className={styles.heading_text}>Add a new event trigger</h2>
           <div className="clearfix" />
         </div>
         <br />

--- a/console/src/components/Services/EventTrigger/PageContainer/PageContainer.js
+++ b/console/src/components/Services/EventTrigger/PageContainer/PageContainer.js
@@ -85,7 +85,7 @@ const PageContainer = ({
             type="text"
             onChange={triggerSearch.bind(this)}
             className="form-control"
-            placeholder="search triggers"
+            placeholder="search event triggers"
             data-test="search-triggers"
           />
         </div>
@@ -100,7 +100,7 @@ const PageContainer = ({
               styles.padd_left_remove
             }
           >
-            Triggers ({triggerList.length})
+            Event Triggers ({triggerList.length})
           </div>
           {migrationMode ? (
             <div
@@ -116,7 +116,7 @@ const PageContainer = ({
                 to={'/events/manage/triggers/add'}
               >
                 <Button color="white" size="xs" data-test="sidebar-add-table">
-                  Add Trigger
+                  Add
                 </Button>
               </Link>
             </div>

--- a/console/src/components/Services/EventTrigger/Schema/Schema.js
+++ b/console/src/components/Services/EventTrigger/Schema/Schema.js
@@ -48,7 +48,7 @@ class Schema extends Component {
                   dispatch(push(`${appPrefix}/manage/triggers/add`));
                 }}
               >
-                Create Trigger
+                Add
               </Button>
             ) : null}
           </div>

--- a/console/src/components/Services/Layout/LeftNavBar/LeftNavBar.js
+++ b/console/src/components/Services/Layout/LeftNavBar/LeftNavBar.js
@@ -39,7 +39,7 @@ const LeftNavBar = ({
             type="text"
             onChange={tableSearch.bind(this)}
             className="form-control"
-            placeholder="Search remote schemas"
+            placeholder="search remote schemas"
             data-test="search-remote-schemas"
           />
         </div>


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->

<!-- Please put an `x` in the boxes below -->

What component does this PR affect? 

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
#1634 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [ ] I have added required tests.
