### PR TITLE
allow x-hasura- req headers for jwt unauth role (close #1686)

### DIFF
--- a/server/src-lib/Hasura/HTTP.hs
+++ b/server/src-lib/Hasura/HTTP.hs
@@ -1,6 +1,7 @@
 module Hasura.HTTP
   ( wreqOptions
   , HttpException(..)
+  , hdrsToText
   ) where
 
 import           Control.Lens          hiding ((.=))
@@ -12,7 +13,15 @@ import qualified Network.HTTP.Client   as HTTP
 import qualified Network.HTTP.Types    as HTTP
 import qualified Network.Wreq          as Wreq
 
+import           Data.CaseInsensitive  (original)
+import           Hasura.Server.Utils   (bsToTxt)
 import           Hasura.Server.Version (currentVersion)
+
+hdrsToText :: [HTTP.Header] -> [(Text, Text)]
+hdrsToText hdrs =
+  [ (bsToTxt $ original hdrName, bsToTxt hdrVal)
+  | (hdrName, hdrVal) <- hdrs
+  ]
 
 wreqOptions :: HTTP.Manager -> [HTTP.Header] -> Wreq.Options
 wreqOptions manager hdrs =

--- a/server/src-lib/Hasura/Server/Auth.hs
+++ b/server/src-lib/Hasura/Server/Auth.hs
@@ -22,7 +22,6 @@ module Hasura.Server.Auth
 import           Control.Exception       (try)
 import           Control.Lens
 import           Data.Aeson
-import           Data.CaseInsensitive    (CI (..), original)
 import           Data.IORef              (newIORef)
 
 import qualified Data.Aeson              as J
@@ -72,12 +71,6 @@ data AuthMode
   | AMAdminSecretAndHook !AdminSecret !AuthHook
   | AMAdminSecretAndJWT !AdminSecret !JWTCtx !(Maybe RoleName)
   deriving (Show, Eq)
-
-hdrsToText :: [N.Header] -> [(T.Text, T.Text)]
-hdrsToText hdrs =
-  [ (bsToTxt $ original hdrName, bsToTxt hdrVal)
-  | (hdrName, hdrVal) <- hdrs
-  ]
 
 mkAuthMode
   :: ( MonadIO m

--- a/server/src-lib/Hasura/Server/Auth/JWT.hs
+++ b/server/src-lib/Hasura/Server/Auth/JWT.hs
@@ -183,7 +183,8 @@ processJwt jwtCtx headers mUnAuthRole =
 
     withoutAuthZHeader = do
       unAuthRole <- maybe missingAuthzHeader return mUnAuthRole
-      return $ mkUserInfo unAuthRole $ mkUserVars []
+      return $ mkUserInfo unAuthRole $ mkUserVars $ hdrsToText headers
+
     missingAuthzHeader =
       throw400 InvalidHeaders "Missing Authorization header in JWT authentication mode"
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
In jwt mode when unauthorized role is used, the `x-hasura-*` headers are not being read. 

<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Affected components 
<!-- Remove non-affected components from the list -->

- Server

### Related Issues
#1686 

