### PR TITLE
add do and azure one-clicks to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ The fastest way to try Hasura out is via Heroku.
 
 Check out the instructions for the following one-click deployment options:
 
-* **DigitalOcean**
+* [**DigitalOcean**](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/digital-ocean-one-click.html#hasura-graphql-engine-digitalocean-one-click-app)
 
-  [![Deploy to DigitalOcean](https://graphql-engine-cdn.hasura.io/img/create_hasura_droplet_200px.png)](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/digital-ocean-one-click.html#hasura-graphql-engine-digitalocean-one-click-app)
+  [![Deploy to DigitalOcean](https://graphql-engine-cdn.hasura.io/img/create_hasura_droplet_200px.png)](https://cloud.digitalocean.com/droplets/new?image=hasura-18-04&utm_source=hasura&utm_campaign=readme)
 
-* **Azure Container Instances**
+* [**Azure Container Instances**](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/azure-container-instances-postgres.html)
 
-  [![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/azure-container-instances-postgres.html)
+  [![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3a%2f%2fraw.githubusercontent.com%2fhasura%2fgraphql-engine%2fmaster%2finstall-manifests%2fazure-container-with-pg%2fazuredeploy.json)
 
 ### Other deployment methods
 

--- a/README.md
+++ b/README.md
@@ -78,15 +78,19 @@ The fastest way to try Hasura out is via Heroku.
 
    Create a table and instantly run your first query. Follow this [simple guide](https://docs.hasura.io/1.0/graphql/manual/getting-started/first-graphql-query.html).
 
-### Other deployment methods
+### Other one-click deployment options
 
 Check out the instructions for the following one-click deployment options:
 
-[![Deploy to DigitalOcean](https://graphql-engine-cdn.hasura.io/img/create_hasura_droplet_200px.png)](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/digital-ocean-one-click.html#hasura-graphql-engine-digitalocean-one-click-app)
+* **DigitalOcean**
 
-<img src="https://graphql-engine-cdn.hasura.io/img/create_hasura_droplet.png" width="150">
+  [![Deploy to DigitalOcean](https://graphql-engine-cdn.hasura.io/img/create_hasura_droplet_200px.png)](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/digital-ocean-one-click.html#hasura-graphql-engine-digitalocean-one-click-app)
 
-[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/azure-container-instances-postgres.html)
+* **Azure Container Instances**
+
+  [![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/azure-container-instances-postgres.html)
+
+### Other deployment methods
 
 For Docker-based deployment and advanced configuration options, see [deployment
 guides](https://docs.hasura.io/1.0/graphql/manual/getting-started/index.html) or

--- a/README.md
+++ b/README.md
@@ -87,14 +87,6 @@ Check out the instructions for the following one-click deployment options:
 | DigitalOcean | [![Deploy to DigitalOcean](https://graphql-engine-cdn.hasura.io/img/create_hasura_droplet_200px.png)](https://cloud.digitalocean.com/droplets/new?image=hasura-18-04&utm_source=hasura&utm_campaign=readme) | [docs](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/digital-ocean-one-click.html#hasura-graphql-engine-digitalocean-one-click-app) |
 | Azure | [![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3a%2f%2fraw.githubusercontent.com%2fhasura%2fgraphql-engine%2fmaster%2finstall-manifests%2fazure-container-with-pg%2fazuredeploy.json) | [docs](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/azure-container-instances-postgres.html) |
 
-* [**DigitalOcean**](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/digital-ocean-one-click.html#hasura-graphql-engine-digitalocean-one-click-app)
-
-  [![Deploy to DigitalOcean](https://graphql-engine-cdn.hasura.io/img/create_hasura_droplet_200px.png)](https://cloud.digitalocean.com/droplets/new?image=hasura-18-04&utm_source=hasura&utm_campaign=readme)
-
-* [**Azure**](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/azure-container-instances-postgres.html)
-
-  [![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3a%2f%2fraw.githubusercontent.com%2fhasura%2fgraphql-engine%2fmaster%2finstall-manifests%2fazure-container-with-pg%2fazuredeploy.json)
-
 ### Other deployment methods
 
 For Docker-based deployment and advanced configuration options, see [deployment

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ The fastest way to try Hasura out is via Heroku.
 
 Check out the instructions for the following one-click deployment options:
 
-[![Deploy to DigitalOcean](https://graphql-engine-cdn.hasura.io/img/create_hasura_droplet.png)](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/digital-ocean-one-click.html#hasura-graphql-engine-digitalocean-one-click-app)
+[![Deploy to DigitalOcean](https://graphql-engine-cdn.hasura.io/img/create_hasura_droplet_200px.png)](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/digital-ocean-one-click.html#hasura-graphql-engine-digitalocean-one-click-app)
+
+<img src="https://graphql-engine-cdn.hasura.io/img/create_hasura_droplet.png" width="150">
 
 [![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/azure-container-instances-postgres.html)
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Check out the instructions for the following one-click deployment options:
 
 | **Infra provider** | **One-click link** | **Additional information** |
 |:------------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------------------------------------------------------------------------------------------:|
-| DigitalOcean | [![Deploy to DigitalOcean](https://graphql-engine-cdn.hasura.io/img/create_hasura_droplet_200px.png)](https://cloud.digitalocean.com/droplets/new?image=hasura-18-04&utm_source=hasura&utm_campaign=readme) | [docs](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/digital-ocean-one-click.html#hasura-graphql-engine-digitalocean-one-click-app) |
+| DigitalOcean | [![Deploy to DigitalOcean](https://graphql-engine-cdn.hasura.io/img/create_hasura_droplet_200px.png)](https://marketplace.digitalocean.com/apps/hasura?action=deploy&refcode=c4d9092d2c48&utm_source=hasura&utm_campaign=readme) | [docs](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/digital-ocean-one-click.html#hasura-graphql-engine-digitalocean-one-click-app) |
 | Azure | [![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3a%2f%2fraw.githubusercontent.com%2fhasura%2fgraphql-engine%2fmaster%2finstall-manifests%2fazure-container-with-pg%2fazuredeploy.json) | [docs](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/azure-container-instances-postgres.html) |
 
 ### Other deployment methods

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ The fastest way to try Hasura out is via Heroku.
 
 ### Other deployment methods
 
+Check out the instructions for the following one-click deployment options:
+
+[![Deploy to DigitalOcean](https://graphql-engine-cdn.hasura.io/img/create_hasura_droplet.png)](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/digital-ocean-one-click.html#hasura-graphql-engine-digitalocean-one-click-app)
+
+[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/azure-container-instances-postgres.html)
+
 For Docker-based deployment and advanced configuration options, see [deployment
 guides](https://docs.hasura.io/1.0/graphql/manual/getting-started/index.html) or
 [install manifests](install-manifests).

--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ The fastest way to try Hasura out is via Heroku.
 
 Check out the instructions for the following one-click deployment options:
 
+| **Infra provider** | **One-click link** | **Additional information** |
+|:------------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------------------------------------------------------------------------------------------:|
+| DigitalOcean | [![Deploy to DigitalOcean](https://graphql-engine-cdn.hasura.io/img/create_hasura_droplet_200px.png)](https://cloud.digitalocean.com/droplets/new?image=hasura-18-04&utm_source=hasura&utm_campaign=readme) | [docs](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/digital-ocean-one-click.html#hasura-graphql-engine-digitalocean-one-click-app) |
+| Azure | [![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3a%2f%2fraw.githubusercontent.com%2fhasura%2fgraphql-engine%2fmaster%2finstall-manifests%2fazure-container-with-pg%2fazuredeploy.json) | [docs](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/azure-container-instances-postgres.html) |
+
 * [**DigitalOcean**](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/digital-ocean-one-click.html#hasura-graphql-engine-digitalocean-one-click-app)
 
   [![Deploy to DigitalOcean](https://graphql-engine-cdn.hasura.io/img/create_hasura_droplet_200px.png)](https://cloud.digitalocean.com/droplets/new?image=hasura-18-04&utm_source=hasura&utm_campaign=readme)

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Check out the instructions for the following one-click deployment options:
 
   [![Deploy to DigitalOcean](https://graphql-engine-cdn.hasura.io/img/create_hasura_droplet_200px.png)](https://cloud.digitalocean.com/droplets/new?image=hasura-18-04&utm_source=hasura&utm_campaign=readme)
 
-* [**Azure Container Instances**](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/azure-container-instances-postgres.html)
+* [**Azure**](https://docs.hasura.io/1.0/graphql/manual/guides/deployment/azure-container-instances-postgres.html)
 
   [![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3a%2f%2fraw.githubusercontent.com%2fhasura%2fgraphql-engine%2fmaster%2finstall-manifests%2fazure-container-with-pg%2fazuredeploy.json)
 


### PR DESCRIPTION
### Description
Add one-click buttons to the repo's README.

### Affected components 
<!-- Remove non-affected components from the list -->

- Community Content


### Solution and Design
Added the buttons in a table, letting the Heroku one-click remain as it is because it's the fastest way to get started and doesn't need a credit card.