### PR TITLE
adds a check to see if the jobs should be run or not (close #1161)

### DIFF
--- a/.ciignore
+++ b/.ciignore
@@ -8,4 +8,3 @@ install-manifests/*
 .ciignore
 .gitignore
 .github/*
-.circleci/*

--- a/.ciignore
+++ b/.ciignore
@@ -8,3 +8,4 @@ install-manifests/*
 .ciignore
 .gitignore
 .github/*
+.circleci/*

--- a/.circleci/ciignore.sh
+++ b/.circleci/ciignore.sh
@@ -11,7 +11,7 @@ set -eo pipefail
 ROOT="$(readlink -f ${BASH_SOURCE[0]%/*}/../)"
 
 # make build directory
-mkdir -p /build
+mkdir -p /build/ciignore
 
 # always build tagged builds
 if [[ ! -z "$CIRCLE_TAG" ]]; then
@@ -73,7 +73,7 @@ if [[ ${#changes[@]} -gt 0 ]]; then
 fi
 
 echo "Only ignored files are present in commits, build is not required, write the skip_job file"
-echo "true" > /build/skip_job.txt
-echo "/build skip_job.txt written"
-cat /build/skip_job.txt
+echo "true" > /build/ciignore/skip_job.txt
+echo "/build/ciignore/skip_job.txt written"
+cat /build/ciignore/skip_job.txt
 exit

--- a/.circleci/ciignore.sh
+++ b/.circleci/ciignore.sh
@@ -74,6 +74,4 @@ fi
 
 echo "Only ignored files are present in commits, build is not required, write the skip_job file"
 echo "true" > /build/ciignore/skip_job.txt
-echo "/build/ciignore/skip_job.txt written"
-cat /build/ciignore/skip_job.txt
 exit

--- a/.circleci/ciignore.sh
+++ b/.circleci/ciignore.sh
@@ -13,11 +13,6 @@ ROOT="$(readlink -f ${BASH_SOURCE[0]%/*}/../)"
 # make build directory
 mkdir -p /build
 
-write_skip_job_file_and_exit() {
-    echo "true" > /build/skip_job.txt
-    exit
-}
-
 # always build tagged builds
 if [[ ! -z "$CIRCLE_TAG" ]]; then
     echo "Skipping check for tags"
@@ -77,5 +72,8 @@ if [[ ${#changes[@]} -gt 0 ]]; then
 	  exit
 fi
 
-echo "Only ignored files are present in commits, no need to build, write the skip_job file"
-write_skip_job_file_and_exit
+echo "Only ignored files are present in commits, build is not required, write the skip_job file"
+echo "true" > /build/skip_job.txt
+echo "/build skip_job.txt written"
+cat /build/skip_job.txt
+exit

--- a/.circleci/ciignore.sh
+++ b/.circleci/ciignore.sh
@@ -10,8 +10,13 @@
 set -eo pipefail
 ROOT="$(readlink -f ${BASH_SOURCE[0]%/*}/../)"
 
-# succeed until the script is fixed: https://github.com/hasura/graphql-engine/issues/1161
-exit
+# make build directory
+mkdir -p /build
+
+write_skip_job_file_and_exit() {
+    echo "true" > /build/skip_job.txt
+    exit
+}
 
 # always build tagged builds
 if [[ ! -z "$CIRCLE_TAG" ]]; then
@@ -19,11 +24,11 @@ if [[ ! -z "$CIRCLE_TAG" ]]; then
     exit
 fi
 
-# always build default branch
-if [[ "$CIRCLE_BRANCH" == "master" ]]; then
-    echo "Skipping check for master branch"
-    exit
-fi
+#  # always build default branch
+#  if [[ "$CIRCLE_BRANCH" == "master" ]]; then
+#      echo "Skipping check for master branch"
+#      exit
+#  fi
 
 if [[ ! -a "$ROOT/.ciignore" ]]; then
     echo "Skipping check since .ciignore is not found"
@@ -31,7 +36,7 @@ if [[ ! -a "$ROOT/.ciignore" ]]; then
 fi
 
 # Check CIRCLE_COMPARE_URL first and if its not set, check for diff with master.
-    
+
 if [[ ! -z "$CIRCLE_COMPARE_URL" ]]; then
     # CIRCLE_COMPARE_URL is not empty, use it to get the diff
     if [[ $CIRCLE_COMPARE_URL = *"commit"* ]]; then
@@ -72,5 +77,5 @@ if [[ ${#changes[@]} -gt 0 ]]; then
 	  exit
 fi
 
-echo "Only ignored files are present in commits, no need to build, fail the job"
-exit 1
+echo "Only ignored files are present in commits, no need to build, write the skip_job file"
+write_skip_job_file_and_exit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,8 @@
 refs:
   skip_job_on_ciignore: &skip_job_on_ciignore
     run: |
-      if [ -f /build/skip_job.txt ]; then
-        echo "halting job due to /build/skip_job.txt"
-        circleci-agent step halt
-      fi
+      echo "halting job due to /build/skip_job.txt"
+      circleci-agent step halt
   wait_for_postgres: &wait_for_postgres
     run:
       name: waiting for postgres to be ready

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,11 @@
 # anchor refs to be used elsewhere
 refs:
+  skip_job_on_ciignore: &skip_job_on_ciignore
+    run: |
+      if [ -f /build/skip_job.txt ]; then
+        echo "halting job due to /build/skip_job.txt"
+        circleci-agent step halt
+      fi
   wait_for_postgres: &wait_for_postgres
     run:
       name: waiting for postgres to be ready
@@ -65,9 +71,10 @@ refs:
   test_server: &test_server
     working_directory: ~/graphql-engine
     steps:
-    - checkout
     - attach_workspace:
         at: /build
+    - *skip_job_on_ciignore
+    - checkout
     - *wait_for_postgres
     - run:
         name: test the server
@@ -79,6 +86,9 @@ refs:
   pytest_server: &pytest_server
     working_directory: ~/graphql-engine
     steps:
+    - attach_workspace:
+        at: /build
+    - *skip_job_on_ciignore
     - checkout
     - restore_cache:
         keys:
@@ -86,8 +96,6 @@ refs:
     - restore_cache:
         keys:
         - server-deps-cache-{{ checksum "server/graphql-engine.cabal" }}-{{ checksum "server/stack.yaml" }}
-    - attach_workspace:
-        at: /build
     - *wait_for_postgres
     - run:
         name: Run Python tests
@@ -112,6 +120,8 @@ jobs:
   # check if this should be built or not, fails if
   # changes only contains files in .ciignore
   check_build_worthiness:
+    - attach_workspace:
+        at: /build
     docker:
     - image: hasura/graphql-engine-cli-builder:v0.3
     working_directory: ~/graphql-engine
@@ -127,6 +137,9 @@ jobs:
     - image: hasura/graphql-engine-server-builder:v0.3
     working_directory: ~/graphql-engine
     steps:
+    - attach_workspace:
+        at: /build
+    - *skip_job_on_ciignore
     - checkout
     - *setup_remote_docker
     - restore_cache:
@@ -223,9 +236,10 @@ jobs:
         POSTGRES_DB: gql_test
     working_directory: /go/src/github.com/hasura/graphql-engine
     steps:
-    - checkout
     - attach_workspace:
         at: /build
+    - *skip_job_on_ciignore
+    - checkout
     - restore_cache:
         keys:
         - cli-vendor-{{ checksum "cli/Gopkg.toml" }}-{{ checksum "cli/Gopkg.lock" }}
@@ -255,9 +269,10 @@ jobs:
         POSTGRES_DB: gql_test
     working_directory: /go/src/github.com/hasura/graphql-engine
     steps:
-    - checkout
     - attach_workspace:
         at: /build
+    - *skip_job_on_ciignore
+    - checkout
     - restore_cache:
         keys:
         - cli-vendor-{{ checksum "cli/Gopkg.toml" }}-{{ checksum "cli/Gopkg.lock" }}
@@ -301,9 +316,10 @@ jobs:
     working_directory: ~/graphql-engine
     parallelism: 4
     steps:
-    - checkout
     - attach_workspace:
         at: /build
+    - *skip_job_on_ciignore
+    - checkout
     - restore_cache:
         key:
           console-npm-cache-{{ checksum "console/package.json" }}-{{ checksum "console/package-lock.json" }}
@@ -348,9 +364,10 @@ jobs:
         POSTGRES_DB: gql_test
     working_directory: ~/graphql-engine
     steps:
-    - checkout
     - attach_workspace:
         at: /build
+    - *skip_job_on_ciignore
+    - checkout
     - run:
         name: upgrade_test 
         command: .circleci/server-upgrade/run.sh
@@ -363,10 +380,11 @@ jobs:
     - image: hasura/graphql-engine-deployer:v0.3
     working_directory: ~/graphql-engine
     steps:
-    - *setup_remote_docker
-    - checkout
     - attach_workspace:
         at: /build
+    - *skip_job_on_ciignore
+    - *setup_remote_docker
+    - checkout
     - run:
         name: deploy
         command: .circleci/deploy.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,9 @@
 refs:
   skip_job_on_ciignore: &skip_job_on_ciignore
     run: |
-      ls -l /build
-      echo "halting job due to /build/skip_job.txt"
+      ls -l /build/ciignore
+      cat /build/ciignore/skip_job.txt
+      echo "halting job due to /build/ciignore/skip_job.txt"
       circleci-agent step halt
   wait_for_postgres: &wait_for_postgres
     run:
@@ -129,6 +130,10 @@ jobs:
     - run:
         name: check build worthiness
         command: .circleci/ciignore.sh
+    - persist_to_workspace:
+        root: /build
+        paths:
+        - ciignore  
 
   # build the server binary, and package into docker image
   build_server:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,12 +120,12 @@ jobs:
   # check if this should be built or not, fails if
   # changes only contains files in .ciignore
   check_build_worthiness:
-    - attach_workspace:
-        at: /build
     docker:
     - image: hasura/graphql-engine-cli-builder:v0.3
     working_directory: ~/graphql-engine
     steps:
+    - attach_workspace:
+        at: /build
     - checkout
     - run:
         name: check build worthiness

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,15 @@
 # anchor refs to be used elsewhere
 refs:
   skip_job_on_ciignore: &skip_job_on_ciignore
-    run: |
-      ls -l /build/ciignore
-      cat /build/ciignore/skip_job.txt
-      echo "halting job due to /build/ciignore/skip_job.txt"
-      circleci-agent step halt
+    run:
+      name: checking if job should be terminated or not
+      command: |
+        if [ -f /build/ciignore/skip_job.txt ]; then
+          echo "halting job due to /build/ciignore/skip_job.txt"
+          circleci-agent step halt
+        else
+          echo "no skip_job file present, full steam ahead"
+        fi
   wait_for_postgres: &wait_for_postgres
     run:
       name: waiting for postgres to be ready

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@
 refs:
   skip_job_on_ciignore: &skip_job_on_ciignore
     run: |
+      ls -l /build
       echo "halting job due to /build/skip_job.txt"
       circleci-agent step halt
   wait_for_postgres: &wait_for_postgres

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -428,6 +428,8 @@ workflows:
         - test_server_upgrade
     - test_cli_with_last_release:
         <<: *filter_only_vtags
+        requires:
+        - check_build_worthiness
     - test_and_build_cli:
         <<: *filter_only_vtags
         requires:


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
CircleCI jobs are run for any PR that is submitted to the repo. This PR adds a check to decide whether the job should be run or not.

### Affected components 
<!-- Remove non-affected components from the list -->

- Build System

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#1161 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
Figured out that CircleCI has a way to gracefully terminate a job:
```
circleci-agent step halt
```

A `.ciignore` file is ran against all the changes in the PR to decide whether the PR should be built or not. If the answer comes out as `no`, a file is written at `/buid/skip_job.txt`. This is done in the `check_build_worthiness` step.

All further jobs, in the beginning, looks for this file and gracefully terminates the job if this file is present. The directory is passed down to the jobs as the workspace.

```yaml
  skip_job_on_ciignore: &skip_job_on_ciignore
    run: |
      if [ -f /build/skip_job.txt ]; then
        echo "halting job due to /build/skip_job.txt"
        circleci-agent step halt
      fi
```

ref: https://support.circleci.com/hc/en-us/articles/360015562253-Conditionally-end-a-running-job-gracefully

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Changes to docs or md files (those mentioned in `.ciignore` file) should result in immediate completion of all jobs.

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
There are some known issues on jobs that are run when PR is merged to master, need to address them after this PR is merged.