### PR TITLE
support ciignore for builds on master branch

### DIFF
--- a/.circleci/ciignore.sh
+++ b/.circleci/ciignore.sh
@@ -19,19 +19,12 @@ if [[ ! -z "$CIRCLE_TAG" ]]; then
     exit
 fi
 
-#  # always build default branch
-#  if [[ "$CIRCLE_BRANCH" == "master" ]]; then
-#      echo "Skipping check for master branch"
-#      exit
-#  fi
-
 if [[ ! -a "$ROOT/.ciignore" ]]; then
     echo "Skipping check since .ciignore is not found"
 	  exit # If .ciignore doesn't exists, just quit this script
 fi
 
-# Check CIRCLE_COMPARE_URL first and if its not set, check for diff with master.
-
+# get the diff
 if [[ ! -z "$CIRCLE_COMPARE_URL" ]]; then
     # CIRCLE_COMPARE_URL is not empty, use it to get the diff
     if [[ $CIRCLE_COMPARE_URL = *"commit"* ]]; then
@@ -41,8 +34,12 @@ if [[ ! -z "$CIRCLE_COMPARE_URL" ]]; then
     fi
     echo "Diff: $COMMIT_RANGE"
     changes="$(git diff $COMMIT_RANGE --name-only)"
+elif [[ "$CIRCLE_BRANCH" == "master" ]]; then
+    # CIRCLE_COMPARE_URL is not set, but branch is master, diff with last commit
+    echo "Diff: HEAD~1"
+    changes="$(git diff HEAD~1 --name-only)"
 else
-    # CIRCLE_COMPARE_URL is not set, diff with origin/master
+    # CIRCLE_COMPARE_URL is not set, branch is not master, diff with origin/master
     echo "Diff: origin/master..HEAD"
     changes="$(git diff-tree --no-commit-id --name-only -r origin/master..HEAD)"
 fi


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
As indicated in the PR #1705, the build will always skip merges to master. This PR fixes that by enforcing `ciignore` step on master branch builds too.

### Affected components 
<!-- Remove non-affected components from the list -->

- Build System

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#1705
### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
For master branch, the diff is taken as `HEAD~1` - always compared with the last commit.
### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
This PR, when merged, should not skip any steps.

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
None so far.
<!-- Feel free to delete these comment lines -->
