### PR TITLE
remove sql files from migrate create output (fix #1682)

### DIFF
--- a/cli/commands/migrate_create.go
+++ b/cli/commands/migrate_create.go
@@ -44,12 +44,11 @@ type migrateCreateOptions struct {
 func (o *migrateCreateOptions) run() error {
 	timestamp := getTime()
 	createOptions := mig.New(timestamp, o.name, o.EC.MigrationDir)
-	createOptions.IsCMD = true
 	err := createOptions.Create()
 	if err != nil {
 		return errors.Wrap(err, "error creating migration files")
 	}
-	o.EC.Logger.Infof("Migration files created with version %d_%s.[up|down].[yaml|sql]", timestamp, o.name)
+	o.EC.Logger.Infof("Migration files created with version %d_%s.[up|down].yaml", timestamp, o.name)
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
The motivation behind doing this to reduce the cognitive load on the user by presenting them with 1 YAML file for up and 1 YAML file for down.
### Affected components 
<!-- Remove non-affected components from the list -->

- CLI

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#1682 
### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
```hasura migrate create test```
The above command will create only up|down.yaml files.

<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
