### PR TITLE
pg permission docs: make hasura user owner of system schemas (fix #1697)

### DIFF
--- a/docs/graphql/manual/deployment/postgres-permissions.rst
+++ b/docs/graphql/manual/deployment/postgres-permissions.rst
@@ -38,9 +38,9 @@ Here's a sample SQL block that you can run on your database to create the right 
     CREATE SCHEMA IF NOT EXISTS hdb_catalog;
     CREATE SCHEMA IF NOT EXISTS hdb_views;
 
-    -- grant all privileges on system schemas
-    GRANT ALL PRIVILEGES ON SCHEMA hdb_catalog TO hasurauser;
-    GRANT ALL PRIVILEGES ON SCHEMA hdb_views TO hasurauser;
+    -- make the user an owner of system schemas
+    ALTER SCHEMA hdb_catalog OWNER TO hasurauser;
+    ALTER SCHEMA hdb_views OWNER TO hasurauser;
 
     -- grant select permissions on information_schema and pg_catalog. This is
     -- required for hasura to query list of available tables


### PR DESCRIPTION

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
There was a postgres permission issue in the docs. The hasura user needed to be owner of the system schemas (`hdb_catalog`, `hdb_views`), otherwise it won't be able to apply table schema changes during version upgrades.

### Affected components 
<!-- Remove non-affected components from the list -->
- Docs

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#1697 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->


### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
