### PR TITLE
remote schema subscriptions (fix #1599)

### DIFF
--- a/.circleci/test-server.sh
+++ b/.circleci/test-server.sh
@@ -133,6 +133,37 @@ HS_PID=""
 trap stop_services ERR
 trap stop_services INT
 
+# !!!! >>> TODO: put the test below regular tests
+# test remote schema graphql subscriptions
+
+echo -e "\n<########## TEST GRAPHQL-ENGINE WITH REMOTE SCHEMA SUBSCRIPTIONS ########>\n"
+
+HASURA_RM_SUBS_TEST_DB='postgres://gql_test:@localhost:5432/rem_hge_test'
+echo "Installing psql"
+apt-get update && apt-get install -y postgresql-client
+psql "$HASURA_GRAPHQL_DATABASE_URL" -c "create database rem_hge_test;"
+
+# start another hasura instance as a remote graphql server for subscriptions
+"$GRAPHQL_ENGINE" --database-url "$HASURA_RM_SUBS_TEST_DB" serve \
+                  --server-port 8081 --server-host 0.0.0.0 \
+                  >> "$OUTPUT_FOLDER/remote-graphql-engine.log" 2>&1 & RM_PID=$!
+
+wait_for_port 8081
+
+"$GRAPHQL_ENGINE" serve >> "$OUTPUT_FOLDER/graphql-engine.log" 2>&1 & PID=$!
+
+wait_for_port 8080
+
+pytest -vv --hge-url="$HGE_URL" --pg-url="$HASURA_GRAPHQL_DATABASE_URL" --test-remote-subs="http://localhost:8081" test_remote_subscriptions.py
+
+kill -INT $PID
+kill -INT $RM_PID
+psql "$HASURA_GRAPHQL_DATABASE_URL" -c "drop database rem_hge_test;"
+sleep 4
+combine_hpc_reports
+unset HASURA_RM_SUBS_TEST_DB
+
+
 echo -e "\n<########## TEST GRAPHQL-ENGINE WITHOUT ADMIN SECRET ###########################################>\n"
 
 "$GRAPHQL_ENGINE" serve > "$OUTPUT_FOLDER/graphql-engine.log" & PID=$!
@@ -355,8 +386,8 @@ if [ "$RUN_WEBHOOK_TESTS" == "true" ] ; then
 
 	kill $WH_PID
 
-
 fi
+
 
 # horizontal scale test
 unset HASURA_GRAPHQL_AUTH_HOOK

--- a/docs/graphql/manual/remote-schemas/index.rst
+++ b/docs/graphql/manual/remote-schemas/index.rst
@@ -126,7 +126,6 @@ Current limitations
 
 - Nodes from different GraphQL servers cannot be used in the same query/mutation. All top-level fields have to be
   from the same GraphQL server.
-- Subscriptions on remote GraphQL servers are not supported.
 
 These limitations will be addressed in upcoming versions.
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -12,7 +12,11 @@ build_output := /build/_server_output
 
 dev: src-lib src-exec src-rsr
 	stack build --fast
-	stack exec graphql-engine -- --database-url postgres://postgres:@localhost:5432/hge serve --enable-console
+	stack exec graphql-engine -- \
+		--database-url postgres://postgres:@localhost:5432/hge \
+		serve \
+		--enable-telemetry false \
+		--enable-console
 
 image: $(project).cabal
 	docker build -t "$(registry)/$(project):$(version)" \

--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -195,7 +195,9 @@ library
                      , Hasura.GraphQL.Transport.HTTP.Protocol
                      , Hasura.GraphQL.Transport.HTTP
                      , Hasura.GraphQL.Transport.WebSocket.Protocol
+                     , Hasura.GraphQL.Transport.WebSocket.Connection
                      , Hasura.GraphQL.Transport.WebSocket.Server
+                     , Hasura.GraphQL.Transport.WebSocket.Client
                      , Hasura.GraphQL.Transport.WebSocket
                      , Hasura.GraphQL.Schema
                      , Hasura.GraphQL.Utils

--- a/server/src-lib/Hasura/GraphQL/Transport/WebSocket/Client.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/WebSocket/Client.hs
@@ -1,0 +1,223 @@
+module Hasura.GraphQL.Transport.WebSocket.Client
+  ( runGqlClient
+  , WebsocketPayload (..)
+  , sendStopMsg
+  , updateState
+  , stopRemote
+  , closeRemote
+  )
+  where
+
+import           Control.Concurrent                            (forkIO,
+                                                                killThread)
+import           Control.Exception                             (SomeException,
+                                                                try)
+
+import           Hasura.GraphQL.Transport.WebSocket.Connection
+import           Hasura.GraphQL.Transport.WebSocket.Protocol   (OperationId (..))
+import           Hasura.Prelude
+import           Hasura.RQL.Types
+
+--import qualified Control.Concurrent.Async                      as A
+import qualified Data.Aeson                                    as J
+import qualified Data.Aeson.Casing                             as J
+import qualified Data.Aeson.TH                                 as J
+import qualified Data.ByteString.Lazy                          as BL
+import qualified Data.HashMap.Strict                           as Map
+import qualified Data.IORef                                    as IORef
+import qualified Data.Text                                     as T
+import qualified Network.URI                                   as URI
+import qualified Network.WebSockets                            as WS
+
+import qualified Hasura.GraphQL.Transport.WebSocket.Server     as WS
+import qualified Hasura.Logging                                as L
+
+
+-- | TODO:
+-- | The following ADT is required so that we can parse the incoming websocket
+-- | frame, and only pick the payload, for remote schema queries.
+-- | Ideally we should use `tartMsg` from Websocket.Protocol, but as
+-- | `GraphQLRequest` doesn't have a ToJSON instance we are using our own type to
+-- | get only the payload
+data WebsocketPayload
+  = WebsocketPayload
+  { _wpId      :: !Text
+  , _wpType    :: !Text
+  , _wpPayload :: !J.Value
+  } deriving (Show, Eq)
+$(J.deriveJSON (J.aesonDrop 3 J.snakeCase) ''WebsocketPayload)
+
+
+sendInit :: WS.Connection -> WebsocketPayload -> IO ()
+sendInit conn payload =
+  WS.sendTextData conn $ J.encode $
+    J.object [ "type" J..= ("connection_init" :: Text)
+             , "payload" J..= _wpPayload payload
+             ]
+
+sendStopMsg :: WS.Connection -> OperationId -> IO ()
+sendStopMsg conn opId =
+  WS.sendTextData conn $ J.encode $
+    J.object [ "type" J..= ("stop" :: Text)
+             , "id" J..= unOperationId opId
+             ]
+
+
+mkGraphqlProxy
+  :: WS.WSConn a
+  -> IORef.IORef WSConnState
+  -> RemoteSchemaName
+  -> WebsocketPayload -- the start msg
+  -> WS.ClientApp ()
+mkGraphqlProxy wsconn stRef rn payload destConn = do
+  -- setup initial connection protocol
+  setupInitialGraphqlProto destConn
+  res <- getWsProxyState stRef rn
+  -- if corresponding state is not found, are we silently ignoring it?
+  -- the state won't have the remote's websocket conn. which is actually problematic
+  onJust res $ \curState -> do
+    let newState = curState{ _wpsRemoteConn = Just destConn }
+    updateState stRef rn newState
+
+  -- setting up the proxy from remote to hasura
+  proxy destConn srcConn
+  where
+    srcConn = WS._wcConnRaw wsconn
+    proxy recvConn sendConn =
+      forever $ do
+        msg <- WS.receiveData recvConn
+        sendMsg sendConn msg
+
+    sendMsg :: WS.Connection -> BL.ByteString -> IO ()
+    sendMsg = WS.sendTextData
+
+    -- send an init message with the same payload recieved, and then send the
+    -- payload as it is (assuming this is the start msg)
+    setupInitialGraphqlProto conn = do
+      sendInit conn payload
+      WS.sendTextData conn $ J.encode payload
+
+
+runGqlClient'
+  :: L.Logger
+  -> URI.URI
+  -> WS.WSConn a
+  -> IORef.IORef WSConnState
+  -> RemoteSchemaName
+  -> OperationId
+  -> WebsocketPayload
+  -> ExceptT QErr IO ()
+runGqlClient' (L.Logger logger) url wsConn stRef rn opId payload = do
+  host <- maybe (throw500 "empty hostname for websocket conn") return mHost
+  let gqClient = mkGraphqlProxy wsConn stRef rn payload
+
+  thrId <- liftIO $ forkIO $ do
+    res <- try $ WS.runClient host port path gqClient
+    onLeft res $ \e -> do
+      let err = T.pack $ show (e :: SomeException)
+          opDet = ODQueryErr $ err500 Unexpected err
+      logger $ WSLog wsId Nothing (EOperation opId Nothing opDet)
+        (Just "exception from runClient thread")
+
+  let newState = WebsocketProxyState thrId Nothing [(wsId, opId)]
+  liftIO $ updateState stRef rn newState
+
+  where
+    mHost = (URI.uriUserInfo <$> uriAuth) <> (URI.uriRegName <$> uriAuth)
+    port = read $ maybe "80" (drop 1 . URI.uriPort) uriAuth
+    path = URI.uriPath url
+    uriAuth = URI.uriAuthority url
+    wsId = WS._wcConnId wsConn
+
+
+runGqlClient
+  :: L.Logger
+  -> URI.URI
+  -> WS.WSConn a
+  -> IORef.IORef WSConnState
+  -> RemoteSchemaName
+  -> OperationId
+  -> WebsocketPayload
+  -> ExceptT QErr IO ()
+runGqlClient logger url wsConn stRef rn opId payload = do
+  mState <- getWsProxyState stRef rn
+  case mState of
+    Nothing ->
+      runGqlClient' logger url wsConn stRef rn opId payload
+    Just st -> do
+      -- send init message and the raw message on the existing conn
+      let wsconn   = _wpsRemoteConn st
+          opids    = _wpsOperations st
+          wsId     = WS._wcConnId wsConn
+          newState = st { _wpsOperations = opids ++ [(wsId, opId)] }
+      conn <- maybe (throwError wsConnErr) return wsconn
+      liftIO $ do
+        updateState stRef rn newState
+        sendInit conn payload
+        WS.sendTextData conn $ J.encode payload
+
+updateState
+  :: IORef.IORef WSConnState
+  -> RemoteSchemaName
+  -> WebsocketProxyState
+  -> IO ()
+updateState stRef rn wsProxyState = do
+  -- this updates the IORef only on start msg, should we be doing this with a
+  -- lock?
+  st <- IORef.readIORef stRef
+  let rmConnState = getStateData st
+  onJust rmConnState $ \connState -> do
+    let rmConnState' = Map.insert rn wsProxyState $ _cisRemoteConn connState
+    let newSt = connState {_cisRemoteConn = rmConnState'}
+    IORef.writeIORef stRef (CSInitialised newSt)
+
+getWsProxyState
+  :: (MonadIO m)
+  => IORef.IORef WSConnState
+  -> RemoteSchemaName
+  -> m (Maybe WebsocketProxyState)
+getWsProxyState ref rn = do
+  st <- liftIO $ IORef.readIORef ref
+  let mCurState = getStateData st
+  case mCurState of
+    Nothing                            -> return Nothing
+    Just (ConnInitState _ _ rmConnMap) -> return $ Map.lookup rn rmConnMap
+
+
+-- given a websocket id (WSId), close connections to that remote from
+-- WSConnState
+-- and updates state :: modifies IORef
+closeRemote :: L.Logger -> IORef.IORef WSConnState -> WS.WSId -> IO ()
+closeRemote (L.Logger logger) stRef wsId = do
+  logger $ L.debugT $ "closing connections belonging to: " <>
+    T.pack (show wsId)
+  connState <- liftIO $ IORef.readIORef stRef
+  let stData = getStateData connState
+  onJust stData $ \ciSt@(ConnInitState _ _ connMap) ->
+    onJust (findWebsocketId connMap wsId) $ \(rn, wst) -> do
+      let (WebsocketProxyState thrId _ _) = wst
+      --A.cancel rmOp
+      liftIO $ killThread thrId
+      let newConnMap = Map.delete rn connMap
+          newState = CSInitialised $ ciSt {_cisRemoteConn = newConnMap }
+      IORef.writeIORef stRef newState
+
+
+stopRemote
+  :: L.Logger -> WebsocketProxyState -> OperationId
+  -> ExceptT QErr IO WebsocketProxyState
+stopRemote (L.Logger logger) wsState aOpId = do
+  liftIO $ logger $ L.debugT "stopping the remote.."
+  let (WebsocketProxyState thrId wsConn ops) = wsState
+  remoteConn <- maybe (throwError wsConnErr) return wsConn
+  liftIO $ sendStopMsg remoteConn aOpId
+  -- remaing operations
+  let remOps = filter (\(_, opId) -> opId /= aOpId) ops
+  when (null remOps) $ do
+    -- close the client connection to remote
+    liftIO $ logger $ L.debugT "no remaining ops; closing remote"
+    liftIO $ killThread thrId
+  return $ wsState { _wpsOperations = remOps }
+
+wsConnErr :: QErr
+wsConnErr = err500 Unexpected "remote websocket conn not found in state"

--- a/server/src-lib/Hasura/GraphQL/Transport/WebSocket/Connection.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/WebSocket/Connection.hs
@@ -1,0 +1,129 @@
+{-
+  This module has WebSocket Connection related state and data types
+-}
+
+module Hasura.GraphQL.Transport.WebSocket.Connection where
+
+import           Control.Concurrent                          (ThreadId)
+
+import           Hasura.GraphQL.Transport.HTTP.Protocol      (OperationName)
+import           Hasura.GraphQL.Transport.WebSocket.Protocol (ConnErrMsg,
+                                                              OperationId)
+import           Hasura.GraphQL.Transport.WebSocket.Server   (WSId)
+import           Hasura.Prelude
+import           Hasura.RQL.Types
+
+
+--import qualified Control.Concurrent.Async                    as A
+import qualified Data.Aeson                                  as J
+import qualified Data.Aeson.Casing                           as J
+import qualified Data.Aeson.TH                               as J
+import qualified Data.HashMap.Strict                         as Map
+import qualified Hasura.Logging                              as L
+import qualified Network.HTTP.Types                          as HTTP
+import qualified Network.WebSockets                          as WS
+
+
+-- uniquely identifies an operation
+type GOperationId = (WSId, OperationId)
+
+data ConnInitState
+  = ConnInitState
+  { _cisUserInfo   :: !UserInfo
+  -- headers from the client (in conn params) to forward to the remote schema
+  , _cisHeaders    :: ![HTTP.Header]
+  , _cisRemoteConn :: !RemoteConnState
+  } deriving (Show)
+
+newtype WsHeaders
+  = WsHeaders { unWsHeaders :: [HTTP.Header] }
+  deriving (Show, Eq)
+
+data WSConnState
+  -- headers from the client for websockets
+  = CSNotInitialised !WsHeaders
+  | CSInitError Text
+  | CSInitialised ConnInitState
+  deriving (Show)
+
+type RemoteConnState
+  = Map.HashMap RemoteSchemaName WebsocketProxyState
+
+type WebsocketProxyState = WebsocketProxyStateG ()
+
+data WebsocketProxyStateG a
+  = WebsocketProxyState
+  { _wpsRunClientThread :: !ThreadId
+  , _wpsRemoteConn      :: !(Maybe WS.Connection)
+  , _wpsOperations      :: ![GOperationId]
+  }
+
+instance Show (WebsocketProxyStateG a) where
+  show (WebsocketProxyState thrdId wscon ops) =
+    "WebsocketProxyState { "
+    ++ "_wpsRunClientThread = " ++ show thrdId
+    ++ ", _wpsRemoteConn = " ++ wsconD
+    ++ ", _wpsOperations = " ++ show ops
+    ++ " }"
+    where
+      wsconD = maybe "Nothing" (const "Just <WebsocketConn>") wscon
+
+findRemoteName :: RemoteConnState -> RemoteSchemaName -> Maybe WebsocketProxyState
+findRemoteName connMap rn = snd <$> find ((==) rn . fst) (Map.toList connMap)
+
+findOperationId
+  :: RemoteConnState -> GOperationId
+  -> Maybe (RemoteSchemaName, WebsocketProxyState)
+findOperationId connMap opId =
+  find (elem opId . _wpsOperations . snd) $ Map.toList connMap
+
+findWebsocketId
+  :: RemoteConnState -> WSId
+  -> Maybe (RemoteSchemaName, WebsocketProxyState)
+findWebsocketId connMap wsId =
+  find (elem wsId . map fst . _wpsOperations . snd) $ Map.toList connMap
+
+getStateData :: WSConnState -> Maybe ConnInitState
+getStateData = \case
+  CSInitialised d -> Just d
+  _               -> Nothing
+
+
+data OpDetail
+  = ODStarted
+  | ODProtoErr !Text
+  | ODQueryErr !QErr
+  | ODCompleted
+  | ODStopped
+  deriving (Show, Eq)
+$(J.deriveToJSON
+  J.defaultOptions { J.constructorTagModifier = J.snakeCase . drop 2
+                   , J.sumEncoding = J.TaggedObject "type" "detail"
+                   }
+  ''OpDetail)
+
+data WSEvent
+  = EAccepted
+  | ERejected !QErr
+  | EConnErr !ConnErrMsg
+  | EOperation !OperationId !(Maybe OperationName) !OpDetail
+  | EClosed
+  deriving (Show, Eq)
+$(J.deriveToJSON
+  J.defaultOptions { J.constructorTagModifier = J.snakeCase . drop 1
+                   , J.sumEncoding = J.TaggedObject "type" "detail"
+                   }
+  ''WSEvent)
+
+data WSLog
+  = WSLog
+  { _wslWebsocketId :: !WSId
+  , _wslUser        :: !(Maybe UserVars)
+  , _wslEvent       :: !WSEvent
+  , _wslMsg         :: !(Maybe Text)
+  } deriving (Show, Eq)
+$(J.deriveToJSON (J.aesonDrop 4 J.snakeCase) ''WSLog)
+
+instance L.ToEngineLog WSLog where
+  toEngineLog wsLog =
+    (L.LevelInfo, "ws-handler", J.toJSON wsLog)

--- a/server/src-lib/Hasura/GraphQL/Transport/WebSocket/Server.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/WebSocket/Server.hs
@@ -3,7 +3,7 @@
 module Hasura.GraphQL.Transport.WebSocket.Server
   ( WSId(..)
 
-  , WSConn
+  , WSConn(..)
   , getData
   , getWSId
   , closeConn

--- a/server/tests-py/conftest.py
+++ b/server/tests-py/conftest.py
@@ -34,6 +34,13 @@ def pytest_addoption(parser):
     )
 
     parser.addoption(
+        "--test-remote-subs",
+        metavar="<url>",
+        required=False,
+        help="Run testcases for remote schema subscriptions"
+    )
+
+    parser.addoption(
         "--test-ws-init-cookie",
         metavar="read|noread",
         required=False,
@@ -68,6 +75,7 @@ def hge_ctx(request):
     webhook_insecure = request.config.getoption('--test-webhook-insecure')
     hge_jwt_key_file = request.config.getoption('--hge-jwt-key-file')
     hge_jwt_conf = request.config.getoption('--hge-jwt-conf')
+    test_remote = request.config.getoption('--test-remote-subs')
     ws_read_cookie = request.config.getoption('--test-ws-init-cookie')
     metadata_disabled = request.config.getoption('--test-metadata-disabled')
     hge_scale_url = request.config.getoption('--test-hge-scale-url')
@@ -82,6 +90,7 @@ def hge_ctx(request):
             hge_jwt_conf=hge_jwt_conf,
             ws_read_cookie=ws_read_cookie,
             metadata_disabled=metadata_disabled,
+            test_remote=test_remote,
             hge_scale_url=hge_scale_url
         )
     except HGECtxError as e:

--- a/server/tests-py/context.py
+++ b/server/tests-py/context.py
@@ -74,8 +74,11 @@ class WebhookServer(http.server.HTTPServer):
 
 
 class HGECtx:
+
     def __init__(self, hge_url, pg_url, hge_key, hge_webhook, webhook_insecure,
-                 hge_jwt_key_file, hge_jwt_conf, metadata_disabled, ws_read_cookie, hge_scale_url):
+                 hge_jwt_key_file, hge_jwt_conf, metadata_disabled, ws_read_cookie, test_remote,
+                 hge_scale_url):
+
         server_address = ('0.0.0.0', 5592)
 
         self.resp_queue = queue.Queue(maxsize=1)
@@ -115,6 +118,8 @@ class HGECtx:
         self.graphql_server = graphql_server.create_server('127.0.0.1', 5000)
         self.gql_srvr_thread = threading.Thread(target=self.graphql_server.serve_forever)
         self.gql_srvr_thread.start()
+        # test hasura graphql-engine as a remote schema
+        self.test_remote_hge = test_remote
 
         self.ws_read_cookie = ws_read_cookie
 

--- a/server/tests-py/queries/remote_schemas/hge_remote_setup.yaml
+++ b/server/tests-py/queries/remote_schemas/hge_remote_setup.yaml
@@ -1,0 +1,45 @@
+type: bulk
+args:
+- type: run_sql
+  args:
+    sql: |
+      CREATE TABLE hello (
+        id SERIAL PRIMARY KEY,
+        code TEXT,
+        name TEXT
+      );
+
+- type: track_table
+  args:
+    schema: public
+    name: hello
+
+- type: run_sql
+  args:
+    sql: |
+      INSERT INTO hello (code, name) VALUES
+      ('felu', 'Pradosh C Mitter'),
+      ('holmes', 'Sherlock Holmes')
+
+- type: run_sql
+  args:
+    sql: |
+      CREATE TABLE animals (
+        id SERIAL PRIMARY KEY,
+        common_name TEXT,
+        genus TEXT,
+        species TEXT
+      );
+
+- type: track_table
+  args:
+    schema: public
+    name: animals
+
+- type: run_sql
+  args:
+    sql: |
+      INSERT INTO animals (common_name, genus, species) VALUES
+      ('Eurasian Eagle-Owl', 'Bubo', 'bubo'),
+      ('White-eyed Buzzard', 'Butastur', 'teesa'),
+      ('Plum-headed Parakeet', 'Psitaculla', 'cyanocephala')

--- a/server/tests-py/queries/remote_schemas/hge_remote_teardown.yaml
+++ b/server/tests-py/queries/remote_schemas/hge_remote_teardown.yaml
@@ -1,0 +1,11 @@
+type: bulk
+args:
+- type: run_sql
+  args:
+    sql: |
+      DROP TABLE hello;
+
+- type: run_sql
+  args:
+    sql: |
+      DROP TABLE animals;

--- a/server/tests-py/queries/remote_schemas/tbls_setup.yaml
+++ b/server/tests-py/queries/remote_schemas/tbls_setup.yaml
@@ -14,6 +14,13 @@ args:
     schema: public
     name: hello
 
+- type: run_sql
+  args:
+    sql: |
+      INSERT INTO hello (code, name) VALUES
+      ('felu', 'Pradosh C Mitter'),
+      ('holmes', 'Sherlock Holmes')
+
 - type: add_remote_schema
   args:
     name: simple2-graphql

--- a/server/tests-py/test_remote_subscriptions.py
+++ b/server/tests-py/test_remote_subscriptions.py
@@ -1,0 +1,129 @@
+import time
+from urllib.parse import urlparse
+import pytest
+import yaml
+
+from ws_graphql_client import GraphQLClient
+from test_schema_stitching import mk_add_remote_q
+
+if not pytest.config.getoption("--test-remote-subs"):
+    pytest.skip("--test-remote-subs flag is missing, skipping tests", allow_module_level=True)
+
+#@pytest.mark.skip(reason='does not have proper env')
+class TestRemoteSchemaSubscriptions():
+    dir = 'queries/remote_schemas'
+    teardown = {"type": "clear_metadata", "args": {}}
+
+    @pytest.fixture(autouse=True, scope='class')
+    def transact(self, hge_ctx):
+        self._setup_remote_schema_tbls(hge_ctx)
+        url = hge_ctx.test_remote_hge + '/v1alpha1/graphql'
+        q = mk_add_remote_q('subs-test', url)
+        st_code, resp = hge_ctx.v1q(q)
+        assert st_code == 200, resp
+        yield
+        # teardown
+        self._drop_remote_schema_tbls(hge_ctx)
+        st_code, resp = hge_ctx.v1q(self.teardown)
+        assert st_code == 200, resp
+
+    def _setup_remote_schema_tbls(self, hge_ctx):
+        fp = open(self.dir + '/hge_remote_setup.yaml')
+        q = yaml.load(fp)
+        resp = hge_ctx.http.post(
+            hge_ctx.test_remote_hge + "/v1/query",
+            json=q,
+        )
+        assert resp.status_code == 200
+
+    def _drop_remote_schema_tbls(self, hge_ctx):
+        fp = open(self.dir + '/hge_remote_teardown.yaml')
+        q = yaml.load(fp)
+        resp = hge_ctx.http.post(
+            hge_ctx.test_remote_hge + "/v1/query",
+            json=q,
+        )
+        assert resp.status_code == 200
+
+    def _run_subscription(self, hge_ctx, query):
+        self.wsc = GraphQLClient(hge_ctx)
+        headers = {}
+        if hge_ctx.hge_key:
+            headers = {'x-hasura-admin-secret': hge_ctx.hge_key}
+
+        self.wsc.conn_init(headers)
+        ev = hge_ctx.get_ws_event(3)
+        assert ev['type'] == 'connection_ack', ev
+        id = self.wsc.start(query)
+        return id
+
+    def test_simple_subscription(self, hge_ctx):
+        query = "subscription { animals {id common_name} }"
+        id = self._run_subscription(hge_ctx, query)
+        hge_ctx.get_ws_event(3)
+        res = hge_ctx.get_ws_event(3)
+        assert len(res['payload']['data']['animals']) == 3
+        self.wsc.stop(id)
+
+    def test_remote_then_local_subscription(self, hge_ctx):
+        q1 = "subscription { animals {id common_name} }"
+        q2 = "subscription { hello { code name } }"
+
+        id1 = self._run_subscription(hge_ctx, q1)
+        hge_ctx.get_ws_event(3)
+        res = hge_ctx.get_ws_event(3)
+        assert len(res['payload']['data']['animals']) == 3
+        self.wsc.stop(id1)
+
+        id2 = self._run_subscription(hge_ctx, q2)
+        hge_ctx.get_ws_event(3)
+        res = hge_ctx.get_ws_event(3)
+        assert len(res['payload']['data']['hello']) == 2
+        self.wsc.stop(id2)
+
+    def test_local_then_remote_subscription(self, hge_ctx):
+        q1 = "subscription { hello { code name } }"
+        q2 = "subscription { animals {id common_name} }"
+
+        id1 = self._run_subscription(hge_ctx, q1)
+        hge_ctx.get_ws_event(3)
+        res = hge_ctx.get_ws_event(3)
+        assert len(res['payload']['data']['hello']) == 2
+        self.wsc.stop(id1)
+
+        id2 = self._run_subscription(hge_ctx, q2)
+        hge_ctx.get_ws_event(3)
+        res = hge_ctx.get_ws_event(3)
+        assert len(res['payload']['data']['animals']) == 3
+        self.wsc.stop(id2)
+
+    def test_consecutive_remote_subscription(self, hge_ctx):
+        q = "subscription { animals { id common_name } }"
+
+        id1 = self._run_subscription(hge_ctx, q)
+        hge_ctx.get_ws_event(3)
+        res = hge_ctx.get_ws_event(3)
+        assert len(res['payload']['data']['animals']) == 3
+        self.wsc.stop(id1)
+
+        id2 = self._run_subscription(hge_ctx, q)
+        hge_ctx.get_ws_event(3)
+        res = hge_ctx.get_ws_event(3)
+        self.wsc.stop(id2)
+
+    def test_interleaved_remote_subscription(self, hge_ctx):
+        q1 = "subscription { animals { id common_name } }"
+        q2 = "subscription { hello { code name } }"
+
+        id1 = self._run_subscription(hge_ctx, q1)
+        hge_ctx.get_ws_event(3)
+        res = hge_ctx.get_ws_event(3)
+        assert len(res['payload']['data']['animals']) == 3
+
+        id2 = self._run_subscription(hge_ctx, q2)
+        hge_ctx.get_ws_event(3)
+        res = hge_ctx.get_ws_event(3)
+        assert len(res['payload']['data']['hello']) == 2
+
+        self.wsc.stop(id1)
+        self.wsc.stop(id2)

--- a/server/tests-py/test_schema_stitching.py
+++ b/server/tests-py/test_schema_stitching.py
@@ -1,12 +1,10 @@
-#!/usr/bin/env python3
-
+import json
 import string
 import random
+
 import yaml
-import json
 import queue
 import requests
-
 import pytest
 
 from validate import check_query_f, check_query

--- a/server/tests-py/ws_graphql_client.py
+++ b/server/tests-py/ws_graphql_client.py
@@ -1,0 +1,57 @@
+import string
+import random
+import json
+import websocket
+import time
+import threading
+
+
+class GraphQLClient():
+    """
+    A simple GraphQL client that works over Websocket as the transport
+    protocol, instead of HTTP.
+    This follows the Apollo protocol.
+    https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md
+    """
+
+    def __init__(self, hge_ctx):
+        #self.ws_url = url
+        #self._conn = websocket.create_connection(self.ws_url, on_message=self._on_message)
+        #self._conn.on_message = self._on_message
+        self.ctx = hge_ctx
+        self._subscription_running = False
+        self._st_id = None
+
+    def conn_init(self, headers=None):
+        payload = {
+            'type': 'connection_init',
+            'payload': {'headers': headers}
+        }
+        self.ctx.ws.send(json.dumps(payload))
+
+    def start(self, query, id=None, headers={}, variables={}):
+        _id = id if id else gen_id()
+        payload = {'headers': headers, 'query': query, 'variables': variables}
+        frame = {'id': _id, 'type': 'start', 'payload': payload}
+        self.ctx.ws.send(json.dumps(frame))
+        return _id
+
+    def stop(self, _id):
+        payload = {'id': _id, 'type': 'stop'}
+        self.ctx.ws.send(json.dumps(payload))
+
+    def query(self, query, variables=None, headers=None):
+        self.conn_init(headers)
+        payload = {'headers': headers, 'query': query, 'variables': variables}
+        _id = self.start(payload)
+        #res = self._stop(_id)
+        #print(dir(self._conn))
+        return self.ctx.get_ws_event(3)
+
+    def close(self):
+        self.ctx.ws.close()
+
+
+# generate random alphanumeric id
+def gen_id(size=6, chars=string.ascii_letters + string.digits):
+    return ''.join(random.choice(chars) for _ in range(size))


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- Describe your changes in detail -->
Support subscriptions to remote schema servers.

### To try/test it out
1. Start a Hasura server which will act as remote.
2. Open the app in the current PR.
3. Add the Hasura instance in step 1 as a remote schema.
4. Head to GraphiQL and make subscription queries to the remote schema.

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
<!-- Please put an `x` in the boxes below -->

Sending subscriptions to remote servers works over the apollo websocket protocol. Hasura does not create a simple proxy, as there can be mixed fields in the same query in the future. Instead it operates on the protocol level. 

It is modeled as handlers on various apollo protocol messages. Different handlers for different apollo protocol messages are outlined below.

#### When Hasura receives a `start` message
1. When a client sends a `start` message, parse the query to determine if its for Hasura or remote.
2. If its remote, check if its already has an open connection. 
   1. If not, open a new connection and save the connection (to remote), operation id and websocket id in the state.
   2. Use the existing connection, append the operation id to existing operations and websocket id to state.
3. Run this ws connection on a separate thread (as it is blocking operation), save the thread id in state. 
4. Setup a handler to receive messages from the remote and send back to the client. This is also in a separate thread (as it is blocking) as save the thread id in state.
5. On this connection, send a `conn_init` with the same payload as the original message.
6. On this connection, send a `start` message identical to the client's.

#### When Hasura receives a `stop` message
1. When client sends `stop`, check to see if there is any remote connection in state corresponding to that operation id
2. If exists, send `stop` to the remote.
3. If there are no other operations on that remote, close the ws connection.

#### When Hasura receives a close connection
1. Get the websocket id
2. See if there is any remote connection with that websocket id, if exists, close the connection.


### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
#1599 

What component does this PR affect? 

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System

Requires changes from other components? If yes, please mark the components:

- [ ] Server
- [ ] Console
- [ ] CLI
- [x] Docs
- [ ] Community Content
- [ ] Build System



### Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] Community content

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[contributing guide](https://github.com/hasura/graphql-engine/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [x] This change requires a change in the documentation. 
- [ ] I have updated the documentation accordingly.
- [x] I have added required tests.
