### PR TITLE
reduce server build time on ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,15 +96,12 @@ refs:
     - checkout
     - restore_cache:
         keys:
-        - server-app-cache-{{ .Branch }}-{{ .Revision }}
-    - restore_cache:
-        keys:
-        - server-deps-cache-{{ checksum "server/graphql-engine.cabal" }}-{{ checksum "server/stack.yaml" }}
+        - server-cache-v1-{{ checksum "server/graphql-engine.cabal" }}-{{ checksum "server/stack.yaml" }}
     - *wait_for_postgres
     - run:
-        name: Install deps
-        # if the man directories are missing, postgresql-client fails
-        # to install in debian
+        name: Install test dependencies
+        # if the man directories are missing, postgresql-client fails to
+        # install in debian
         command: |
           mkdir -p /usr/share/man/man{1,7}
           apt-get update
@@ -158,10 +155,7 @@ jobs:
     - *setup_remote_docker
     - restore_cache:
         keys:
-        - server-deps-cache-{{ checksum "server/graphql-engine.cabal" }}-{{ checksum "server/stack.yaml" }}
-    - restore_cache:
-        keys:
-        - server-app-cache-{{ .Branch }}-{{ .Revision }}
+        - server-cache-v1-{{ checksum "server/graphql-engine.cabal" }}-{{ checksum "server/stack.yaml" }}
     - run:
         name: Build the server
         working_directory: ./server
@@ -177,13 +171,10 @@ jobs:
           make ci-image
           make ci-save-image
     - save_cache:
-        key: server-app-cache-{{ .Branch }}-{{ .Revision }}
-        paths:
-        - ./server/.stack-work
-    - save_cache:
-        key: server-deps-cache-{{ checksum "server/graphql-engine.cabal" }}-{{ checksum "server/stack.yaml" }}
+        key: server-cache-v1-{{ checksum "server/graphql-engine.cabal" }}-{{ checksum "server/stack.yaml" }}
         paths:
         - ~/.stack
+        - ./server/.stack-work
     - store_artifacts:
         path: /build/_server_output
         destination: server

--- a/server/Makefile
+++ b/server/Makefile
@@ -33,6 +33,7 @@ release-image: $(project).cabal
 
 # assumes this is built in circleci
 ci-binary:
+	stack clean
 	mkdir -p packaging/build/rootfs
 	stack $(STACK_FLAGS) build $(BUILD_FLAGS)
 	mkdir -p $(build_output)


### PR DESCRIPTION
  Fix caching issues on build server job. Reduces server build time.

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Due to misconfiguration in the caching logic, server was building dependencies on every build. This fixes it to reduce server build time.

### Affected components 
<!-- Remove non-affected components from the list -->
- Build System

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
