### PR TITLE
validate relationship definitions on startup

### DIFF
--- a/server/src-lib/Hasura/Server/App.hs
+++ b/server/src-lib/Hasura/Server/App.hs
@@ -12,6 +12,7 @@ import           Data.Time.Clock                        (UTCTime,
                                                          getCurrentTime)
 import           Network.Wai                            (requestHeaders,
                                                          strictRequestBody)
+import           System.Exit                            (exitFailure)
 import           Web.Spock.Core
 
 import qualified Data.ByteString.Lazy                   as BL
@@ -304,6 +305,12 @@ legacyQueryHandler tn queryType =
   where
     qt = QualifiedObject publicSchema tn
 
+initErrExit :: QErr -> IO a
+initErrExit e = do
+  putStrLn $
+    "failed to build schema-cache because of inconsistent metadata: "
+    <> T.unpack (qeError e)
+  exitFailure
 
 mkWaiApp
   :: Q.TxIsolation -> L.LoggerCtx -> Bool

--- a/server/src-lib/Hasura/Server/Init.hs
+++ b/server/src-lib/Hasura/Server/Init.hs
@@ -3,7 +3,6 @@ module Hasura.Server.Init where
 import qualified Database.PG.Query            as Q
 
 import           Options.Applicative
-import           System.Exit                  (exitFailure)
 
 import qualified Data.Aeson                   as J
 import qualified Data.HashSet                 as Set
@@ -28,9 +27,6 @@ newtype InstanceId
 
 mkInstanceId :: IO InstanceId
 mkInstanceId = (InstanceId . UUID.toText) <$> UUID.nextRandom
-
-initErrExit :: (Show e) => e -> IO a
-initErrExit e = print e >> exitFailure
 
 data RawConnParams
   = RawConnParams


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

In `buildSchemaCache`, we don't check the validity of a relationship definition because of which on startup we load relationships that will not work. The error message on startup is also improved.

### Affected components 
<!-- Remove non-affected components from the list -->

- Server

