### PR TITLE
breaking: drop id from event_triggers table (fix #1840)

### DIFF
--- a/console/src/components/Services/EventTrigger/EventActions.js
+++ b/console/src/components/Services/EventTrigger/EventActions.js
@@ -242,7 +242,7 @@ const loadEventLogs = triggerName => (dispatch, getState) => {
                     columns: ['*'],
                   },
                 ],
-                where: { event: { trigger_id: triggerData[0].id } },
+                where: { event: { trigger_name: triggerData[0].name } },
                 order_by: ['-created_at'],
                 limit: 10,
               },

--- a/console/src/components/Services/EventTrigger/Modify/Info.js
+++ b/console/src/components/Services/EventTrigger/Modify/Info.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Tooltip from './Tooltip';
 
-const Info = ({ triggerName, tableName, schemaName, triggerId, styles }) => (
+const Info = ({ triggerName, tableName, schemaName, styles }) => (
   <div className={`${styles.container} ${styles.borderBottom}`}>
     <div className={styles.modifySection}>
       <h4 className={styles.modifySectionHeading}>
@@ -15,10 +15,6 @@ const Info = ({ triggerName, tableName, schemaName, triggerId, styles }) => (
             <tr>
               <td>Trigger name</td>
               <td>{triggerName}</td>
-            </tr>
-            <tr>
-              <td>Trigger ID</td>
-              <td>{triggerId}</td>
             </tr>
             <tr>
               <td>Table</td>

--- a/console/src/components/Services/EventTrigger/Modify/Modify.js
+++ b/console/src/components/Services/EventTrigger/Modify/Modify.js
@@ -65,7 +65,6 @@ class Modify extends React.Component {
             triggerName={currentTrigger.name}
             tableName={currentTrigger.table_name}
             schemaName={currentTrigger.schema_name}
-            triggerId={currentTrigger.id}
             styles={styles}
           />
           <WebhookEditor

--- a/console/src/components/Services/EventTrigger/PendingEvents/ViewActions.js
+++ b/console/src/components/Services/EventTrigger/PendingEvents/ViewActions.js
@@ -36,11 +36,11 @@ const vMakeRequest = () => {
     const originalTrigger = getState().triggers.currentTrigger;
     const triggerList = getState().triggers.triggerList;
     const triggerSchema = triggerList.filter(t => t.name === originalTrigger);
-    const triggerId = triggerSchema[0].id;
+    const triggerName = triggerSchema[0].name;
     const currentQuery = JSON.parse(JSON.stringify(state.triggers.view.query));
     // count query
     const countQuery = JSON.parse(JSON.stringify(state.triggers.view.query));
-    countQuery.columns = ['id'];
+    countQuery.columns = ['name'];
 
     // delivered = false and error = false
     // where clause for relationship
@@ -52,7 +52,7 @@ const vMakeRequest = () => {
       finalAndClause.push({ error: false });
       currentQuery.columns[1].where = { $and: finalAndClause };
       currentQuery.where = { name: state.triggers.currentTrigger };
-      countQuery.where.$and.push({ trigger_id: triggerId });
+      countQuery.where.$and.push({ trigger_name: triggerName });
     } else {
       // reset where for events
       if (currentQuery.columns[1]) {

--- a/console/src/components/Services/EventTrigger/PendingEvents/ViewActions.js
+++ b/console/src/components/Services/EventTrigger/PendingEvents/ViewActions.js
@@ -40,7 +40,7 @@ const vMakeRequest = () => {
     const currentQuery = JSON.parse(JSON.stringify(state.triggers.view.query));
     // count query
     const countQuery = JSON.parse(JSON.stringify(state.triggers.view.query));
-    countQuery.columns = ['name'];
+    countQuery.columns = ['id'];
 
     // delivered = false and error = false
     // where clause for relationship

--- a/console/src/components/Services/EventTrigger/ProcessedEvents/ViewActions.js
+++ b/console/src/components/Services/EventTrigger/ProcessedEvents/ViewActions.js
@@ -50,7 +50,7 @@ const vMakeRequest = () => {
     const currentQuery = JSON.parse(JSON.stringify(state.triggers.view.query));
     // count query
     const countQuery = JSON.parse(JSON.stringify(state.triggers.view.query));
-    countQuery.columns = ['name'];
+    countQuery.columns = ['id'];
 
     // delivered = true || error = true
     // where clause for relationship

--- a/console/src/components/Services/EventTrigger/ProcessedEvents/ViewActions.js
+++ b/console/src/components/Services/EventTrigger/ProcessedEvents/ViewActions.js
@@ -46,11 +46,11 @@ const vMakeRequest = () => {
     const originalTrigger = getState().triggers.currentTrigger;
     const triggerList = getState().triggers.triggerList;
     const triggerSchema = triggerList.filter(t => t.name === originalTrigger);
-    const triggerId = triggerSchema[0].id;
+    const triggerName = triggerSchema[0].name;
     const currentQuery = JSON.parse(JSON.stringify(state.triggers.view.query));
     // count query
     const countQuery = JSON.parse(JSON.stringify(state.triggers.view.query));
-    countQuery.columns = ['id'];
+    countQuery.columns = ['name'];
 
     // delivered = true || error = true
     // where clause for relationship
@@ -76,7 +76,7 @@ const vMakeRequest = () => {
       currentQuery.where = { name: state.triggers.currentTrigger };
       countQuery.where = {
         $and: [
-          { trigger_id: triggerId },
+          { trigger_name: triggerName },
           { $or: [{ delivered: { $eq: true } }, { error: { $eq: true } }] },
         ],
       };

--- a/console/src/components/Services/EventTrigger/RunningEvents/ViewActions.js
+++ b/console/src/components/Services/EventTrigger/RunningEvents/ViewActions.js
@@ -39,7 +39,7 @@ const vMakeRequest = () => {
     const currentQuery = JSON.parse(JSON.stringify(state.triggers.view.query));
     // count query
     const countQuery = JSON.parse(JSON.stringify(state.triggers.view.query));
-    countQuery.columns = ['id'];
+    countQuery.columns = ['name'];
 
     // delivered = false and error = false
     // where clause for relationship

--- a/console/src/components/Services/EventTrigger/RunningEvents/ViewActions.js
+++ b/console/src/components/Services/EventTrigger/RunningEvents/ViewActions.js
@@ -39,7 +39,7 @@ const vMakeRequest = () => {
     const currentQuery = JSON.parse(JSON.stringify(state.triggers.view.query));
     // count query
     const countQuery = JSON.parse(JSON.stringify(state.triggers.view.query));
-    countQuery.columns = ['name'];
+    countQuery.columns = ['id'];
 
     // delivered = false and error = false
     // where clause for relationship

--- a/console/src/components/Services/EventTrigger/StreamingLogs/LogActions.js
+++ b/console/src/components/Services/EventTrigger/StreamingLogs/LogActions.js
@@ -38,7 +38,7 @@ const vMakeRequest = triggerName => {
     const currentQuery = JSON.parse(JSON.stringify(state.triggers.log.query));
     // count query
     const countQuery = JSON.parse(JSON.stringify(state.triggers.log.query));
-    countQuery.columns = ['id'];
+    countQuery.columns = ['name'];
 
     currentQuery.where = { event: { trigger_name: triggerName } };
 
@@ -105,7 +105,7 @@ const loadNewerEvents = (latestTimestamp, triggerName) => {
     const currentQuery = JSON.parse(JSON.stringify(state.triggers.log.query));
     // count query
     const countQuery = JSON.parse(JSON.stringify(state.triggers.log.query));
-    countQuery.columns = ['id'];
+    countQuery.columns = ['name'];
 
     currentQuery.where = {
       event: { trigger_name: triggerName },
@@ -195,7 +195,7 @@ const loadOlderEvents = (oldestTimestamp, triggerName) => {
     const currentQuery = JSON.parse(JSON.stringify(state.triggers.log.query));
     // count query
     const countQuery = JSON.parse(JSON.stringify(state.triggers.log.query));
-    countQuery.columns = ['id'];
+    countQuery.columns = ['name'];
 
     currentQuery.where = {
       event: { trigger_name: triggerName },

--- a/console/src/components/Services/EventTrigger/StreamingLogs/LogActions.js
+++ b/console/src/components/Services/EventTrigger/StreamingLogs/LogActions.js
@@ -38,7 +38,7 @@ const vMakeRequest = triggerName => {
     const currentQuery = JSON.parse(JSON.stringify(state.triggers.log.query));
     // count query
     const countQuery = JSON.parse(JSON.stringify(state.triggers.log.query));
-    countQuery.columns = ['name'];
+    countQuery.columns = ['id'];
 
     currentQuery.where = { event: { trigger_name: triggerName } };
 
@@ -105,7 +105,7 @@ const loadNewerEvents = (latestTimestamp, triggerName) => {
     const currentQuery = JSON.parse(JSON.stringify(state.triggers.log.query));
     // count query
     const countQuery = JSON.parse(JSON.stringify(state.triggers.log.query));
-    countQuery.columns = ['name'];
+    countQuery.columns = ['id'];
 
     currentQuery.where = {
       event: { trigger_name: triggerName },
@@ -195,7 +195,7 @@ const loadOlderEvents = (oldestTimestamp, triggerName) => {
     const currentQuery = JSON.parse(JSON.stringify(state.triggers.log.query));
     // count query
     const countQuery = JSON.parse(JSON.stringify(state.triggers.log.query));
-    countQuery.columns = ['name'];
+    countQuery.columns = ['id'];
 
     currentQuery.where = {
       event: { trigger_name: triggerName },

--- a/docs/graphql/manual/event-triggers/payload.rst
+++ b/docs/graphql/manual/event-triggers/payload.rst
@@ -33,8 +33,7 @@ JSON payload
       "created_at": "<timestamp>",
       "id": "<uuid>",
       "trigger": {
-          "name": "<name-of-trigger>",
-          "id": "<uuid>"
+          "name": "<name-of-trigger>"
       },
       "table":  {
           "schema": "<schema-name>",
@@ -60,16 +59,16 @@ JSON payload
      - Key-value pairs of column name and their values of the table
    * - timestamp
      - String
-     - Timestamp value
+     - Timestamp at which event was created
    * - uuid
      - String
-     - A UUID value
+     - UUID identifier for the event
    * - name-of-trigger
      - String
      - Name of the trigger
    * - schema-name
      - String
-     - Name of the postgres schema where the table is
+     - Name of the schema for the table
    * - table-name
      - String
      - Name of the table
@@ -100,8 +99,7 @@ JSON payload
       "id": "85558393-c75d-4d2f-9c15-e80591b83894",
       "created_at": "2018-09-05T07:14:21.601701Z",
       "trigger": {
-          "name": "test_trigger",
-          "id": "37b7f91a-b3a5-4b85-be59-e5920d72f6aa"
+          "name": "test_trigger"
       },
       "table": {
           "schema": "public",

--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -164,7 +164,7 @@ library
                      , Hasura.RQL.Types.Permission
                      , Hasura.RQL.Types.Error
                      , Hasura.RQL.Types.DML
-                     , Hasura.RQL.Types.Subscribe
+                     , Hasura.RQL.Types.EventTrigger
                      , Hasura.RQL.Types.RemoteSchema
                      , Hasura.RQL.DDL.Deps
                      , Hasura.RQL.DDL.Permission.Internal
@@ -180,7 +180,7 @@ library
                      , Hasura.RQL.DDL.Schema.Diff
                      , Hasura.RQL.DDL.Metadata
                      , Hasura.RQL.DDL.Utils
-                     , Hasura.RQL.DDL.Subscribe
+                     , Hasura.RQL.DDL.EventTrigger
                      , Hasura.RQL.DDL.Headers
                      , Hasura.RQL.DDL.RemoteSchema
                      , Hasura.RQL.DML.Delete

--- a/server/src-lib/Hasura/Events/HTTP.hs
+++ b/server/src-lib/Hasura/Events/HTTP.hs
@@ -31,14 +31,14 @@ import           Data.Has
 import           Hasura.Logging
 import           Hasura.Prelude
 import           Hasura.RQL.DDL.Headers
-import           Hasura.RQL.Types.Subscribe
+import           Hasura.RQL.Types.EventTrigger
 
 type HLogger = (LogLevel, EngineLogType, J.Value) -> IO ()
 
 data ExtraContext
   = ExtraContext
   { elEventCreatedAt :: Time.UTCTime
-  , elEventId        :: TriggerId
+  , elEventId        :: EventId
   } deriving (Show, Eq)
 
 $(J.deriveJSON (J.aesonDrop 2 J.snakeCase){J.omitNothingFields=True} ''ExtraContext)

--- a/server/src-lib/Hasura/RQL/DDL/EventTrigger.hs
+++ b/server/src-lib/Hasura/RQL/DDL/EventTrigger.hs
@@ -1,4 +1,4 @@
-module Hasura.RQL.DDL.Subscribe
+module Hasura.RQL.DDL.EventTrigger
   ( CreateEventTriggerQuery
   , runCreateEventTriggerQuery
   , DeleteEventTriggerQuery
@@ -16,8 +16,8 @@ module Hasura.RQL.DDL.Subscribe
   ) where
 
 import           Data.Aeson
-import           Hasura.Prelude
 import           Hasura.EncJSON
+import           Hasura.Prelude
 import           Hasura.RQL.DDL.Headers
 import           Hasura.RQL.DML.Internal
 import           Hasura.RQL.Types
@@ -52,17 +52,15 @@ getDropFuncSql op trn = "DROP FUNCTION IF EXISTS"
 
 getTriggerSql
   :: Ops
-  -> TriggerId
   -> TriggerName
   -> QualifiedTable
   -> [PGColInfo]
   -> Bool
   -> Maybe SubscribeOpSpec
   -> Maybe T.Text
-getTriggerSql op trid trn qt allCols strfyNum spec =
+getTriggerSql op trn qt allCols strfyNum spec =
   let globalCtx =  HashMap.fromList
-                   [ (T.pack "ID", trid)
-                   , (T.pack "NAME", trn)
+                   [ (T.pack "NAME", trn)
                    , (T.pack "QUALIFIED_TRIGGER_NAME", pgIdenTrigger op trn)
                    , (T.pack "QUALIFIED_TABLE", toSQLTxt qt)
                    ]
@@ -115,17 +113,16 @@ getTriggerSql op trid trn qt allCols strfyNum spec =
     fromMaybePayload = fromMaybe SubCStar
 
 mkTriggerQ
-  :: TriggerId
-  -> TriggerName
+  :: TriggerName
   -> QualifiedTable
   -> [PGColInfo]
   -> Bool
   -> TriggerOpsDef
   -> Q.TxE QErr ()
-mkTriggerQ trid trn qt allCols strfyNum (TriggerOpsDef insert update delete) = do
-  let msql = getTriggerSql INSERT trid trn qt allCols strfyNum insert
-             <> getTriggerSql UPDATE trid trn qt allCols strfyNum update
-             <> getTriggerSql DELETE trid trn qt allCols strfyNum delete
+mkTriggerQ trn qt allCols strfyNum (TriggerOpsDef insert update delete) = do
+  let msql = getTriggerSql INSERT trn qt allCols strfyNum insert
+             <> getTriggerSql UPDATE trn qt allCols strfyNum update
+             <> getTriggerSql DELETE trn qt allCols strfyNum delete
   case msql of
     Just sql -> Q.multiQE defaultTxErrorHandler (Q.fromText sql)
     Nothing  -> throw500 "no trigger sql generated"
@@ -140,24 +137,19 @@ addEventTriggerToCatalog
   -> [PGColInfo]
   -> Bool
   -> EventTriggerConf
-  -> Q.TxE QErr TriggerId
+  -> Q.TxE QErr ()
 addEventTriggerToCatalog qt allCols strfyNum etc = do
-  ids <- map runIdentity <$> Q.listQE defaultTxErrorHandler
+  Q.unitQE defaultTxErrorHandler
          [Q.sql|
            INSERT into hdb_catalog.event_triggers
                        (name, type, schema_name, table_name, configuration)
            VALUES ($1, 'table', $2, $3, $4)
-           RETURNING id
-               |] (name, sn, tn, Q.AltJ $ toJSON etc) True
+         |] (name, sn, tn, Q.AltJ $ toJSON etc) True
 
-  trid <- getTrid ids
-  mkTriggerQ trid name qt allCols strfyNum opsdef
-  return trid
+  mkTriggerQ name qt allCols strfyNum opsdef
   where
     QualifiedObject sn tn = qt
     (EventTriggerConf name opsdef _ _ _ _) = etc
-    getTrid []    = throw500 "could not create event-trigger"
-    getTrid (x:_) = return x
 
 delEventTriggerFromCatalog :: TriggerName -> Q.TxE QErr ()
 delEventTriggerFromCatalog trn = do
@@ -173,12 +165,10 @@ updateEventTriggerToCatalog
   -> [PGColInfo]
   -> Bool
   -> EventTriggerConf
-  -> Q.TxE QErr TriggerId
+  -> Q.TxE QErr ()
 updateEventTriggerToCatalog qt allCols strfyNum etc = do
-  trid <- updateEventTriggerDef name etc
   delTriggerQ name
-  mkTriggerQ trid name qt allCols strfyNum opsdef
-  return trid
+  mkTriggerQ name qt allCols strfyNum opsdef
   where
     EventTriggerConf name opsdef _ _ _ _ = etc
 
@@ -189,7 +179,7 @@ fetchEvent eid = do
               SELECT l.id, l.locked
               FROM hdb_catalog.event_log l
               JOIN hdb_catalog.event_triggers e
-              ON l.trigger_id = e.id
+              ON l.trigger_name = e.name
               WHERE l.id = $1
               |] (Identity eid) True
   event <- getEvent events
@@ -240,8 +230,8 @@ subTableP1 (CreateEventTriggerQuery name qt insert update delete retryConf webho
 
 subTableP2Setup
   :: (QErrM m, CacheRWM m, MonadIO m)
-  => QualifiedTable -> TriggerId -> EventTriggerConf -> m ()
-subTableP2Setup qt trid (EventTriggerConf name def webhook webhookFromEnv rconf mheaders) = do
+  => QualifiedTable -> EventTriggerConf -> m ()
+subTableP2Setup qt (EventTriggerConf name def webhook webhookFromEnv rconf mheaders) = do
   webhookConf <- case (webhook, webhookFromEnv) of
     (Just w, Nothing)    -> return $ WCValue w
     (Nothing, Just wEnv) -> return $ WCEnv wEnv
@@ -249,7 +239,7 @@ subTableP2Setup qt trid (EventTriggerConf name def webhook webhookFromEnv rconf 
   let headerConfs = fromMaybe [] mheaders
   webhookInfo <- getWebhookInfoFromConf webhookConf
   headerInfos <- getHeaderInfosFromConf headerConfs
-  let eTrigInfo = EventTriggerInfo trid name def rconf webhookInfo headerInfos
+  let eTrigInfo = EventTriggerInfo name def rconf webhookInfo headerInfos
       tabDep = SchemaDependency (SOTable qt) "parent"
   addEventTriggerToCache qt eTrigInfo (tabDep:getTrigDefDeps qt def)
 
@@ -279,13 +269,13 @@ subTableP2
 subTableP2 qt replace etc = do
   allCols <- getCols . tiFieldInfoMap <$> askTabInfo qt
   strfyNum <- stringifyNum <$> askSQLGenCtx
-  trid <- if replace
+  if replace
     then do
     delEventTriggerFromCache qt (etcName etc)
     liftTx $ updateEventTriggerToCatalog qt allCols strfyNum etc
     else
     liftTx $ addEventTriggerToCatalog qt allCols strfyNum etc
-  subTableP2Setup qt trid etc
+  subTableP2Setup qt etc
 
 runCreateEventTriggerQuery
   :: (QErrM m, UserInfoM m, CacheRWM m, MonadTx m, MonadIO m, HasSQLGenCtx m)
@@ -370,13 +360,13 @@ getEventTriggerDef triggerName = do
   return (QualifiedObject sn tn, etc)
 
 updateEventTriggerDef
-  :: TriggerName -> EventTriggerConf -> Q.TxE QErr TriggerId
+  :: TriggerName -> EventTriggerConf -> Q.TxE QErr ()
 updateEventTriggerDef trigName trigConf =
-  runIdentity . Q.getRow <$> Q.withQE defaultTxErrorHandler
+  Q.unitQE defaultTxErrorHandler
     [Q.sql|
       UPDATE hdb_catalog.event_triggers
       SET
       configuration = $1
       WHERE name = $2
       RETURNING id
-          |] (Q.AltJ $ toJSON trigConf, trigName) True
+    |] (Q.AltJ $ toJSON trigConf, trigName) True

--- a/server/src-lib/Hasura/RQL/DDL/Metadata.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Metadata.hs
@@ -43,9 +43,9 @@ import qualified Hasura.RQL.DDL.Relationship    as DR
 import qualified Hasura.RQL.DDL.RemoteSchema    as DRS
 import qualified Hasura.RQL.DDL.Schema.Function as DF
 import qualified Hasura.RQL.DDL.Schema.Table    as DT
-import qualified Hasura.RQL.DDL.Subscribe       as DS
+import qualified Hasura.RQL.DDL.EventTrigger    as DS
 import qualified Hasura.RQL.Types.RemoteSchema  as TRS
-import qualified Hasura.RQL.Types.Subscribe     as DTS
+import qualified Hasura.RQL.Types.EventTrigger  as DTS
 
 data TableMeta
   = TableMeta

--- a/server/src-lib/Hasura/RQL/DDL/Schema/Rename.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Rename.hs
@@ -10,7 +10,7 @@ import           Hasura.Prelude
 import           Hasura.RQL.DDL.Permission
 import           Hasura.RQL.DDL.Permission.Internal
 import           Hasura.RQL.DDL.Relationship.Types
-import qualified Hasura.RQL.DDL.Subscribe           as DS
+import qualified Hasura.RQL.DDL.EventTrigger as DS
 import           Hasura.RQL.Types
 import           Hasura.SQL.Types
 

--- a/server/src-lib/Hasura/RQL/DDL/Schema/Table.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Table.hs
@@ -14,7 +14,7 @@ import           Hasura.RQL.DDL.RemoteSchema
 import           Hasura.RQL.DDL.Schema.Diff
 import           Hasura.RQL.DDL.Schema.Function
 import           Hasura.RQL.DDL.Schema.Rename
-import           Hasura.RQL.DDL.Subscribe
+import           Hasura.RQL.DDL.EventTrigger
 import           Hasura.RQL.DDL.Utils
 import           Hasura.RQL.Types
 import           Hasura.Server.Utils                (matchRegex)
@@ -333,13 +333,13 @@ buildSchemaCache = do
     addQTemplateToCache qti deps
 
   eventTriggers <- liftTx $ Q.catchE defaultTxErrorHandler fetchEventTriggers
-  forM_ eventTriggers $ \(sn, tn, trid, trn, Q.AltJ configuration) -> do
+  forM_ eventTriggers $ \(sn, tn, trn, Q.AltJ configuration) -> do
     etc <- decodeValue configuration
 
     let qt = QualifiedObject sn tn
-    subTableP2Setup qt trid etc
+    subTableP2Setup qt etc
     allCols <- getCols . tiFieldInfoMap <$> askTabInfo qt
-    liftTx $ mkTriggerQ trid trn qt allCols strfyNum (etcDefinition etc)
+    liftTx $ mkTriggerQ trn qt allCols strfyNum (etcDefinition etc)
 
   functions <- liftTx $ Q.catchE defaultTxErrorHandler fetchFunctions
   forM_ functions $ \(sn, fn) ->
@@ -396,7 +396,7 @@ buildSchemaCache = do
 
     fetchEventTriggers =
       Q.listQ [Q.sql|
-               SELECT e.schema_name, e.table_name, e.id, e.name, e.configuration::json
+               SELECT e.schema_name, e.table_name, e.name, e.configuration::json
                  FROM hdb_catalog.event_triggers e
                |] () False
     fetchFunctions =
@@ -514,8 +514,7 @@ execWithMDCheck (RunSQL t cascade _) = do
               cols = getCols $ tiFieldInfoMap ti
           forM_ (M.toList $ tiEventTriggerInfoMap ti) $ \(trn, eti) -> do
             let opsDef = etiOpsDef eti
-                trid = etiId eti
-            liftTx $ mkTriggerQ trid trn tn cols strfyNum opsDef
+            liftTx $ mkTriggerQ trn tn cols strfyNum opsDef
 
   bool withoutReload withReload reloadRequired
 

--- a/server/src-lib/Hasura/RQL/Types.hs
+++ b/server/src-lib/Hasura/RQL/Types.hs
@@ -53,7 +53,7 @@ import           Hasura.RQL.Types.Error        as R
 import           Hasura.RQL.Types.Permission   as R
 import           Hasura.RQL.Types.RemoteSchema as R
 import           Hasura.RQL.Types.SchemaCache  as R
-import           Hasura.RQL.Types.Subscribe    as R
+import           Hasura.RQL.Types.EventTrigger as R
 
 import           Hasura.SQL.Types
 

--- a/server/src-lib/Hasura/RQL/Types/EventTrigger.hs
+++ b/server/src-lib/Hasura/RQL/Types/EventTrigger.hs
@@ -1,9 +1,8 @@
-module Hasura.RQL.Types.Subscribe
+module Hasura.RQL.Types.EventTrigger
   ( CreateEventTriggerQuery(..)
   , SubscribeOpSpec(..)
   , SubscribeColumns(..)
   , TriggerName
-  , TriggerId
   , Ops(..)
   , EventId
   , TriggerOpsDef(..)
@@ -35,7 +34,6 @@ import qualified Data.Text                  as T
 import qualified Text.Regex.TDFA            as TDFA
 
 type TriggerName = T.Text
-type TriggerId   = T.Text
 type EventId     = T.Text
 
 data Ops = INSERT | UPDATE | DELETE deriving (Show)

--- a/server/src-lib/Hasura/RQL/Types/SchemaCache.hs
+++ b/server/src-lib/Hasura/RQL/Types/SchemaCache.hs
@@ -106,7 +106,7 @@ import           Hasura.RQL.Types.Error
 import           Hasura.RQL.Types.Permission
 import           Hasura.RQL.Types.RemoteSchema
 import           Hasura.RQL.Types.SchemaCacheTypes
-import           Hasura.RQL.Types.Subscribe
+import           Hasura.RQL.Types.EventTrigger
 import           Hasura.SQL.Types
 
 import           Control.Lens
@@ -254,8 +254,7 @@ type RolePermInfoMap = M.HashMap RoleName RolePermInfo
 
 data EventTriggerInfo
  = EventTriggerInfo
-   { etiId          :: !TriggerId
-   , etiName        :: !TriggerName
+   { etiName        :: !TriggerName
    , etiOpsDef      :: !TriggerOpsDef
    , etiRetryConf   :: !RetryConf
    , etiWebhookInfo :: !WebhookConfInfo

--- a/server/src-lib/Hasura/RQL/Types/SchemaCacheTypes.hs
+++ b/server/src-lib/Hasura/RQL/Types/SchemaCacheTypes.hs
@@ -10,7 +10,7 @@ import qualified Data.Text                   as T
 
 import           Hasura.RQL.Types.Common
 import           Hasura.RQL.Types.Permission
-import           Hasura.RQL.Types.Subscribe
+import           Hasura.RQL.Types.EventTrigger
 import           Hasura.SQL.Types
 
 data TableObjId

--- a/server/src-lib/Hasura/Server/Query.hs
+++ b/server/src-lib/Hasura/Server/Query.hs
@@ -17,7 +17,7 @@ import           Hasura.RQL.DDL.Relationship.Rename
 import           Hasura.RQL.DDL.RemoteSchema
 import           Hasura.RQL.DDL.Schema.Function
 import           Hasura.RQL.DDL.Schema.Table
-import           Hasura.RQL.DDL.Subscribe
+import           Hasura.RQL.DDL.EventTrigger
 import           Hasura.RQL.DML.Count
 import           Hasura.RQL.DML.Delete
 import           Hasura.RQL.DML.Insert

--- a/server/src-rsr/hdb_metadata.yaml
+++ b/server/src-rsr/hdb_metadata.yaml
@@ -207,7 +207,7 @@ args:
           schema: hdb_catalog
           name: event_triggers
         column_mapping:
-          trigger_id : id
+          trigger_name : name
 
 - type: create_array_relationship
   args:
@@ -221,7 +221,7 @@ args:
           schema: hdb_catalog
           name: event_log
         column_mapping:
-          id : trigger_id
+          name : trigger_name
 
 - type: create_object_relationship
   args:

--- a/server/src-rsr/initialise.sql
+++ b/server/src-rsr/initialise.sql
@@ -278,8 +278,7 @@ $$;
 
 CREATE TABLE hdb_catalog.event_triggers
 (
-  id TEXT DEFAULT gen_random_uuid() PRIMARY KEY,
-  name TEXT UNIQUE,
+  name TEXT PRIMARY KEY,
   type TEXT NOT NULL,
   schema_name TEXT NOT NULL,
   table_name TEXT NOT NULL,
@@ -294,7 +293,6 @@ CREATE TABLE hdb_catalog.event_log
   id TEXT DEFAULT gen_random_uuid() PRIMARY KEY,
   schema_name TEXT NOT NULL,
   table_name TEXT NOT NULL,
-  trigger_id TEXT NOT NULL,
   trigger_name TEXT NOT NULL,
   payload JSONB NOT NULL,
   delivered BOOLEAN NOT NULL DEFAULT FALSE,
@@ -305,7 +303,7 @@ CREATE TABLE hdb_catalog.event_log
   next_retry_at TIMESTAMP
 );
 
-CREATE INDEX ON hdb_catalog.event_log (trigger_id);
+CREATE INDEX ON hdb_catalog.event_log (trigger_name);
 
 CREATE TABLE hdb_catalog.event_invocation_logs
 (

--- a/server/src-rsr/migrate_from_11_to_12.sql
+++ b/server/src-rsr/migrate_from_11_to_12.sql
@@ -1,0 +1,28 @@
+ALTER TABLE hdb_catalog.event_triggers
+  DROP CONSTRAINT event_triggers_pkey;
+
+ALTER TABLE hdb_catalog.event_triggers
+  DROP CONSTRAINT event_triggers_name_key;
+
+ALTER TABLE hdb_catalog.event_triggers
+  ADD PRIMARY KEY (name);
+
+ALTER TABLE hdb_catalog.event_triggers
+  DROP COLUMN id;
+
+ALTER TABLE hdb_catalog.event_log
+  DROP COLUMN trigger_id;
+
+CREATE INDEX ON hdb_catalog.event_log (trigger_name);
+
+UPDATE hdb_catalog.hdb_relationship
+   SET rel_def = '{"manual_configuration":{"remote_table":{"schema":"hdb_catalog","name":"event_log"},"column_mapping":{"name":"trigger_name"}}}'
+ WHERE table_schema = 'hdb_catalog'
+       AND table_name = 'event_triggers'
+       AND rel_name = 'events';
+
+UPDATE hdb_catalog.hdb_relationship
+   SET rel_def = '{"manual_configuration":{"remote_table":{"schema":"hdb_catalog","name":"event_triggers"},"column_mapping":{"trigger_name":"name"}}}'
+ WHERE table_schema = 'hdb_catalog'
+       AND table_name = 'event_log'
+       AND rel_name = 'trigger';

--- a/server/src-rsr/trigger.sql.j2
+++ b/server/src-rsr/trigger.sql.j2
@@ -40,9 +40,9 @@ CREATE OR REPLACE function hdb_views.{{QUALIFIED_TRIGGER_NAME}}() RETURNS trigge
                         )::text;
      IF (TG_OP <> 'UPDATE') OR (_old <> _new) THEN
        INSERT INTO
-       hdb_catalog.event_log (id, schema_name, table_name, trigger_name, trigger_id, payload)
+       hdb_catalog.event_log (id, schema_name, table_name, trigger_name, payload)
        VALUES
-       (id, TG_TABLE_SCHEMA, TG_TABLE_NAME, '{{NAME}}', '{{ID}}', payload);
+       (id, TG_TABLE_SCHEMA, TG_TABLE_NAME, '{{NAME}}', payload);
      END IF;
      RETURN NULL;
    END;

--- a/server/tests-py/validate.py
+++ b/server/tests-py/validate.py
@@ -20,7 +20,7 @@ def check_ev_payload_shape(ev_payload):
     event_keys = ["data", "op"]
     check_keys(event_keys, ev_payload['event'])
 
-    trigger_keys = ["id", "name"]
+    trigger_keys = ["name"]
     check_keys(trigger_keys, ev_payload['trigger'])
 
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

An auto-generated trigger_id was being generated for each event_trigger. This trigger_id was causing problems as described in #1840 . We solve this by removing the trigger_id and using trigger_name as the identifier for the event_trigger everywhere.

### Affected components 
<!-- Remove non-affected components from the list -->

- Server
- Console
- Docs

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

#1840 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->

This change is breaking in the following way:

- There will no longer be an `id` key in the `trigger` section of the event payload i.e.

```
  "trigger": {
      "name": "<name-of-trigger>",
      "id": "<uuid>"
  }
```

changes to: 

```
  "trigger": {
      "name": "<name-of-trigger>"
  }
```