### PR TITLE
bump haskell-docker-packager version

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -4,7 +4,7 @@ version  := $(shell ../scripts/get-version.sh)
 
 # TODO: needs to be replaced with something like yq
 stack_resolver := $(shell awk '/^resolver:/ {print $$2;}' stack.yaml)
-packager_ver := 20190314
+packager_ver := 20190326
 project_dir := $(shell pwd)
 build_dir := $(project_dir)/$(shell stack path --dist-dir)/build
 

--- a/server/packaging/packager.df
+++ b/server/packaging/packager.df
@@ -1,4 +1,4 @@
-FROM hasura/haskell-docker-packager:20190314
+FROM hasura/haskell-docker-packager:20190326
 MAINTAINER vamshi@hasura.io
 
 RUN apt-get update && apt-get install -y libpq5 upx \


### PR DESCRIPTION
The previous version didn't include libgcc_s.so.1 in rootfs. We never encountered an error before as it was most likely packaged by busybox.


### Affected components 
<!-- Remove non-affected components from the list -->

- Server