### PR TITLE
fix minimum pg disk value on azure template

### DIFF
--- a/install-manifests/azure-container-with-pg/azuredeploy.json
+++ b/install-manifests/azure-container-with-pg/azuredeploy.json
@@ -52,7 +52,7 @@
     "postgresDiskSizeInMB": {
       "type": "int",
       "minValue": 5120,
-      "maxValue": 4194303,
+      "maxValue": 4194304,
       "defaultValue": 10240,
       "metadata": {
         "description": "Azure database for PostgreSQL SKU storage size."

--- a/install-manifests/azure-container-with-pg/azuredeploy.json
+++ b/install-manifests/azure-container-with-pg/azuredeploy.json
@@ -51,7 +51,7 @@
     },
     "postgresDiskSizeInMB": {
       "type": "int",
-      "minValue": 5210,
+      "minValue": 5120,
       "maxValue": 4096000,
       "defaultValue": 10240,
       "metadata": {

--- a/install-manifests/azure-container-with-pg/azuredeploy.json
+++ b/install-manifests/azure-container-with-pg/azuredeploy.json
@@ -52,7 +52,7 @@
     "postgresDiskSizeInMB": {
       "type": "int",
       "minValue": 5120,
-      "maxValue": 4096000,
+      "maxValue": 4194303,
       "defaultValue": 10240,
       "metadata": {
         "description": "Azure database for PostgreSQL SKU storage size."


### PR DESCRIPTION
Minimum postgres disk size is 5120 MB rather than 5210.  Attempting to specify 5210 results in an ARM deployment error.
