### PR TITLE
fix input argument types for custom SQL functions (fix #1952)

### DIFF
--- a/server/src-exec/Migrate.hs
+++ b/server/src-exec/Migrate.hs
@@ -19,7 +19,7 @@ import qualified Data.Yaml.TH                as Y
 import qualified Database.PG.Query           as Q
 
 curCatalogVer :: T.Text
-curCatalogVer = "12"
+curCatalogVer = "13"
 
 migrateMetadata
   :: ( MonadTx m
@@ -265,6 +265,13 @@ from11To12 = liftTx $ do
     $(Q.sqlFromFile "src-rsr/migrate_from_11_to_12.sql")
   return ()
 
+from12To13 :: (MonadTx m) => m ()
+from12To13 = liftTx $ do
+  -- Migrate database
+  Q.Discard () <- Q.multiQE defaultTxErrorHandler
+    $(Q.sqlFromFile "src-rsr/migrate_from_12_to_13.sql")
+  return ()
+
 migrateCatalog
   :: ( MonadTx m
      , CacheRWM m
@@ -290,10 +297,13 @@ migrateCatalog migrationTime = do
      | preVer == "9"   -> from9ToCurrent
      | preVer == "10"   -> from10ToCurrent
      | preVer == "11"   -> from11ToCurrent
+     | preVer == "12"   -> from12ToCurrent
      | otherwise -> throw400 NotSupported $
                     "unsupported version : " <> preVer
   where
-    from11ToCurrent = from11To12 >> postMigrate
+    from12ToCurrent = from12To13 >> postMigrate
+
+    from11ToCurrent = from11To12 >> from12ToCurrent
 
     from10ToCurrent = from10To11 >> from11ToCurrent
 

--- a/server/src-rsr/initialise.sql
+++ b/server/src-rsr/initialise.sql
@@ -368,14 +368,19 @@ SELECT
   END AS return_type_type,
   p.proretset AS returns_set,
   ( SELECT
-      COALESCE(json_agg(pt.typname), '[]')
+      COALESCE(json_agg(q.type_name), '[]')
     FROM
       (
-        unnest(
-          COALESCE(p.proallargtypes, (p.proargtypes) :: oid [])
-        ) WITH ORDINALITY pat(oid, ordinality)
-        LEFT JOIN pg_type pt ON ((pt.oid = pat.oid))
-      )
+        SELECT
+          pt.typname AS type_name,
+          pat.ordinality
+        FROM
+          unnest(
+            COALESCE(p.proallargtypes, (p.proargtypes) :: oid [])
+          ) WITH ORDINALITY pat(oid, ordinality)
+          LEFT JOIN pg_type pt ON ((pt.oid = pat.oid))
+        ORDER BY pat.ordinality ASC
+      ) q
    ) AS input_arg_types,
   to_json(COALESCE(p.proargnames, ARRAY [] :: text [])) AS input_arg_names
 FROM

--- a/server/src-rsr/migrate_from_12_to_13.sql
+++ b/server/src-rsr/migrate_from_12_to_13.sql
@@ -1,0 +1,73 @@
+CREATE OR REPLACE VIEW hdb_catalog.hdb_function_agg AS
+(
+SELECT
+  p.proname::text AS function_name,
+  pn.nspname::text AS function_schema,
+
+  CASE
+    WHEN (p.provariadic = (0) :: oid) THEN false
+    ELSE true
+  END AS has_variadic,
+
+  CASE
+    WHEN (
+      (p.provolatile) :: text = ('i' :: character(1)) :: text
+    ) THEN 'IMMUTABLE' :: text
+    WHEN (
+      (p.provolatile) :: text = ('s' :: character(1)) :: text
+    ) THEN 'STABLE' :: text
+    WHEN (
+      (p.provolatile) :: text = ('v' :: character(1)) :: text
+    ) THEN 'VOLATILE' :: text
+    ELSE NULL :: text
+  END AS function_type,
+
+  pg_get_functiondef(p.oid) AS function_definition,
+
+  rtn.nspname::text AS return_type_schema,
+  rt.typname::text AS return_type_name,
+
+  CASE
+    WHEN ((rt.typtype) :: text = ('b' :: character(1)) :: text) THEN 'BASE' :: text
+    WHEN ((rt.typtype) :: text = ('c' :: character(1)) :: text) THEN 'COMPOSITE' :: text
+    WHEN ((rt.typtype) :: text = ('d' :: character(1)) :: text) THEN 'DOMAIN' :: text
+    WHEN ((rt.typtype) :: text = ('e' :: character(1)) :: text) THEN 'ENUM' :: text
+    WHEN ((rt.typtype) :: text = ('r' :: character(1)) :: text) THEN 'RANGE' :: text
+    WHEN ((rt.typtype) :: text = ('p' :: character(1)) :: text) THEN 'PSUEDO' :: text
+    ELSE NULL :: text
+  END AS return_type_type,
+  p.proretset AS returns_set,
+  ( SELECT
+      COALESCE(json_agg(q.type_name), '[]')
+    FROM
+      (
+        SELECT
+          pt.typname AS type_name,
+          pat.ordinality
+        FROM
+          unnest(
+            COALESCE(p.proallargtypes, (p.proargtypes) :: oid [])
+          ) WITH ORDINALITY pat(oid, ordinality)
+          LEFT JOIN pg_type pt ON ((pt.oid = pat.oid))
+        ORDER BY pat.ordinality ASC
+      ) q
+   ) AS input_arg_types,
+  to_json(COALESCE(p.proargnames, ARRAY [] :: text [])) AS input_arg_names
+FROM
+  pg_proc p
+  JOIN pg_namespace pn ON (pn.oid = p.pronamespace)
+  JOIN pg_type rt ON (rt.oid = p.prorettype)
+  JOIN pg_namespace rtn ON (rtn.oid = rt.typnamespace)
+WHERE
+  pn.nspname :: text NOT LIKE 'pg_%'
+  AND pn.nspname :: text NOT IN ('information_schema', 'hdb_catalog', 'hdb_views')
+  AND (NOT EXISTS (
+          SELECT
+            1
+          FROM
+            pg_aggregate
+          WHERE
+            ((pg_aggregate.aggfnoid) :: oid = p.oid)
+        )
+    )
+);

--- a/server/tests-py/queries/graphql_query/functions/query_get_test_uuid.yaml
+++ b/server/tests-py/queries/graphql_query/functions/query_get_test_uuid.yaml
@@ -1,0 +1,22 @@
+description: Query using get_test function
+url: /v1alpha1/graphql
+status: 200
+response:
+  data:
+    get_test:
+    - id: 1
+      uuid_col: 8e3e4a14-c831-45a2-9e78-8e86028d1ee5
+      name: clarke
+query:
+  query: |
+    query {
+      get_test(
+      args: { uuid_arg: "8e3e4a14-c831-45a2-9e78-8e86028d1ee5"
+            , name_arg: "clarke"
+            }
+     ) {
+        id
+        uuid_col
+        name
+      }
+    }

--- a/server/tests-py/queries/graphql_query/functions/setup.yaml
+++ b/server/tests-py/queries/graphql_query/functions/setup.yaml
@@ -41,4 +41,35 @@ args:
       ('post by hasura', 'content for post'),
       ('post by another', 'content for another post')
 
+# Table with uuid column
+- type: run_sql
+  args:
+    sql: |
+      create table test(
+        id serial primary key,
+        name text not null,
+        uuid_col uuid not null
+      );
+
+      insert into test (name, uuid_col) values
+       ('clarke', '8e3e4a14-c831-45a2-9e78-8e86028d1ee5')
+      ,('michael', '8e3e4a14-c831-45a2-9e78-8e86028d1ee5')
+      ,('fitch', '8e3e4a14-c831-45a2-9e78-8e86028d1ee6') ;
+
+      create function get_test(uuid_arg uuid, name_arg text)
+      returns setof test as $$
+      select * from test where uuid_col = uuid_arg and name = name_arg
+      $$ language sql stable;
+
+- type: track_table
+  args:
+    name: test
+    schema: public
+
+- type: track_function
+  args:
+    name: get_test
+    schema: public
+
+
 

--- a/server/tests-py/queries/graphql_query/functions/teardown.yaml
+++ b/server/tests-py/queries/graphql_query/functions/teardown.yaml
@@ -1,20 +1,9 @@
 type: bulk
 args:
-#Drop function first
-- type: untrack_function
-  args:
-    name: search_posts
-    schema: public
-
-- type: untrack_table
-  args:
-    table:
-      schema: public
-      name: post
-
 #Drop table and function from postgres
 - type: run_sql
   args:
     sql: |
-      drop table post cascade;
+      DROP TABLE post cascade;
+      DROP TABLE test cascade;
     cascade: true

--- a/server/tests-py/test_graphql_queries.py
+++ b/server/tests-py/test_graphql_queries.py
@@ -351,6 +351,9 @@ class TestGraphQLQueryFunctions(DefaultTestSelectQueries):
     def test_overloading_function_error(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + '/overloading_function_error.yaml')
 
+    def test_query_get_test_uuid(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + '/query_get_test_uuid.yaml')
+
     @classmethod
     def dir(cls):
         return 'queries/graphql_query/functions'


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Correctly generate types for input arguments of a custom SQL function query.

via **MalawiAli** [discord]

### Affected components 
<!-- Remove non-affected components from the list -->

- Server
- Tests

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
fix #1952 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

- Fix `hdb_function_agg` view in `hdb_catalog` view to enforce input argument type sequence of a function.
- Catalog bump to `13` 

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

Create Postgres schema as follows:- 
```sql
      create table test(
        id serial primary key,
        name text not null,
        uuid_col uuid not null
      );
      create function get_test(uuid_arg uuid, name_arg text)
      returns setof test as $$
      select * from test where uuid_col = uuid_arg and name = name_arg
      $$ language sql stable;

```
Make following graphql query:- 
```graphql
    query {
      get_test(
      args: { uuid_arg: "8e3e4a14-c831-45a2-9e78-8e86028d1ee5"
            , name_arg: "clarke"
            }
     ) {
        id
        uuid_col
        name
      }
    }
```

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
