### PR TITLE
Explain required key length for HMAC encryption to user

### DIFF
--- a/docs/graphql/manual/auth/jwt.rst
+++ b/docs/graphql/manual/auth/jwt.rst
@@ -138,7 +138,8 @@ public keys are not yet supported.
 ``key``
 ^^^^^^^
 - In case of symmetric key (i.e. HMAC based key), the key as it is. (e.g. -
-  "abcdef...").
+  "abcdef..."). The key must be long enough for the algorithm chosen,
+  (e.g. for HS256 it must be at least 32 characters long).
 - In case of asymmetric keys (RSA etc.), only the public key, in a PEM encoded
   string or as a X509 certificate.
 


### PR DESCRIPTION
### Description
Following on from a discussion in discord, a small tweak to make the required key length for a HMAC key more obvious.

### Affected components 
<!-- Remove non-affected components from the list -->


- Docs


