### PR TITLE
update regex to delete event triggers in edit-pg-dump (close #1959)

### DIFF
--- a/docs/graphql/manual/migrations/existing-database.rst
+++ b/docs/graphql/manual/migrations/existing-database.rst
@@ -100,9 +100,7 @@ Step 3: Initialize the migrations as per your current state
      # POST the SQL to a serverless function and save the response
      curl --data-binary @public-schema.sql https://hasura-edit-pg-dump.now.sh > public-schema-edited.sql
 
-  *(The source code for this function can be found on `GitHub
-  <https://github.com/hasura/graphql-engine/tree/master/scripts/edit-pg-dump>`__
-  along with a bash script if you'd prefer that.)*
+  (The source code for this function can be found on `GitHub <https://github.com/hasura/graphql-engine/tree/master/scripts/edit-pg-dump>`__ along with a bash script if you'd prefer that.)
 
 - Create a migration called ``init`` using this SQL file and the metadata that
   is on the server right now:

--- a/docs/graphql/manual/migrations/existing-database.rst
+++ b/docs/graphql/manual/migrations/existing-database.rst
@@ -100,6 +100,10 @@ Step 3: Initialize the migrations as per your current state
      # POST the SQL to a serverless function and save the response
      curl --data-binary @public-schema.sql https://hasura-edit-pg-dump.now.sh > public-schema-edited.sql
 
+  *(The source code for this function can be found on `GitHub
+  <https://github.com/hasura/graphql-engine/tree/master/scripts/edit-pg-dump>`__
+  along with a bash script if you'd prefer that.)*
+
 - Create a migration called ``init`` using this SQL file and the metadata that
   is on the server right now:
 

--- a/scripts/edit-pg-dump/README.md
+++ b/scripts/edit-pg-dump/README.md
@@ -1,12 +1,13 @@
 # hasura-edit-pg-dump
 
 This is a serverless function written in Go and deployed onto now.sh which can
-takes the output SQL from `pg_dump` and clean it up so that it can be used as a
+take the SQL output from `pg_dump` and clean it up so that it can be used as a
 migration file with Hasura.
 
 1. SQL front matter, like `SET` statements are removed.
-2. Comments and empty newlines are removed.
-3. Postgres triggers created by Hasura are removed.
+2. `CREATE SCHEMA public` is removed.
+3. Comments (`--`) and empty newlines are removed.
+4. Postgres triggers created by Hasura for event triggers are removed.
 
 This app is available at https://hasura-edit-pg-dump.now.sh
 

--- a/scripts/edit-pg-dump/edit-pg-dump.sh
+++ b/scripts/edit-pg-dump/edit-pg-dump.sh
@@ -37,6 +37,7 @@ SET client_min_messages = warning;
 SET row_security = off;
 SET default_tablespace = '';
 SET default_with_oids = false;
+CREATE SCHEMA public
 EOF
 
 while read -r line; do
@@ -45,7 +46,7 @@ done <<< $lines
 
 # delete notify triggers
 
-sed -i -E '/^CREATE TRIGGER "?notify_hasura_\w+"? AFTER \w+ ON "?\w+"?\."?\w+"? FOR EACH ROW EXECUTE PROCEDURE "?hdb_views"?\."?notify_hasura_\w+"?\(\);$/d' $filename
+sed -i -E '/^CREATE TRIGGER "?notify_hasura_.+"? AFTER \w+ ON .+ FOR EACH ROW EXECUTE PROCEDURE "?hdb_views"?\."?notify_hasura_.+"?\(\);$/d' $filename
 
 # delete empty lines
 

--- a/scripts/edit-pg-dump/index.go
+++ b/scripts/edit-pg-dump/index.go
@@ -27,7 +27,7 @@ const helpStr = `POST the SQL file contents to this URL:
 
 curl --data-binary @filename.sql https://hasura-edit-pg-dump.now.sh > newfile.sql
 
-Source code can be found athttps://github.com/hasura/graphql-engine/tree/master/scripts/edit-pg-dump `
+Source code can be found at https://github.com/hasura/graphql-engine/tree/master/scripts/edit-pg-dump`
 
 // Handler is the now.sh serverless handler
 func Handler(w http.ResponseWriter, r *http.Request) {

--- a/scripts/edit-pg-dump/index.go
+++ b/scripts/edit-pg-dump/index.go
@@ -20,11 +20,14 @@ var frontMatter = []string{
 	"SET row_security = off;",
 	"SET default_tablespace = '';",
 	"SET default_with_oids = false;",
+	"CREATE SCHEMA public",
 }
 
 const helpStr = `POST the SQL file contents to this URL:
 
-curl --data-binary @filename.sql https://hasura-edit-pg-dump.now.sh > newfile.sql`
+curl --data-binary @filename.sql https://hasura-edit-pg-dump.now.sh > newfile.sql
+
+Source code can be found athttps://github.com/hasura/graphql-engine/tree/master/scripts/edit-pg-dump `
 
 // Handler is the now.sh serverless handler
 func Handler(w http.ResponseWriter, r *http.Request) {
@@ -50,7 +53,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// build the regular expression for matching triggers created by Hasura
-	triggerRe, err := regexp.Compile(`(?m)^CREATE TRIGGER "?notify_hasura_\w+"? AFTER \w+ ON "?\w+"?\."?\w+"? FOR EACH ROW EXECUTE PROCEDURE "?hdb_views"?\."?notify_hasura_\w+"?\(\);$`)
+	triggerRe, err := regexp.Compile(`(?m)^CREATE TRIGGER "?notify_hasura_.+"? AFTER \w+ ON .+ FOR EACH ROW EXECUTE PROCEDURE "?hdb_views"?\."?notify_hasura_.+"?\(\);$`)
 	if err != nil {
 		http.Error(w, err.Error(), 500)
 		return


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
This PR updates the regex in edit-pg-dump script for finding and deleting Hasura event trigger created postgres triggers.

Also adds the link to source code to docs.
### Affected components 
<!-- Remove non-affected components from the list -->

- Docs
- edit-pg-dump

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
close #1959 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
The regex now uses `.+` to match with the table/column name instead of `w+` - which didn't match a dash (`-`)

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
curl --data-binary @file.sql https://hasura-edit-pg-dump.now.sh > cleaned.sql
### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
NA
<!-- Feel free to delete these comment lines -->
