### PR TITLE
 support metadata.json in cli-migrations image (close #1947)

### DIFF
--- a/scripts/cli-migrations/docker-entrypoint.sh
+++ b/scripts/cli-migrations/docker-entrypoint.sh
@@ -54,9 +54,12 @@ if [ -d "$HASURA_GRAPHQL_MIGRATIONS_DIR" ]; then
     cd "$TEMP_MIGRATIONS_DIR"
     echo "endpoint: http://localhost:$HASURA_GRAPHQL_SERVER_PORT" > config.yaml
     hasura-cli migrate apply
-    # check if metadata.yaml exist and apply
+    # check if metadata.[yaml|json] exist and apply
     if [ -f migrations/metadata.yaml ]; then
         log "applying metadata from $HASURA_GRAPHQL_MIGRATIONS_DIR/metadata.yaml"
+        hasura-cli metadata apply
+    elif [ -f migrations/metadata.json ]; then
+        log "applying metadata from $HASURA_GRAPHQL_MIGRATIONS_DIR/metadata.json"
         hasura-cli metadata apply
     fi
 else


### PR DESCRIPTION
### Description
/scripts/cli-migrations/docker-entrypoint.sh only checks for metadata.yaml, however, https://docs.hasura.io/1.0/graphql/manual/migrations/manage-metadata.html#exporting-hasura-metadata talks about a metadata.json

This PR adds support for metadata.json.

### Affected components 
<!-- Remove non-affected components from the list -->

- Build System

### Related Issues
#1947 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
