### PR TITLE
fix bulk queries using more memory (fix #1942)

### DIFF
--- a/server/src-lib/Hasura/Prelude.hs
+++ b/server/src-lib/Hasura/Prelude.hs
@@ -5,32 +5,34 @@ module Hasura.Prelude
   , onLeft
   ) where
 
-import           Control.Applicative    as M ((<|>))
-import           Control.Monad          as M (void, when)
-import           Control.Monad.Base     as M
-import           Control.Monad.Except   as M
-import           Control.Monad.Fail     as M (MonadFail)
-import           Control.Monad.Identity as M
-import           Control.Monad.Reader   as M
-import           Control.Monad.State    as M
-import           Data.Bool              as M (bool)
-import           Data.Either            as M (lefts, partitionEithers, rights)
-import           Data.Foldable          as M (foldrM, toList)
-import           Data.Hashable          as M (Hashable)
-import           Data.List              as M (find, foldl', group, intercalate,
-                                              intersect, lookup, sort, sortBy,
-                                              sortOn, union, unionBy, (\\))
-import           Data.Maybe             as M (catMaybes, fromMaybe, isJust,
-                                              isNothing, listToMaybe, mapMaybe,
-                                              maybeToList)
-import           Data.Ord               as M (comparing)
-import           Data.Semigroup         as M (Semigroup (..))
-import           Data.String            as M (IsString)
-import           Data.Text              as M (Text)
-import           Data.Word              as M (Word64)
-import           GHC.Generics           as M (Generic)
-import           Prelude                as M hiding (fail, init, lookup)
-import           Text.Read              as M (readEither, readMaybe)
+import           Control.Applicative        as M ((<|>))
+import           Control.Monad              as M (void, when)
+import           Control.Monad.Base         as M
+import           Control.Monad.Except       as M
+import           Control.Monad.Fail         as M (MonadFail)
+import           Control.Monad.Identity     as M
+import           Control.Monad.Reader       as M
+import           Control.Monad.State.Strict as M
+import           Data.Bool                  as M (bool)
+import           Data.Either                as M (lefts, partitionEithers,
+                                                  rights)
+import           Data.Foldable              as M (foldrM, toList)
+import           Data.Hashable              as M (Hashable)
+import           Data.List                  as M (find, foldl', group,
+                                                  intercalate, intersect,
+                                                  lookup, sort, sortBy, sortOn,
+                                                  union, unionBy, (\\))
+import           Data.Maybe                 as M (catMaybes, fromMaybe, isJust,
+                                                  isNothing, listToMaybe,
+                                                  mapMaybe, maybeToList)
+import           Data.Ord                   as M (comparing)
+import           Data.Semigroup             as M (Semigroup (..))
+import           Data.String                as M (IsString)
+import           Data.Text                  as M (Text)
+import           Data.Word                  as M (Word64)
+import           GHC.Generics               as M (Generic)
+import           Prelude                    as M hiding (fail, init, lookup)
+import           Text.Read                  as M (readEither, readMaybe)
 
 onNothing :: (Monad m) => Maybe a -> m a -> m a
 onNothing m act = maybe act return m

--- a/server/src-lib/Hasura/RQL/Types.hs
+++ b/server/src-lib/Hasura/RQL/Types.hs
@@ -50,10 +50,10 @@ import           Hasura.RQL.Types.BoolExp      as R
 import           Hasura.RQL.Types.Common       as R
 import           Hasura.RQL.Types.DML          as R
 import           Hasura.RQL.Types.Error        as R
+import           Hasura.RQL.Types.EventTrigger as R
 import           Hasura.RQL.Types.Permission   as R
 import           Hasura.RQL.Types.RemoteSchema as R
 import           Hasura.RQL.Types.SchemaCache  as R
-import           Hasura.RQL.Types.EventTrigger as R
 
 import           Hasura.SQL.Types
 
@@ -165,9 +165,9 @@ instance (MonadTx m) => MonadTx (ReaderT s m) where
   liftTx = lift . liftTx
 
 data LazyTx e a
-  = LTErr e
-  | LTNoTx a
-  | LTTx (Q.TxE e a)
+  = LTErr !e
+  | LTNoTx !a
+  | LTTx !(Q.TxE e a)
 
 lazyTxToQTx :: LazyTx e a -> Q.TxE e a
 lazyTxToQTx = \case


### PR DESCRIPTION
Use 'Strict' State monad instead of 'Lazy' to avoid unevaluated memory
thunks

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Reduce memory usage by `/v1/query` of type `bulk`

### Affected components 
<!-- Remove non-affected components from the list -->

- Server

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
fixes one of the issues causing #1942 


### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
Use `Strict` State Monad from `Control.Monad.State.Strict` module

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
