### PR TITLE
validate input in console's retry config editor, fix #1975

### DIFF
--- a/console/src/components/Services/EventTrigger/Modify/RetryConfEditor.js
+++ b/console/src/components/Services/EventTrigger/Modify/RetryConfEditor.js
@@ -178,7 +178,7 @@ class RetryConfEditor extends React.Component {
             editorExpanded={expanded}
             ongoingRequest={modifyTrigger.ongoingRequest}
             property={'retry'}
-            saveFunc={save}
+            saveFunc={this.validateAndSave}
             service="modify-trigger"
             expandCallback={this.setValues}
             styles={styles}


### PR DESCRIPTION
### Description
See issue #1975 

### Affected components 
Console only

### Solution and Design
Really trivial fix to call an existing method.

### Steps to test and verify
- Open console
- Create an EventTrigger and try to update it's retry config