### PR TITLE
update auto apply migrations doc

### DIFF
--- a/docs/graphql/manual/migrations/auto-apply-migrations.rst
+++ b/docs/graphql/manual/migrations/auto-apply-migrations.rst
@@ -47,7 +47,7 @@ Example:
    docker run -p 8080:8080 \
           -v /home/me/my-project/migrations:/hasura-migrations \
           -e HASURA_GRAPHQL_DATABASE_URL=postgres://postgres:@postgres:5432/postgres \
-          hasura/graphql-engine:v1.0.0-alpha27.cli-migrations
+          hasura/graphql-engine:v1.0.0-alpha42.cli-migrations
 
 
 .. _auto_apply_metadata:


### PR DESCRIPTION
# Updated tag of graphql-engine docker image supporting "rename_relationship" tag field.

### Description
I have been working with hasura cli-migrations so I followed doc here:
https://docs.hasura.io/1.0/graphql/manual/migrations/auto-apply-migrations.html
During migration, I got an error:
`
FATA[0002] apply failed: [parse-failed] When parsing Hasura.Server.Query.RQLQuery expected an Object with a tag field where the value is one of [add_existing_table_or_view, track_table, untrack_table, create_object_relationship, create_array_relationship, drop_relationship, set_relationship_comment, create_insert_permission, create_select_permission, create_update_permission, create_delete_permission, drop_insert_permission, drop_select_permission, drop_update_permission, drop_delete_permission, set_permission_comment, insert, select, update, delete, count, bulk, create_event_trigger, delete_event_trigger, deliver_event, create_query_template, drop_query_template, execute_query_template, set_query_template_comment, run_sql, replace_metadata, export_metadata, clear_metadata, reload_metadata, dump_internal_state], but got rename_relationship. ($[72])
`
then I realised the problem is outdated documetation using hasura graphql-engine in version `v1.0.0-alpha27` which doesn't support `rename_relationship` tag field.

I haven't created an issue as this PR is so small that I hope it's not necessary.

### Affected components 
- Docs

### Related Issues
none
