### PR TITLE
fix incorrect default value map of insert mutation after column drop (close #1991)

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Resolve/ContextTypes.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/ContextTypes.hs
@@ -45,7 +45,7 @@ data UpdPermForIns
 data InsCtx
   = InsCtx
   { icView      :: !QualifiedTable
-  , icColumns   :: ![PGColInfo]
+  , icAllCols   :: ![PGColInfo]
   , icSet       :: !PreSetCols
   , icRelations :: !RelationInfoMap
   , icUpdPerm   :: !(Maybe UpdPermForIns)

--- a/server/src-lib/Hasura/GraphQL/Resolve/Insert.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/Insert.hs
@@ -498,7 +498,7 @@ getInsCtx tn = do
   ctxMap <- asks getter
   insCtx <- onNothing (Map.lookup tn ctxMap) $
     throw500 $ "table " <> tn <<> " not found"
-  let defValMap = S.mkColDefValMap $ map pgiName $ icColumns insCtx
+  let defValMap = S.mkColDefValMap $ map pgiName $ icAllCols insCtx
       setCols = icSet insCtx
   return $ insCtx {icSet = Map.union setCols defValMap}
 

--- a/server/src-lib/Hasura/GraphQL/Schema.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema.hs
@@ -72,14 +72,17 @@ qualObjectToName = G.Name . snakeCaseQualObject
 isValidObjectName :: (ToTxt a) => QualifiedObject a -> Bool
 isValidObjectName = isValidName . qualObjectToName
 
+isValidCol :: PGCol -> Bool
+isValidCol = isValidName . G.Name . getPGColTxt
+
+isValidRel :: ToTxt a => RelName -> QualifiedObject a -> Bool
+isValidRel rn rt = isValidName (G.Name $ getRelTxt rn)
+                          && isValidObjectName rt
+
 isValidField :: FieldInfo -> Bool
 isValidField = \case
-  FIColumn (PGColInfo col _ _) -> isColEligible col
-  FIRelationship (RelInfo rn _ _ remTab _) -> isRelEligible rn remTab
-  where
-    isColEligible = isValidName . G.Name . getPGColTxt
-    isRelEligible rn rt = isValidName (G.Name $ getRelTxt rn)
-                          && isValidObjectName rt
+  FIColumn (PGColInfo col _ _) -> isValidCol col
+  FIRelationship (RelInfo rn _ _ remTab _) -> isValidRel rn remTab
 
 upsertable :: [ConstraintName] -> Bool -> Bool -> Bool
 upsertable uniqueOrPrimaryCons isUpsertAllowed view =
@@ -937,17 +940,13 @@ input table_insert_input {
 -}
 
 mkInsInp
-  :: QualifiedTable -> InsCtx -> InpObjTyInfo
-mkInsInp tn insCtx =
+  :: QualifiedTable -> [PGColInfo] -> RelationInfoMap -> InpObjTyInfo
+mkInsInp tn insCols relInfoMap =
   mkHsraInpTyInfo (Just desc) (mkInsInpTy tn) $ fromInpValL $
   map mkPGColInp insCols <> relInps
   where
     desc = G.Description $
       "input type for inserting data into table " <>> tn
-    cols = icColumns insCtx
-    setCols = Map.keys $ icSet insCtx
-    insCols = flip filter cols $ \ci -> pgiName ci `notElem` setCols
-    relInfoMap = icRelations insCtx
 
     relInps = flip map (Map.toList relInfoMap) $
       \(relName, relInfo) ->
@@ -1228,8 +1227,8 @@ mkOnConflictTypes tn uniqueOrPrimaryCons cols =
 
 mkGCtxRole'
   :: QualifiedTable
-  -- insert perm
-  -> Maybe (InsCtx, Bool)
+  -- insert permission
+  -> Maybe ([PGColInfo], RelationInfoMap)
   -- select permission
   -> Maybe (Bool, [SelField])
   -- update cols
@@ -1251,7 +1250,7 @@ mkGCtxRole' tn insPermM selPermM updColsM
   where
 
     ordByCtx = fromMaybe Map.empty ordByCtxM
-    upsertPerm = or $ fmap snd insPermM
+    upsertPerm = isJust updColsM
     isUpsertable = upsertable constraints upsertPerm $ isJust viM
     updatableCols = maybe [] (map pgiName) updColsM
     onConflictTypes = mkOnConflictTypes tn constraints updatableCols isUpsertable
@@ -1293,14 +1292,12 @@ mkGCtxRole' tn insPermM selPermM updColsM
     mkColFldMap ty cols = Map.fromList $ flip map cols $
       \c -> ((ty, mkColName $ pgiName c), Left c)
 
-    insCtxM = fst <$> insPermM
-    insColsM = icColumns <$> insCtxM
     -- insert input type
-    insInpObjM = mkInsInp tn <$> insCtxM
+    insInpObjM = uncurry (mkInsInp tn) <$> insPermM
     -- column fields used in insert input object
-    insInpObjFldsM = mkColFldMap (mkInsInpTy tn) <$> insColsM
+    insInpObjFldsM = (mkColFldMap (mkInsInpTy tn) . fst) <$> insPermM
     -- relationship input objects
-    relInsInpObjsM = const (mkRelInsInps tn isUpsertable) <$> insCtxM
+    relInsInpObjsM = const (mkRelInsInps tn isUpsertable) <$> insPermM
     -- update set input type
     updSetInpObjM = mkUpdSetInp tn <$> updColsM
     -- update increment input type
@@ -1354,7 +1351,7 @@ mkGCtxRole' tn insPermM selPermM updColsM
       then Just $ mkMutRespObj tn $ isJust selFldsM
       else Nothing
 
-    isMut = (isJust insColsM || isJust updColsM || isJust delPermM)
+    isMut = (isJust insPermM || isJust updColsM || isJust delPermM)
             && any (`isMutable` viM) [viIsInsertable, viIsUpdatable, viIsDeletable]
 
     -- table obj
@@ -1532,12 +1529,12 @@ mkInsCtx role tableCache fields insPermInfo updPermM = do
     let insPermM = getInsPerm remoteTableInfo role
         viewInfoM = tiViewInfo remoteTableInfo
     return $ bool Nothing (Just (relName, relInfo)) $
-      isInsertable insPermM viewInfoM
+      isInsertable insPermM viewInfoM && isValidRel relName remoteTable
 
   let relInfoMap = Map.fromList $ catMaybes relTupsM
-  return $ InsCtx iView cols setCols relInfoMap updPermForIns
+  return $ InsCtx iView allCols setCols relInfoMap updPermForIns
   where
-    cols = getValidCols fields
+    allCols = getCols fields
     rels = getValidRels fields
     iView = ipiView insPermInfo
     setCols = ipiSet insPermInfo
@@ -1561,14 +1558,15 @@ mkAdminInsCtx tn tc fields = do
     remoteTableInfo <- getTabInfo tc remoteTable
     let viewInfoM = tiViewInfo remoteTableInfo
     return $ bool Nothing (Just (relName, relInfo)) $
-      isMutable viIsInsertable viewInfoM
+      isMutable viIsInsertable viewInfoM && isValidRel relName remoteTable
 
   let relInfoMap = Map.fromList $ catMaybes relTupsM
-      updPerm = UpdPermForIns (map pgiName cols) noFilter Map.empty
+      updPerm = UpdPermForIns updCols noFilter Map.empty
 
-  return $ InsCtx tn cols Map.empty relInfoMap (Just updPerm)
+  return $ InsCtx tn allCols Map.empty relInfoMap (Just updPerm)
   where
-    cols = getValidCols fields
+    allCols = getCols fields
+    updCols = map pgiName $ getValidCols fields
     rels = getValidRels fields
 
 mkGCtxRole
@@ -1585,14 +1583,18 @@ mkGCtxRole
   -> m (TyAgg, RootFlds, InsCtxMap)
 mkGCtxRole tableCache tn fields pCols constraints funcs viM role permInfo = do
   selPermM <- mapM (getSelPerm tableCache fields role) $ _permSel permInfo
-  tabInsCtxM <- forM (_permIns permInfo) $ \ipi -> do
-    tic <- mkInsCtx role tableCache fields ipi $ _permUpd permInfo
-    return (tic, isJust $ _permUpd permInfo)
-  let updColsM = filterColInfos . upiCols <$> _permUpd permInfo
-      tyAgg = mkGCtxRole' tn tabInsCtxM selPermM updColsM
+  tabInsInfoM <- forM (_permIns permInfo) $ \ipi -> do
+    ctx <- mkInsCtx role tableCache fields ipi $ _permUpd permInfo
+    let permCols = flip getColInfos allCols $
+                   filter isValidCol $ Set.toList $ ipiCols ipi
+    return (ctx, (permCols, icRelations ctx))
+  let insPermM = snd <$> tabInsInfoM
+      insCtxM = fst <$> tabInsInfoM
+      updColsM = filterColInfos . upiCols <$> _permUpd permInfo
+      tyAgg = mkGCtxRole' tn insPermM selPermM updColsM
               (void $ _permDel permInfo) pColInfos constraints viM funcs
       rootFlds = getRootFldsRole tn pCols constraints fields funcs viM permInfo
-      insCtxMap = maybe Map.empty (Map.singleton tn) $ fmap fst tabInsCtxM
+      insCtxMap = maybe Map.empty (Map.singleton tn) insCtxM
   return (tyAgg, rootFlds, insCtxMap)
   where
     allCols = getCols fields
@@ -1637,7 +1639,7 @@ mkGCtxMapTable tableCache funcCache tabInfo = do
   m <- Map.traverseWithKey
        (mkGCtxRole tableCache tn fields pkeyCols validConstraints tabFuncs viewInfo) rolePerms
   adminInsCtx <- mkAdminInsCtx tn tableCache fields
-  let adminCtx = mkGCtxRole' tn (Just (adminInsCtx, True))
+  let adminCtx = mkGCtxRole' tn (Just (colInfos, icRelations adminInsCtx))
                  (Just (True, selFlds)) (Just colInfos) (Just ())
                  pkeyColInfos validConstraints viewInfo tabFuncs
       adminInsCtxMap = Map.singleton tn adminInsCtx

--- a/server/src-lib/Hasura/RQL/DML/Insert.hs
+++ b/server/src-lib/Hasura/RQL/DML/Insert.hs
@@ -63,11 +63,6 @@ toSQLConflict conflict = case conflict of
       Column pgCols -> S.SQLColumn pgCols
       Constraint cn -> S.SQLConstraint cn
 
-mkDefValMap :: FieldInfoMap -> HM.HashMap PGCol S.SQLExp
-mkDefValMap cim =
-  HM.fromList $ flip zip (repeat $ S.SEUnsafe "DEFAULT") $
-  map (PGCol . getFieldNameTxt) $ HM.keys $ HM.filter isPGColInfo cim
-
 getInsertDeps
   :: InsertQueryP1 -> [SchemaDependency]
 getInsertDeps (InsertQueryP1 tn _ _ _ _ mutFlds _) =
@@ -201,7 +196,8 @@ convInsertQuery objsParser prepFn (InsertQuery tableName val oC mRetCols) = do
 
   let mutFlds = mkDefaultMutFlds mAnnRetCols
 
-  let defInsVals = mkDefValMap fieldInfoMap
+  let defInsVals = S.mkColDefValMap $
+                   map pgiName $ getCols fieldInfoMap
       allCols    = getCols fieldInfoMap
       insCols    = HM.keys defInsVals
       insView    = ipiView insPerm

--- a/server/src-lib/Hasura/RQL/DML/Internal.hs
+++ b/server/src-lib/Hasura/RQL/DML/Internal.hs
@@ -45,12 +45,10 @@ mkAdminRolePermInfo :: TableInfo -> RolePermInfo
 mkAdminRolePermInfo ti =
   RolePermInfo (Just i) (Just s) (Just u) (Just d)
   where
-    pgCols = map pgiName
-      . fst . partitionEithers
-      . map fieldInfoToEither . M.elems $ tiFieldInfoMap ti
+    pgCols = map pgiName $ getCols $ tiFieldInfoMap ti
 
     tn = tiName ti
-    i = InsPermInfo tn annBoolExpTrue M.empty []
+    i = InsPermInfo (HS.fromList pgCols) tn annBoolExpTrue M.empty []
     s = SelPermInfo (HS.fromList pgCols) tn annBoolExpTrue
         Nothing True []
     u = UpdPermInfo (HS.fromList pgCols) tn annBoolExpTrue M.empty []

--- a/server/src-lib/Hasura/RQL/Types/SchemaCache.hs
+++ b/server/src-lib/Hasura/RQL/Types/SchemaCache.hs
@@ -103,10 +103,10 @@ import           Hasura.RQL.Types.BoolExp
 import           Hasura.RQL.Types.Common
 import           Hasura.RQL.Types.DML
 import           Hasura.RQL.Types.Error
+import           Hasura.RQL.Types.EventTrigger
 import           Hasura.RQL.Types.Permission
 import           Hasura.RQL.Types.RemoteSchema
 import           Hasura.RQL.Types.SchemaCacheTypes
-import           Hasura.RQL.Types.EventTrigger
 import           Hasura.SQL.Types
 
 import           Control.Lens
@@ -196,7 +196,8 @@ isPGColInfo _            = False
 
 data InsPermInfo
   = InsPermInfo
-  { ipiView            :: !QualifiedTable
+  { ipiCols            :: !(HS.HashSet PGCol)
+  , ipiView            :: !QualifiedTable
   , ipiCheck           :: !AnnBoolExpSQL
   , ipiSet             :: !PreSetCols
   , ipiRequiredHeaders :: ![T.Text]


### PR DESCRIPTION

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

via @timgreen

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Affected components 
<!-- Remove non-affected components from the list -->

- Server

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
fix #1991 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
Do not union `preset` columns map with default values map of all columns while constructing `InsPermInfo` type.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
- Define a table with insert permission on any role
- Drop a column via console
- Perform insert mutation 
