### PR TITLE
Better introspection query caching

### DIFF
--- a/server/src-lib/Hasura/EncJSON.hs
+++ b/server/src-lib/Hasura/EncJSON.hs
@@ -5,6 +5,7 @@ module Hasura.EncJSON
   ( EncJSON
   , encJFromBuilder
   , encJToLBS
+  , encJToBS
   , encJFromJValue
   , encJFromChar
   , encJFromText
@@ -36,6 +37,10 @@ instance Q.FromCol EncJSON where
 encJToLBS :: EncJSON -> BL.ByteString
 encJToLBS = BB.toLazyByteString . unEncJSON
 {-# INLINE encJToLBS #-}
+
+encJToBS :: EncJSON -> B.ByteString
+encJToBS = BL.toStrict . encJToLBS
+{-# INLINE encJToBS #-}
 
 encJFromBuilder :: BB.Builder -> EncJSON
 encJFromBuilder = EncJSON


### PR DESCRIPTION
Changes the internal data structure used for caching introspection query result. This reduces the CPU load when retrieving introspection result from cache. 

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) --> closes #1942 


