### PR TITLE
candidate id shouldn't be part of the plan in multiplexed subscriptions

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Execute.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute.hs
@@ -158,7 +158,7 @@ getResolvedExecPlan pgExecCtx planCache userInfo sqlGenCtx
       EP.RPQuery queryPlan ->
         ExOpQuery <$> EQ.queryOpFromPlan usrVars queryVars queryPlan
       EP.RPSubs subsPlan ->
-        ExOpSubs <$> EL.subsOpFromPlan pgExecCtx queryVars subsPlan
+        ExOpSubs <$> EL.subsOpFromPlan pgExecCtx usrVars queryVars subsPlan
     Nothing -> noExistingPlan
   where
     GQLReq opNameM queryStr queryVars = reqUnparsed

--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery.hs
@@ -207,10 +207,11 @@ subsOpFromPGAST pgExecCtx reqUnparsed varDefs (fldAls, astUnresolved) = do
       (astResolved, annVarVals) <-
         flip runStateT mempty $ GR.traverseQueryRootFldAST
         toMultiplexedQueryVar astUnresolved
-      let mxOpCtx = LQM.mkMxOpCtx userInfo reqUnparsed fldAls $
+      let mxOpCtx = LQM.mkMxOpCtx (userRole userInfo)
+                    (GH._grQuery reqUnparsed) fldAls $
                     GR.toPGQuery astResolved
       txtEncodedVars <- validateAnnVarValsOnPg pgExecCtx annVarVals
-      let mxOp = (mxOpCtx, txtEncodedVars)
+      let mxOp = (mxOpCtx, userVars userInfo, txtEncodedVars)
       return (LQMultiplexed mxOp, Just $ SubsPlan mxOpCtx varTypes)
 
     -- fallback tx subscription
@@ -274,10 +275,11 @@ subsOpFromPlan
      , MonadIO m
      )
   => PGExecCtx
+  -> UserVars
   -> Maybe GH.VariableValues
   -> SubsPlan
   -> m LiveQueryOp
-subsOpFromPlan pgExecCtx varValsM (SubsPlan mxOpCtx varTypes) = do
+subsOpFromPlan pgExecCtx usrVars varValsM (SubsPlan mxOpCtx varTypes) = do
   annVarVals <- GV.getAnnPGVarVals varTypes varValsM
   txtEncodedVars <- validateAnnVarValsOnPg pgExecCtx annVarVals
-  return $ LQMultiplexed (mxOpCtx, txtEncodedVars)
+  return $ LQMultiplexed (mxOpCtx, usrVars, txtEncodedVars)

--- a/server/src-lib/Hasura/SQL/Value.hs
+++ b/server/src-lib/Hasura/SQL/Value.hs
@@ -49,7 +49,14 @@ data PGColValue
 data TxtEncodedPGVal
   = TENull
   | TELit !Text
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
+
+instance Hashable TxtEncodedPGVal
+
+instance ToJSON TxtEncodedPGVal where
+  toJSON = \case
+    TENull  -> Null
+    TELit t -> String t
 
 txtEncodedPGVal :: PGColValue -> TxtEncodedPGVal
 txtEncodedPGVal colVal = case colVal of


### PR DESCRIPTION
candidate id is incorrectly cached in multiplexed subscriptions plan. This could result in subscriptions returning incorrect data. This PR fixes it.