### PR TITLE
add headers at request level in console (for better DX)

### DIFF
--- a/console/src/utils/requestAction.js
+++ b/console/src/utils/requestAction.js
@@ -31,7 +31,10 @@ const requestAction = (
 
   return (dispatch, getState) => {
     if (includeDataHeaders) {
-      options.headers = getState().tables.dataHeaders;
+      options.headers = {
+        ...options.headers,
+        ...getState().tables.dataHeaders
+      };
     }
     const p1 = new Promise((resolve, reject) => {
       dispatch({ type: LOAD_REQUEST });

--- a/console/src/utils/requestAction.js
+++ b/console/src/utils/requestAction.js
@@ -18,13 +18,21 @@ const requestAction = (
   options,
   SUCCESS,
   ERROR,
-  includeCredentials = true
+  includeCredentials = true,
+  includeDataHeaders
 ) => {
   if (!options.credentials && includeCredentials) {
     options.credentials = 'omit';
   }
 
-  return dispatch => {
+  if (!options.headers) {
+    options.headers = {};
+  }
+
+  return (dispatch, getState) => {
+    if (includeDataHeaders) {
+      options.headers = getState().tables.dataHeaders;
+    }
     const p1 = new Promise((resolve, reject) => {
       dispatch({ type: LOAD_REQUEST });
       fetch(url, options).then(


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

Currently, everytime you have to add headers with a request in console, you need to access it from redux and pass it. These headers are never really changed. In this PR, I have added a boolean argument to the [requestAction](https://github.com/wawhal/graphql-engine/blob/2ca00aec18c7d60c1b82082a3650ff685d49c690/console/src/utils/requestAction.js#L33) function so that you can easily include headers whenever required.

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Affected components 
<!-- Remove non-affected components from the list -->

- Console

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
None

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
```js
const requestAction = (
  url,
  options,
  otherArguments,
  includeDataHeaders
) => {
  if (!options.headers) {
    options.headers = {};
  }

  if (includeDataHeaders) {
    options.headers = { ...options.headers, ...getState().tables.dataHeaders };
  }
}
```

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Not being used anywhere right now, but can be used here on.

