### PR TITLE
multiplexed subscription improvements

### DIFF
--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -290,7 +290,7 @@ library
   if flag(profile)
     ghc-prof-options: -rtsopts -fprof-auto -fno-prof-count-entries
   if flag(developer)
-    cpp-options: -DInternalAPIs -DLocalConsole
+    cpp-options: -DDeveloperAPIs -DLocalConsole
   if flag(local-console)
     cpp-options: -DLocalConsole
 

--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery.hs
@@ -69,9 +69,9 @@ data LiveQueriesState
   }
 
 dumpLiveQueriesState
-  :: LiveQueriesState -> IO J.Value
-dumpLiveQueriesState (LiveQueriesState mx fallback _) = do
-  mxJ <- LQM.dumpLiveQueriesState mx
+  :: Bool -> LiveQueriesState -> IO J.Value
+dumpLiveQueriesState extended (LiveQueriesState mx fallback _) = do
+  mxJ <- LQM.dumpLiveQueriesState extended mx
   fallbackJ <- LQF.dumpLiveQueriesState fallback
   return $ J.object
     [ "fallback" J..= fallbackJ


### PR DESCRIPTION
1. faster snapshotting of the internal state for mx subs
2. expose dev apis to monitor the internal state of mx subs

Affects server.

The internal dev APIs can be enabled by passing `developer` to `--enabled-apis`. The dev APIs structure is as follows:
```
GET "/dev/subscriptions"
Use this to monitor multixplexed subscriptions

GET "/dev/subscriptions/extended"
This dumps a lot of data, including individual subscriptions, their arguments, session variables

GET "/dev/plan_cache"
Dumps the plan cache for queries and subscriptions
```
All of these are admin only endpoints and not enabled by default except when compiled with `--developer` flag. 