### PR TITLE
update schema cache on columns' null-ability or type changes (fix #2101)

### DIFF
--- a/server/src-lib/Hasura/RQL/DDL/Schema/Table.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Table.hs
@@ -181,8 +181,10 @@ processTableChanges ti tableDiff = do
             " as a relationship with the name already exists"
           _ -> addColToCache colName pci tn
 
-    procAlteredCols sc tn = fmap or $
-      forM alteredCols $ \(PGColInfo oColName oColTy _, PGColInfo nColName nColTy _) ->
+    procAlteredCols sc tn = fmap or $ forM alteredCols $
+      \( PGColInfo oColName oColTy oNullable
+       , npci@(PGColInfo nColName nColTy nNullable)
+       ) ->
         if | oColName /= nColName -> do
                renameColInCatalog oColName nColName tn ti
                return True
@@ -193,6 +195,10 @@ processTableChanges ti tableDiff = do
                  "cannot change type of column " <> oColName <<> " in table "
                  <> tn <<> " because of the following dependencies : " <>
                  reportSchemaObjs depObjs
+               updColInCache nColName npci tn
+               return False
+           | oNullable /= nNullable -> do
+               updColInCache nColName npci tn
                return False
            | otherwise -> return False
 

--- a/server/src-lib/Hasura/RQL/Types/SchemaCache.hs
+++ b/server/src-lib/Hasura/RQL/Types/SchemaCache.hs
@@ -47,6 +47,7 @@ module Hasura.RQL.Types.SchemaCache
        , addRelToCache
 
        , delColFromCache
+       , updColInCache
        , delRelFromCache
 
        , RolePermInfo(..)
@@ -621,6 +622,14 @@ delRelFromCache rn tn = do
   modDepMapInCache (removeFromDepMap schObjId)
   where
     schObjId = SOTableObj tn $ TORel rn
+
+updColInCache
+  :: (QErrM m, CacheRWM m)
+  => PGCol -> PGColInfo
+  -> QualifiedTable -> m ()
+updColInCache cn ci tn = do
+  delColFromCache cn tn
+  addColToCache cn ci tn
 
 data PermAccessor a where
   PAInsert :: PermAccessor InsPermInfo

--- a/server/tests-py/queries/graphql_query/basic/select_query_user_col_change.yaml
+++ b/server/tests-py/queries/graphql_query/basic/select_query_user_col_change.yaml
@@ -1,0 +1,61 @@
+- description: Alter column id of user table to integer
+  url: /v1/query
+  status: 200
+  query:
+    type: run_sql
+    args:
+      sql: |
+        ALTER TABLE "user" ALTER COLUMN id set data type integer;
+
+- description: Query data from user table
+  url: /v1alpha1/graphql
+  status: 200
+  response:
+    data:
+      user:
+      - id: 1
+        name: User 1
+        number: '123456789'
+      - id: 2
+        name: User 2
+        number: '123456780'
+  query:
+    query: |
+      query {
+        user{
+          id
+          name
+          number
+        }
+      }
+
+- description: Alter column id of user table to bigint
+  url: /v1/query
+  status: 200
+  query:
+    type: run_sql
+    args:
+      sql: |
+        ALTER TABLE "user" ALTER COLUMN id set data type bigint;
+
+- description: Query data from user table
+  url: /v1alpha1/graphql
+  status: 200
+  response:
+    data:
+      user:
+      - id: '1'
+        name: User 1
+        number: '123456789'
+      - id: '2'
+        name: User 2
+        number: '123456780'
+  query:
+    query: |
+      query {
+        user{
+          id
+          name
+          number
+        }
+      }

--- a/server/tests-py/test_graphql_queries.py
+++ b/server/tests-py/test_graphql_queries.py
@@ -43,6 +43,9 @@ class TestGraphQLQueryBasic(DefaultTestSelectQueries):
     def test_select_query_col_not_present_err(self, hge_ctx, transport):
         check_query_f(hge_ctx, self.dir() + "/select_query_author_col_not_present_err.yaml", transport)
 
+    def test_select_query_user_col_change(self, hge_ctx, transport):
+        check_query_f(hge_ctx, self.dir() + "/select_query_user_col_change.yaml", transport)
+
     @classmethod
     def dir(cls):
         return 'queries/graphql_query/basic'


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

If a user tries to update column nullability or it's type via `modify table` or `SQL` section of the console then update the cache with new column info.

[via @anisjonischkeit]
### Affected components 
<!-- Remove non-affected components from the list -->

- Server
- Tests

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
fix #2101 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

Update `PGColInfo` of a column on any of `pgiType` and `pgiIsNullable` change via `run_sql` `/v1/query` metadata query.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

Create a table and modify any column's nullability or type. This change should reflect in GraphQL schema. 
