### PR TITLE
fix console expandable editor component styling

### DIFF
--- a/console/src/components/Common/Layout/ExpandableEditor/Editor.js
+++ b/console/src/components/Common/Layout/ExpandableEditor/Editor.js
@@ -32,9 +32,10 @@ class Editor extends React.Component {
     if (this.props.isCollapsable === false && this.state.isEditing) {
       return null;
     }
+
     return (
       <Button
-        className={`${styles.add_mar_small} ${styles.add_mar_bottom_mid}`}
+        className={`${styles.add_mar_small}`}
         color="white"
         size="xs"
         data-test={`${this.props.service}-${
@@ -133,7 +134,7 @@ class Editor extends React.Component {
 
     return (
       <div className={editorClass}>
-        <div className={styles.display_flex}>
+        <div className={styles.display_flex + ' ' + styles.add_mar_bottom_mid}>
           {this.toggleButton()}
           {editorLabel}
         </div>

--- a/console/src/components/Common/Layout/ExpandableEditor/Editor.scss
+++ b/console/src/components/Common/Layout/ExpandableEditor/Editor.scss
@@ -10,7 +10,7 @@
 
 .editorCollapsed {
   display: block;
-  margin-bottom: 10px;
+  margin-bottom: 20px;
 }
 
 .editorContent {

--- a/console/src/components/Services/Data/Add/ForeignKeyWrapper.js
+++ b/console/src/components/Services/Data/Add/ForeignKeyWrapper.js
@@ -4,8 +4,6 @@ import ForeignKeySelector from '../Common/ReusableComponents/ForeignKeySelector'
 import { getForeignKeyConfig } from '../Common/ReusableComponents/utils';
 import { setForeignKeys, toggleFk, clearFkToggle } from './AddActions';
 
-import styles from '../../../Common/TableCommon/Table.scss';
-
 const ForeignKeyWrapper = ({
   foreignKeys,
   allSchemas,
@@ -75,24 +73,13 @@ const ForeignKeyWrapper = ({
       collapsedLabelText = <i>(You can add foreign keys later as well)</i>;
     }
 
-    const collapsedLabel = () => (
-      <div>
-        <div className="container-fluid">
-          <div className="row">
-            <h5 className={styles.padd_bottom}>
-              {collapsedLabelText}
-              &nbsp;
-            </h5>
-          </div>
-        </div>
-      </div>
-    );
+    const collapsedLabel = () => <div>{collapsedLabelText}</div>;
 
     const expandedLabel = () => {
       return (
-        <h5 className={styles.padd_bottom}>
+        <div>
           <b>{fkConfig}</b>
-        </h5>
+        </div>
       );
     };
 

--- a/console/src/components/Services/Data/TableModify/ColumnEditorList.js
+++ b/console/src/components/Services/Data/TableModify/ColumnEditorList.js
@@ -105,14 +105,7 @@ const ColumnEditorList = ({
     const collapsedLabel = () => {
       return (
         <div key={colName}>
-          <div className="container-fluid">
-            <div className="row">
-              <h5 className={styles.padd_bottom}>
-                <b>{colName}</b> {keyProperties()}
-                &nbsp;
-              </h5>
-            </div>
-          </div>
+          <b>{colName}</b> {keyProperties()}
         </div>
       );
     };
@@ -120,14 +113,7 @@ const ColumnEditorList = ({
     const expandedLabel = () => {
       return (
         <div key={colName}>
-          <div className="container-fluid">
-            <div className="row">
-              <h5 className={styles.padd_bottom}>
-                <b>{colName}</b>
-                &nbsp;
-              </h5>
-            </div>
-          </div>
+          <b>{colName}</b>
         </div>
       );
     };

--- a/console/src/components/Services/Data/TableModify/ForeignKeyEditor.js
+++ b/console/src/components/Services/Data/TableModify/ForeignKeyEditor.js
@@ -12,8 +12,6 @@ import {
 import ExpandableEditor from '../../../Common/Layout/ExpandableEditor/Editor';
 import ForeignKeySelector from '../Common/ReusableComponents/ForeignKeySelector';
 
-import styles from './ModifyTable.scss';
-
 const ForeignKeyEditor = ({ tableSchema, allSchemas, dispatch, fkModify }) => {
   const columns = tableSchema.columns.sort(ordinalColSort);
 
@@ -70,18 +68,7 @@ const ForeignKeyEditor = ({ tableSchema, allSchemas, dispatch, fkModify }) => {
       const collapsedLabelText =
         isLast && numFks === 1 ? 'No foreign keys' : getFkConfigLabel(fkConfig);
 
-      return (
-        <div>
-          <div className="container-fluid">
-            <div className="row">
-              <h5 className={styles.padd_bottom}>
-                {collapsedLabelText}
-                &nbsp;
-              </h5>
-            </div>
-          </div>
-        </div>
-      );
+      return <div>{collapsedLabelText}</div>;
     };
 
     // The content when the editor is expanded
@@ -115,11 +102,7 @@ const ForeignKeyEditor = ({ tableSchema, allSchemas, dispatch, fkModify }) => {
         orderedColumns
       );
 
-      return (
-        <h5 className={styles.padd_bottom}>
-          {getFkConfigLabel(existingFkConfig)}
-        </h5>
-      );
+      return <div>{getFkConfigLabel(existingFkConfig)}</div>;
     };
 
     // If the user made some changes and collapses the editor, the changes are lost

--- a/console/src/components/Services/Data/TableModify/PrimaryKeyEditor.js
+++ b/console/src/components/Services/Data/TableModify/PrimaryKeyEditor.js
@@ -54,22 +54,11 @@ const PrimaryKeyEditor = ({
   }
 
   const pkEditorCollapsedLabel = () => (
-    <div>
-      <div className="container-fluid">
-        <div className="row">
-          <h5 className={styles.padd_bottom}>
-            {pkConfigText ? pkConfigText : 'No primary key'}
-            &nbsp;
-          </h5>
-        </div>
-      </div>
-    </div>
+    <div>{pkConfigText ? pkConfigText : 'No primary key'}</div>
   );
 
   // label next to the button when the editor is expanded
-  const pkEditorExpandedLabel = () => (
-    <h5 className={styles.padd_bottom}>{pkConfigText}</h5>
-  );
+  const pkEditorExpandedLabel = () => <div>{pkConfigText}</div>;
 
   // expanded editor content
   const pkEditorExpanded = () => (


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Change styling of expandable editor to have expand btn and label center aligned automatically

### Affected components 
<!-- Remove non-affected components from the list -->

- Console


### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Check if all expandable editor uses are rendered correcty

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
