### PR TITLE
fix relationship rename for foreign schemas (closes #1777)

### DIFF
--- a/console/src/components/Services/Data/TableRelationships/Actions.js
+++ b/console/src/components/Services/Data/TableRelationships/Actions.js
@@ -47,7 +47,10 @@ const saveRenameRelationship = (oldName, newName, tableName, callback) => {
       {
         type: 'rename_relationship',
         args: {
-          table: tableName,
+          table: {
+            name: tableName,
+            schema: currentSchema,
+          },
           name: oldName,
           new_name: newName,
         },
@@ -57,7 +60,10 @@ const saveRenameRelationship = (oldName, newName, tableName, callback) => {
       {
         type: 'rename_relationship',
         args: {
-          table: tableName,
+          table: {
+            name: tableName,
+            schema: currentSchema,
+          },
           name: newName,
           new_name: oldName,
         },


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->
#1777 

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->


### Affected components 
<!-- Remove non-affected components from the list -->

- Console

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#1777 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

In the relationship rename API, table was being sent as string (hence it worked only for public schema). This PR sends table as:
```js
{
  name: "tablename",
  schema: "schemaname"
}
```

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
1. Create a new schema
2. Create two interrelated tables in the new schema and create relationships between them
3. Renaming the relationships should work as expected

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
