### PR TITLE
add skip diff functionality for update events (fix #2087)

### DIFF
--- a/server/src-lib/Hasura/RQL/DDL/EventTrigger.hs
+++ b/server/src-lib/Hasura/RQL/DDL/EventTrigger.hs
@@ -6,8 +6,6 @@ module Hasura.RQL.DDL.EventTrigger
   , RedeliverEventQuery
   , runRedeliverEvent
   , runInvokeEventTrigger
-
-  -- TODO: review
   , delEventTriggerFromCatalog
   , subTableP2
   , subTableP2Setup
@@ -79,15 +77,25 @@ getTriggerSql op trn qt allCols strfyNum spec =
       else
         False
 
-    createOpCtx op1 (SubscribeOpSpec columns payload) =
-      HashMap.fromList
-      [ (T.pack "SHOULD_DIFF", T.pack $ show $ shouldDiff op1 columns )
-      , (T.pack "OPERATION", T.pack $ show op1)
-      , (T.pack "OLD_ROW", toSQLTxt $ renderRow OLD columns )
-      , (T.pack "NEW_ROW", toSQLTxt $ renderRow NEW columns )
-      , (T.pack "OLD_PAYLOAD_EXPRESSION", toSQLTxt $ renderOldDataExp op1 $ fromMaybePayload payload )
-      , (T.pack "NEW_PAYLOAD_EXPRESSION", toSQLTxt $ renderNewDataExp op1 $ fromMaybePayload payload )
-      ]
+    createOpCtx op1 spec' = case spec' of
+      InsDelSpec payload -> HashMap.fromList
+        [ (T.pack "OLD_PAYLOAD_EXPRESSION",
+           toSQLTxt $ renderOldDataExp op1 $ getPayloadCols payload )
+        , (T.pack "NEW_PAYLOAD_EXPRESSION",
+           toSQLTxt $ renderNewDataExp op1 $ getPayloadCols payload )
+        ]
+      UpdSpec payload listenCols -> HashMap.fromList
+        [ (T.pack "SHOULD_DIFF",
+           T.pack $ show $ shouldDiff op1 (getListenCols listenCols))
+        , (T.pack "OLD_ROW",
+           toSQLTxt $ renderRow OLD (getListenCols listenCols))
+        , (T.pack "NEW_ROW",
+           toSQLTxt $ renderRow NEW (getListenCols listenCols))
+        , (T.pack "OLD_PAYLOAD_EXPRESSION",
+           toSQLTxt $ renderOldDataExp op1 $ getPayloadCols payload )
+        , (T.pack "NEW_PAYLOAD_EXPRESSION",
+           toSQLTxt $ renderNewDataExp op1 $ getPayloadCols payload )
+        ]
     renderOldDataExp op2 scs =
       case op2 of
         INSERT -> S.SEUnsafe "NULL"
@@ -122,8 +130,6 @@ getTriggerSql op trn qt allCols strfyNum spec =
         SubCArray cols -> applyRow $
           S.mkRowExp $ map (toExtr . mkQId opVar) $
           getColInfos cols allCols
-
-    fromMaybePayload = fromMaybe SubCStar
 
 mkAllTriggersQ
   :: TriggerName
@@ -231,28 +237,55 @@ markForDelivery eid =
           WHERE id = $1
           |] (Identity eid) True
 
-subTableP1 :: (UserInfoM m, QErrM m, CacheRM m) => CreateEventTriggerQuery -> m (QualifiedTable, Bool, EventTriggerConf)
-subTableP1 (CreateEventTriggerQuery name qt insert update delete enableManual retryConf webhook webhookFromEnv mheaders replace) = do
+subTableP1
+  :: (UserInfoM m, QErrM m, CacheRM m)
+  => CreateEventTriggerQuery
+  -> m (QualifiedTable, Bool, EventTriggerConf)
+subTableP1 (CreateEventTriggerQuery
+            name
+            qt
+            insert
+            update
+            delete
+            enableManual
+            retryConf
+            webhook
+            webhookFromEnv
+            mheaders
+            replace) = do
   adminOnly
   ti <- askTabInfo qt
   -- can only replace for same table
   when replace $ do
     ti' <- askTabInfoFromTrigger name
-    when (tiName ti' /= tiName ti) $ throw400 NotSupported "cannot replace table or schema for trigger"
+    when (tiName ti' /= tiName ti) $
+      throw400 NotSupported "cannot replace table or schema for trigger"
 
-  assertCols ti insert
-  assertCols ti update
-  assertCols ti delete
+  onJust insert $ assertCols ti
+  onJust update $ assertCols ti
+  onJust delete $ assertCols ti
 
   let rconf = fromMaybe defaultRetryConf retryConf
-  return (qt, replace, EventTriggerConf name (TriggerOpsDef insert update delete enableManual) webhook webhookFromEnv rconf mheaders)
+      etc = EventTriggerConf
+            name
+            (TriggerOpsDef insert update delete enableManual)
+            webhook
+            webhookFromEnv
+            rconf
+            mheaders
+  return (qt, replace, etc)
   where
-    assertCols _ Nothing = return ()
-    assertCols ti (Just sos) = do
-      let cols = sosColumns sos
-      case cols of
+    assertCols ti spec = case spec of
+      InsDelSpec (PayloadColumns cols) -> case cols of
         SubCStar         -> return ()
         SubCArray pgcols -> forM_ pgcols (assertPGCol (tiFieldInfoMap ti) "")
+      UpdSpec (PayloadColumns payload) (ListenColumns listenCols) -> do
+        case payload of
+          SubCStar         -> return ()
+          SubCArray pgcols -> forM_ pgcols (assertPGCol (tiFieldInfoMap ti) "")
+        case listenCols of
+          SubCStar         -> return ()
+          SubCArray pgcols -> forM_ pgcols (assertPGCol (tiFieldInfoMap ti) "")
 
 --(QErrM m, CacheRWM m, MonadTx m, MonadIO m)
 
@@ -280,13 +313,19 @@ getTrigDefDeps qt (TriggerOpsDef mIns mUpd mDel _) =
   where
     subsOpSpecDeps :: SubscribeOpSpec -> [SchemaDependency]
     subsOpSpecDeps os =
-      let cols = getColsFromSub $ sosColumns os
-          colDeps = flip map cols $ \col ->
-            SchemaDependency (SOTableObj qt (TOCol col)) "column"
-          payload = maybe [] getColsFromSub (sosPayload os)
+      let listenCols = getListenColsFromSub os
+          listenColDeps = flip map listenCols $ \col ->
+            SchemaDependency (SOTableObj qt (TOCol col)) "listen column"
+          payload = getPayloadColsFromSub os
           payloadDeps = flip map payload $ \col ->
             SchemaDependency (SOTableObj qt (TOCol col)) "payload"
-        in colDeps <> payloadDeps
+        in listenColDeps <> payloadDeps
+    getListenColsFromSub spec = case spec of
+      InsDelSpec _                   -> []
+      UpdSpec _ (ListenColumns cols) -> getColsFromSub cols
+    getPayloadColsFromSub spec = case spec of
+      InsDelSpec (PayloadColumns payload) -> getColsFromSub payload
+      UpdSpec (PayloadColumns payload) _  -> getColsFromSub payload
     getColsFromSub sc = case sc of
       SubCStar         -> []
       SubCArray pgcols -> pgcols

--- a/server/src-lib/Hasura/RQL/DDL/Schema/Rename.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Rename.hs
@@ -331,10 +331,13 @@ updateColInEventTriggerDef trigName rnCol = do
       SubCStar       -> SubCStar
       SubCArray cols -> SubCArray $
                         map (getNewCol rnCol trigTab) cols
-    rewriteOpSpec trigTab (SubscribeOpSpec cols payload) =
-      SubscribeOpSpec
-      (rewriteSubsCols trigTab cols)
-      (rewriteSubsCols trigTab <$> payload)
+    rewriteOpSpec trigTab spec = case spec of
+      InsDelSpec (PayloadColumns payload) ->
+        InsDelSpec (PayloadColumns $ rewriteSubsCols trigTab payload)
+      UpdSpec (PayloadColumns payload) (ListenColumns listenCols) ->
+        UpdSpec
+        (PayloadColumns $ rewriteSubsCols trigTab payload)
+        (ListenColumns $ rewriteSubsCols trigTab listenCols)
     rewriteTrigOpsDef trigTab (TriggerOpsDef ins upd del man) =
       TriggerOpsDef
       (rewriteOpSpec trigTab <$> ins)

--- a/server/src-lib/Hasura/RQL/Types/EventTrigger.hs
+++ b/server/src-lib/Hasura/RQL/Types/EventTrigger.hs
@@ -11,6 +11,8 @@ module Hasura.RQL.Types.EventTrigger
   , DeleteEventTriggerQuery(..)
   , RedeliverEventQuery(..)
   , InvokeEventTriggerQuery(..)
+  , ListenColumns(..)
+  , PayloadColumns(..)
   -- , HeaderConf(..)
   -- , HeaderValue(..)
   -- , HeaderName
@@ -52,13 +54,47 @@ instance ToJSON SubscribeColumns where
   toJSON SubCStar         = "*"
   toJSON (SubCArray cols) = toJSON cols
 
-data SubscribeOpSpec
-  = SubscribeOpSpec
-  { sosColumns :: !SubscribeColumns
-  , sosPayload :: !(Maybe SubscribeColumns)
-  } deriving (Show, Eq, Lift)
+newtype ListenColumns
+  = ListenColumns {
+      getListenCols :: SubscribeColumns
+    }
+  deriving (Show, Eq, Lift)
 
-$(deriveJSON (aesonDrop 3 snakeCase){omitNothingFields=True} ''SubscribeOpSpec)
+newtype PayloadColumns
+  = PayloadColumns {
+      getPayloadCols :: SubscribeColumns
+    }
+  deriving (Show, Eq, Lift)
+
+data SubscribeOpSpecOpt
+  = SubscribeOpSpecOpt
+  { sosoColumns :: !(Maybe SubscribeColumns)
+  , sosoPayload :: !(Maybe SubscribeColumns)
+  }
+  deriving (Show, Eq, Lift)
+
+$(deriveFromJSON (aesonDrop 4 snakeCase){omitNothingFields=True} ''SubscribeOpSpecOpt)
+
+data SubscribeOpSpec = InsDelSpec PayloadColumns | UpdSpec PayloadColumns ListenColumns
+  deriving (Show, Eq, Lift)
+
+instance ToJSON SubscribeOpSpec where
+  toJSON (InsDelSpec payload)    = object
+    [ "payload" .= (toJSON $ getPayloadCols payload) ]
+  toJSON (UpdSpec payload listen) = object
+    [ "payload" .= (toJSON $ getPayloadCols payload)
+    , "columns" .= (toJSON $ getListenCols listen)
+    ]
+
+instance FromJSON SubscribeOpSpec where
+  parseJSON (Object v) = parseUpdSpec v <|> parseInsDelSpec v
+    where
+    parseUpdSpec obj = UpdSpec
+                       <$> (PayloadColumns <$> obj .: "payload")
+                       <*> (ListenColumns <$> obj .: "columns")
+    parseInsDelSpec obj = InsDelSpec
+                          <$> (PayloadColumns <$> obj .: "payload")
+  parseJSON _          = fail "expected object for operation spec"
 
 defaultNumRetries :: Int
 defaultNumRetries = 0
@@ -147,12 +183,35 @@ instance FromJSON CreateEventTriggerQuery where
       (Just _, Just _)  -> fail "only one of webhook or webhook_from_env should be given"
       _ ->   fail "must provide webhook or webhook_from_env"
     mapM_ checkEmptyCols [insert, update, delete]
-    return $ CreateEventTriggerQuery name table insert update delete (Just enableManual) retryConf webhook webhookFromEnv headers replace
+    let insert' = fmap mergeInsDefaults insert
+        update' = fmap mergeUpdDefaults update
+        delete' = fmap mergeDelDefaults delete
+    return $ CreateEventTriggerQuery
+      name
+      table
+      insert'
+      update'
+      delete'
+      (Just enableManual)
+      retryConf
+      webhook
+      webhookFromEnv
+      headers
+      replace
     where
       checkEmptyCols spec
-        = case spec of
-        Just (SubscribeOpSpec _ (Just (SubCArray cols)) ) -> when (null cols) (fail "found empty payload specification")
+        = case (sosoPayload <$> spec) of
+        Just (Just (SubCArray cols)) -> when (null cols)
+                                        (fail "found empty payload specification")
         _ -> return ()
+      mergeInsDefaults specOpt = InsDelSpec
+        (PayloadColumns $ fromMaybe SubCStar $ sosoPayload specOpt )
+      mergeUpdDefaults specOpt = UpdSpec
+        (PayloadColumns $ fromMaybe SubCStar $ sosoPayload specOpt)
+        (ListenColumns $ fromMaybe (SubCArray []) $ sosoColumns specOpt)
+      mergeDelDefaults specOpt = InsDelSpec
+        (PayloadColumns $ fromMaybe SubCStar $ sosoPayload specOpt)
+
   parseJSON _ = fail "expecting an object"
 
 $(deriveToJSON (aesonDrop 4 snakeCase){omitNothingFields=True} ''CreateEventTriggerQuery)

--- a/server/src-lib/Hasura/RQL/Types/EventTrigger.hs
+++ b/server/src-lib/Hasura/RQL/Types/EventTrigger.hs
@@ -37,7 +37,7 @@ import qualified Text.Regex.TDFA            as TDFA
 type TriggerName = T.Text
 type EventId     = T.Text
 
-data Ops = INSERT | UPDATE | DELETE | MANUAL deriving (Show)
+data Ops = INSERT | UPDATE | DELETE | MANUAL deriving (Show, Eq)
 
 data SubscribeColumns = SubCStar | SubCArray [PGCol] deriving (Show, Eq, Lift)
 
@@ -151,7 +151,6 @@ instance FromJSON CreateEventTriggerQuery where
     where
       checkEmptyCols spec
         = case spec of
-        Just (SubscribeOpSpec (SubCArray cols) _) -> when (null cols) (fail "found empty column specification")
         Just (SubscribeOpSpec _ (Just (SubCArray cols)) ) -> when (null cols) (fail "found empty payload specification")
         _ -> return ()
   parseJSON _ = fail "expecting an object"

--- a/server/src-rsr/trigger.sql.j2
+++ b/server/src-rsr/trigger.sql.j2
@@ -6,21 +6,23 @@ CREATE OR REPLACE function hdb_views.{{QUALIFIED_TRIGGER_NAME}}() RETURNS trigge
     _new record;
     _data json;
   BEGIN
-    IF TG_OP = 'UPDATE' THEN
-      _old := {{OLD_ROW}};
-      _new := {{NEW_ROW}};
-    ELSE
-    /* initialize _old and _new with dummy values for INSERT and UPDATE events*/
-      _old := row((select 1));
-      _new := row((select 1));
+{% if (OPERATION == "UPDATE") && (SHOULD_DIFF == "True") %}
+    _old := {{OLD_ROW}};
+    _new := {{NEW_ROW}};
+    IF (_old <> _new) THEN
+      _data := json_build_object(
+        'old', {{OLD_PAYLOAD_EXPRESSION}},
+        'new', {{NEW_PAYLOAD_EXPRESSION}}
+      );
+      PERFORM hdb_catalog.insert_event_log(CAST(TG_TABLE_SCHEMA AS text), CAST(TG_TABLE_NAME AS text), CAST('{{NAME}}' AS text), TG_OP, _data);
     END IF;
+{% else %}
     _data := json_build_object(
       'old', {{OLD_PAYLOAD_EXPRESSION}},
       'new', {{NEW_PAYLOAD_EXPRESSION}}
     );
-    IF (TG_OP <> 'UPDATE') OR (_old <> _new) THEN
-      PERFORM hdb_catalog.insert_event_log(CAST(TG_TABLE_SCHEMA AS text), CAST(TG_TABLE_NAME AS text), CAST('{{NAME}}' AS text), TG_OP, _data);
-    END IF;
+    PERFORM hdb_catalog.insert_event_log(CAST(TG_TABLE_SCHEMA AS text), CAST(TG_TABLE_NAME AS text), CAST('{{NAME}}' AS text), TG_OP, _data);
+{% endif %}
     RETURN NULL;
   END;
 $$;

--- a/server/tests-py/queries/event_triggers/basic/setup.yaml
+++ b/server/tests-py/queries/event_triggers/basic/setup.yaml
@@ -18,9 +18,10 @@ args:
       schema: hge_tests
       name: test_t1
     insert:
-      columns: "*"
+      payload: "*"
     update:
       columns: "*"
+      payload: "*"
     delete:
-      columns: "*"
+      payload: "*"
     webhook: http://127.0.0.1:5592

--- a/server/tests-py/queries/event_triggers/create-delete/create_and_delete.yaml
+++ b/server/tests-py/queries/event_triggers/create-delete/create_and_delete.yaml
@@ -16,11 +16,12 @@ query:
         schema: hge_tests
         name: test_t1
       insert:
-        columns: "*"
+        payload: "*"
       update:
         columns: "*"
+        payload: "*"
       delete:
-        columns: "*"
+        payload: "*"
       webhook: http://127.0.0.1:5592
 
   - type: delete_event_trigger

--- a/server/tests-py/queries/event_triggers/create-delete/create_and_reset.yaml
+++ b/server/tests-py/queries/event_triggers/create-delete/create_and_reset.yaml
@@ -15,12 +15,12 @@ query:
         schema: hge_tests
         name: test_t1
       insert:
-        columns: "*"
+        payload: "*"
       update:
         columns: "*"
+        payload: "*"
       delete:
-        columns: "*"
+        payload: "*"
       webhook: http://127.0.0.1:5592
-
   - type: clear_metadata
     args: {}

--- a/server/tests-py/queries/event_triggers/headers/setup.yaml
+++ b/server/tests-py/queries/event_triggers/headers/setup.yaml
@@ -18,11 +18,12 @@ args:
       schema: hge_tests
       name: test_t1
     insert:
-      columns: "*"
+      payload: "*"
     update:
       columns: "*"
+      payload: "*"
     delete:
-      columns: "*"
+      payload: "*"
     webhook: http://127.0.0.1:5592
     headers:
     - name: "X-Header-From-Value"

--- a/server/tests-py/queries/event_triggers/insert_only/setup.yaml
+++ b/server/tests-py/queries/event_triggers/insert_only/setup.yaml
@@ -18,5 +18,5 @@ args:
       schema: hge_tests
       name: test_t1
     insert:
-      columns: "*"
+      payload: "*"
     webhook: http://127.0.0.1:5592

--- a/server/tests-py/queries/event_triggers/listen_cols/setup.yaml
+++ b/server/tests-py/queries/event_triggers/listen_cols/setup.yaml
@@ -18,9 +18,10 @@ args:
       schema: hge_tests
       name: test_t1
     insert:
-      columns: "*"
+      payload: "*"
     update:
+      payload: "*"
       columns: []
     delete:
-      columns: "*"
+      payload: "*"
     webhook: http://127.0.0.1:5592

--- a/server/tests-py/queries/event_triggers/listen_cols/setup.yaml
+++ b/server/tests-py/queries/event_triggers/listen_cols/setup.yaml
@@ -1,0 +1,26 @@
+type: bulk
+args:
+- type: run_sql
+  args:
+    sql: |
+      create table hge_tests.test_t1(
+          c1 int,
+          c2 text
+      );
+- type: track_table
+  args:
+    schema: hge_tests
+    name: test_t1
+- type: create_event_trigger
+  args:
+    name: t1_all
+    table:
+      schema: hge_tests
+      name: test_t1
+    insert:
+      columns: "*"
+    update:
+      columns: []
+    delete:
+      columns: "*"
+    webhook: http://127.0.0.1:5592

--- a/server/tests-py/queries/event_triggers/listen_cols/teardown.yaml
+++ b/server/tests-py/queries/event_triggers/listen_cols/teardown.yaml
@@ -1,0 +1,9 @@
+type: bulk
+args:
+- type: delete_event_trigger
+  args:
+    name: t1_all
+- type: run_sql
+  args:
+    sql: |
+      drop table hge_tests.test_t1

--- a/server/tests-py/queries/event_triggers/manual_events/setup.yaml
+++ b/server/tests-py/queries/event_triggers/manual_events/setup.yaml
@@ -18,11 +18,12 @@ args:
       schema: hge_tests
       name: test_t1
     insert:
-      columns: "*"
+      payload: "*"
     update:
+      payload: "*"
       columns: "*"
     delete:
-      columns: "*"
+      payload: "*"
     enable_manual: true
     webhook: http://127.0.0.1:5592
 - type: create_event_trigger
@@ -32,10 +33,11 @@ args:
       schema: hge_tests
       name: test_t1
     insert:
-      columns: "*"
+      payload: "*"
     update:
+      payload: "*"
       columns: "*"
     delete:
-      columns: "*"
+      payload: "*"
     enable_manual: false
     webhook: http://127.0.0.1:5592

--- a/server/tests-py/queries/event_triggers/retry_conf/setup.yaml
+++ b/server/tests-py/queries/event_triggers/retry_conf/setup.yaml
@@ -34,11 +34,12 @@ args:
       schema: hge_tests
       name: test_t1
     insert:
-      columns: "*"
+      payload: "*"
     update:
-      columns: "*"
+      payload: "*"
+      listen_columns: "*"
     delete:
-      columns: "*"
+      payload: "*"
     webhook: http://127.0.0.1:5592/fail
     retry_conf:
       num_retries: 4
@@ -50,11 +51,12 @@ args:
       schema: hge_tests
       name: test_t2
     insert:
-      columns: "*"
+      payload: "*"
     update:
+      payload: "*"
       columns: "*"
     delete:
-      columns: "*"
+      payload: "*"
     webhook: http://127.0.0.1:5592/timeout_short
     retry_conf:
       num_retries: 2
@@ -67,11 +69,12 @@ args:
       schema: hge_tests
       name: test_t3
     insert:
-      columns: "*"
+      payload: "*"
     update:
+      payload: "*"
       columns: "*"
     delete:
-      columns: "*"
+      payload: "*"
     webhook: http://127.0.0.1:5592/timeout_long
     retry_conf:
       num_retries: 0

--- a/server/tests-py/queries/event_triggers/selected_cols/setup.yaml
+++ b/server/tests-py/queries/event_triggers/selected_cols/setup.yaml
@@ -18,11 +18,12 @@ args:
       schema: hge_tests
       name: test_t1
     insert:
-      columns: "*"
+      payload: "*"
     update:
+      payload: "*"
       columns: ["c1"]
     delete:
-      columns: "*"
+      payload: "*"
     webhook: http://127.0.0.1:5592
     retry_conf:
       num_retries: 10

--- a/server/tests-py/queries/event_triggers/selected_payload/setup.yaml
+++ b/server/tests-py/queries/event_triggers/selected_payload/setup.yaml
@@ -18,13 +18,11 @@ args:
       schema: hge_tests
       name: test_t1
     insert:
-      columns: "*"
       payload: "*"
     update:
       columns: "*"
       payload: ["c1"]
     delete:
-      columns: "*"
       payload: ["c2"]
     webhook: http://127.0.0.1:5592
     retry_conf:

--- a/server/tests-py/queries/event_triggers/update_query/create-setup.yaml
+++ b/server/tests-py/queries/event_triggers/update_query/create-setup.yaml
@@ -18,7 +18,8 @@ args:
       schema: hge_tests
       name: test_t1
     insert:
-      columns: "*"
+      payload: "*"
     update:
       columns: ["c2"]
+      payload: "*"
     webhook: http://127.0.0.1:5592

--- a/server/tests-py/queries/event_triggers/update_query/update-setup.yaml
+++ b/server/tests-py/queries/event_triggers/update_query/update-setup.yaml
@@ -8,8 +8,9 @@ args:
       name: test_t1
     update:
       columns: ["c1"]
+      payload: "*"
     delete:
-      columns: "*"
+      payload: "*"
     webhook: http://127.0.0.1:5592/new
     retry_conf:
       num_retries: 5

--- a/server/tests-py/queries/event_triggers/webhook_env/setup.yaml
+++ b/server/tests-py/queries/event_triggers/webhook_env/setup.yaml
@@ -18,9 +18,10 @@ args:
       schema: hge_tests
       name: test_t1
     insert:
-      columns: "*"
+      payload: "*"
     update:
+      payload: "*"
       columns: "*"
     delete:
-      columns: "*"
+      payload: "*"
     webhook_from_env: WEBHOOK_FROM_ENV

--- a/server/tests-py/test_events.py
+++ b/server/tests-py/test_events.py
@@ -581,3 +581,46 @@ class TestManualEvents(object):
         assert st_code == 200, resp
         st_code, resp = hge_ctx.v1q_f('queries/event_triggers/manual_events/disabled.yaml')
         assert st_code == 400, resp
+
+
+class TestSkipDiff:
+
+    @pytest.fixture(autouse=True)
+    def transact(self, request, hge_ctx, evts_webhook):
+        print("In setup method")
+        st_code, resp = hge_ctx.v1q_f('queries/event_triggers/listen_cols/setup.yaml')
+        assert st_code == 200, resp
+        yield
+        st_code, resp = hge_ctx.v1q_f('queries/event_triggers/listen_cols/teardown.yaml')
+        assert st_code == 200, resp
+
+    def test_row_skip_diff(self, hge_ctx, evts_webhook):
+        table = {"schema": "hge_tests", "name": "test_t1"}
+
+        init_row = {"c1": 1, "c2": "hello"}
+        exp_ev_data = {
+            "old": None,
+            "new": init_row
+        }
+        st_code, resp = insert(hge_ctx, table, init_row)
+        assert st_code == 200, resp
+        check_event(hge_ctx, evts_webhook, "t1_all", table, "INSERT", exp_ev_data)
+
+        where_exp = {"c1": 1}
+        set_exp = {"c2": "world"}
+        exp_ev_data = {
+            "old": init_row,
+            "new": {"c1": 1, "c2": "world"}
+        }
+        st_code, resp = update(hge_ctx, table, where_exp, set_exp)
+        assert st_code == 200, resp
+        check_event(hge_ctx, evts_webhook, "t1_all", table, "UPDATE", exp_ev_data)
+        where_exp = {"c1": 1}
+        set_exp = {"c2": "world"}
+        exp_ev_data = {
+            "old": {"c1": 1, "c2": "world"},
+            "new": {"c1": 1, "c2": "world"}
+        }
+        st_code, resp = update(hge_ctx, table, where_exp, set_exp)
+        assert st_code == 200, resp
+        check_event(hge_ctx, evts_webhook, "t1_all", table, "UPDATE", exp_ev_data)


### PR DESCRIPTION
### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

Currently, for update events the OLD and NEW rows are compared and event is invoked only if there is a diff. This is a sane default but you may need to trigger an update event even if no rows changed as mentioned in #2087 

User can choose a flag called (SKIP DIFF/ SKIP COMPARE) in the Listen Columns section of event trigger which would give the desired behaviour. This is equivalent to giving an empty array in the column spec of the API .

### Affected components 
<!-- Remove non-affected components from the list -->
- Server

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

#2087 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

We template the trigger function based on the condition of the flag.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
