### PR TITLE
learn: fix 'paramter' typo in GraphQL tutorial

### DIFF
--- a/community/learn/graphql-tutorials/tutorials/ios-apollo/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
+++ b/community/learn/graphql-tutorials/tutorials/ios-apollo/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
@@ -101,7 +101,7 @@ query {
 
 ## Adding parameters (arguments) to GraphQL queries
 
-In most API calls, you usually use paramters. For example, to specify what data you're fetching.
+In most API calls, you usually use parameters. For example, to specify what data you're fetching.
 If you're familiar with making `GET` calls, you would have used a query parameter. For example,
 to fetch only 10 todos you might have made this API call: `GET /api/todos?limit=10`.
 

--- a/community/learn/graphql-tutorials/tutorials/react-apollo/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
+++ b/community/learn/graphql-tutorials/tutorials/react-apollo/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
@@ -105,7 +105,7 @@ and their profile information (which is just their name for now):
 
 ## Adding parameters (arguments) to GraphQL queries
 
-In most API calls, you usually use paramters. For example, to specify what data you're fetching.
+In most API calls, you usually use parameters. For example, to specify what data you're fetching.
 If you're familiar with making `GET` calls, you would have used a query parameter. For example,
 to fetch only 10 todos you might have made this API call: `GET /api/todos?limit=10`.
 

--- a/community/learn/graphql-tutorials/tutorials/react-native-apollo/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
+++ b/community/learn/graphql-tutorials/tutorials/react-native-apollo/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
@@ -101,7 +101,7 @@ and their profile information (which is just their name for now):
 
 ## Adding parameters (arguments) to GraphQL queries
 
-In most API calls, you usually use paramters. For example, to specify what data you're fetching.
+In most API calls, you usually use parameters. For example, to specify what data you're fetching.
 If you're familiar with making `GET` calls, you would have used a query parameter. For example,
 to fetch only 10 todos you might have made this API calls: `GET /api/todos?limit=10`.
 

--- a/community/learn/graphql-tutorials/tutorials/vue-apollo/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
+++ b/community/learn/graphql-tutorials/tutorials/vue-apollo/tutorial-site/content/intro-to-graphql/2-fetching-data-queries.md
@@ -105,7 +105,7 @@ and their profile information (which is just their name for now):
 
 ## Adding parameters (arguments) to GraphQL queries
 
-In most API calls, you usually use paramters. For example, to specify what data you're fetching.
+In most API calls, you usually use parameters. For example, to specify what data you're fetching.
 If you're familiar with making `GET` calls, you would have used a query parameter. For example,
 to fetch only 10 todos you might have made this API calls: `GET /api/todos?limit=10`.
 


### PR DESCRIPTION
### Affected components 

- Community Content
