### PR TITLE
ra-data-hasura: add missing "s" to id variable

### DIFF
--- a/community/tools/ra-data-hasura/src/index.js
+++ b/community/tools/ra-data-hasura/src/index.js
@@ -128,7 +128,7 @@ export default (serverEndpoint, headers, config) => {
         finalQuery = cloneQuery(deleteQuery);
         finalQuery.args.table = {'name': tableName, 'schema': schema};
         finalQuery.args.where = {};
-        finalQuery.args.where[primaryKey] = { '$in': params.id };
+        finalQuery.args.where[primaryKey] = { '$in': params.ids };
         finalQuery.args.returning = [primaryKey];
         break;
       case 'GET_MANY':


### PR DESCRIPTION
### Description
Change `id` to `ids`. `id` is null and that was causing all records to be deleted. MANY actions use `ids`.

### Affected components 
<!-- Remove non-affected components from the list -->

- ra-data-hasura

### Solution and Design
Change `id` to `ids`.