### PR TITLE
fix CLI console subscriptions connect via WS instead of WSS on HTTPS/WSS Endpoints, close #2330

### DIFF
--- a/console/src/components/Services/ApiExplorer/Actions.js
+++ b/console/src/components/Services/ApiExplorer/Actions.js
@@ -146,11 +146,7 @@ const changeRequestParams = newParams => {
 
 const createWsClient = (url, headers) => {
   const gqlUrl = new URL(url);
-  const windowUrl = new URL(window.location);
-  let websocketProtocol = 'ws';
-  if (gqlUrl.protocol === 'https:' && windowUrl.protocol === 'https:') {
-    websocketProtocol = 'wss';
-  }
+  const websocketProtocol = gqlUrl.protocol === 'https:' ? 'wss' : 'ws';
   const headersFinal = getHeadersAsJSON(headers);
   const graphqlUrl = `${websocketProtocol}://${url.split('//')[1]}`;
   const client = new SubscriptionClient(graphqlUrl, {


### PR DESCRIPTION
### Description
If GraphQL endpoint is http, protocols used should be http / ws
If GraphQL endpoint is https, protocols used should be https / wss

### Affected components 
<!-- Remove non-affected components from the list -->
- Console

### Related Issues
#2330 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
