### PR TITLE
created docker compose for build and launch of tutorial

### DIFF
--- a/community/learn/graphql-tutorials/tutorials/react-apollo/tutorial-site/docker-compose.yml
+++ b/community/learn/graphql-tutorials/tutorials/react-apollo/tutorial-site/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.7'
+services:
+  gatsby:
+    build: .
+    restart: always
+    ports: 
+      - 8080:8080
+    volumes:
+      - ./content:/gatsby-gitbook-starter/content
+      - ./config.js:/gatsby-gitbook-starter/config.js 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

No specific issues fixed, I just thought adding a compose to the graphql tutorial site would make the container easier to use and understand rather than manually launching with the same commands from the command line.

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

Adding docker-compose file, so that users can run 
`docker-compose up`
rather than
`docker run -ti -p 8080:8080 -v /path/to/graphql-engine/community/learn/graphql-tutorials/tutorials/react-apollo/tutorial-site/content:/gatsby-gitbook-starter/content -v /path/to/graphql-engine/community/learn/graphql-tutorials/tutorials/react-apollo/tutorial-site/config.js:/gatsby-gitbook-starter/config.js tutorial-site:0.1`

### Affected components 
<!-- Remove non-affected components from the list -->

- Community Content

### Solution and Design
I moved the configuration needed in docker run into a docker-compose file, following best practices

### Steps to test and verify
tried running docker-compose build and docker-compose up and they both worked normally


