### PR TITLE
add a make rule to build server docker image locally

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -33,7 +33,7 @@ image: $(project).cabal
 		.
 
 local-image:
-	docker pull "fpco/stack-build:$(stack_resolver)"
+	stack docker pull
 	stack --docker build --fast
 	mkdir -p packaging/build/rootfs
 	docker run --rm -v "$(build_dir_docker)/$(project)/$(project):/root/$(project)" \

--- a/server/Makefile
+++ b/server/Makefile
@@ -10,6 +10,7 @@ packager_ver := 20190326
 pg_dump_ver := 11
 project_dir := $(shell pwd)
 build_dir := $(project_dir)/$(shell stack path --dist-dir)/build
+build_dir_docker := $(project_dir)/$(shell stack --docker path --dist-dir)/build
 
 build_output := /build/_server_output
 
@@ -30,6 +31,17 @@ image: $(project).cabal
 		--build-arg stack_resolver=$(stack_resolver) \
 		--build-arg packager_version=$(packager_ver) \
 		.
+
+local-image:
+	docker pull "fpco/stack-build:$(stack_resolver)"
+	stack --docker build --fast
+	mkdir -p packaging/build/rootfs
+	docker run --rm -v "$(build_dir_docker)/$(project)/$(project):/root/$(project)" \
+		$(registry)/graphql-engine-packager:$(packager_ver) /build.sh \
+		$(project) | tar -x -C packaging/build/rootfs
+	strip --strip-unneeded packaging/build/rootfs/bin/$(project)
+	upx packaging/build/rootfs/bin/$(project)
+	docker build -t "$(registry)/$(project):$(VERSION)" packaging/build
 
 release-image: $(project).cabal
 	docker build -t "$(registry)/$(project):$(VERSION)" \
@@ -77,4 +89,4 @@ push-latest:
 packager: packaging/packager.df
 	docker build -t "$(registry)/graphql-engine-packager:$(packager_ver)" -f packaging/packager.df ./packaging/
 
-.PHONY: image release-image push packager ci-binary-and-test ci-image ci-save-image ci-load-image build exec build-local-console exec-local-console
+.PHONY: image local-image release-image push packager ci-binary-and-test ci-image ci-save-image ci-load-image build exec build-local-console exec-local-console


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

A new make rule, `local-image`, added to server `Makefile` to build docker image locally

**Required Tools**
- stack
- docker
- strip
- upx
- tar

### Affected components
<!-- Remove non-affected components from the list -->

- Server

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

N/A

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

`make local-image` do the following actions.

1. Pull [fpco stack-build](https://hub.docker.com/r/fpco/stack-build/) docker image by using `stack docker pull` command
2. Run `stack --docker build --fast` command to build server in a docker container
3. Create a new folder with the name `rootfs` in `packaging/build/`
4. Run [graphql-engine-packager](https://hub.docker.com/r/hasura/graphql-engine-packager) container by mounting server binary built in `2` which emits its root filesystem with server binary and necessary runtime dependencies into the folder created in `3`
5. Run [strip](https://en.wikipedia.org/wiki/Strip_(Unix)) on server binary present in `packaging/build/rootfs/bin/`
6. Pack the server binary using [upx](https://upx.github.io/) tool
7. Create a minimal docker image by packing `rootfs` folder using `packaging/build/Dockerfile`


### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

In the `server` folder, run
```bash
make local-image
```

### Limitations
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->

- The fpco's `stack-build` image is of size ~8.5 GB
- By default, the generated image is tagged with `hasura` registry
