### PR TITLE
allow to track all tables/relationships (close #1418)

### DIFF
--- a/cli/Gopkg.lock
+++ b/cli/Gopkg.lock
@@ -562,6 +562,7 @@
     "github.com/skratchdot/open-golang/open",
     "github.com/spf13/cobra",
     "github.com/spf13/cobra/doc",
+    "github.com/spf13/pflag",
     "github.com/spf13/viper",
     "github.com/stretchr/testify/assert",
   ]

--- a/cli/commands/console.go
+++ b/cli/commands/console.go
@@ -110,7 +110,7 @@ func (o *consoleOptions) run() error {
 
 	o.EC.Logger.Debugf("rendering console template [%s] with assets [%s]", consoleTemplateVersion, consoleAssetsVersion)
 
-	adminSecretHeader := getAdminSecretHeaderName(o.EC.Version)
+	adminSecretHeader := util.GetAdminSecretHeaderName(o.EC.Version)
 
 	consoleRouter, err := serveConsole(consoleTemplateVersion, o.StaticDir, gin.H{
 		"apiHost":         "http://" + o.Address,
@@ -118,7 +118,7 @@ func (o *consoleOptions) run() error {
 		"cliVersion":      o.EC.Version.GetCLIVersion(),
 		"dataApiUrl":      o.EC.ServerConfig.ParsedEndpoint.String(),
 		"dataApiVersion":  "",
-		"hasAccessKey":    adminSecretHeader == XHasuraAccessKey,
+		"hasAccessKey":    adminSecretHeader == util.XHasuraAccessKey,
 		"adminSecret":     o.EC.ServerConfig.AdminSecret,
 		"assetsVersion":   consoleAssetsVersion,
 		"enableTelemetry": o.EC.GlobalConfig.EnableTelemetry,
@@ -178,7 +178,7 @@ func (router *cRouter) setRoutes(nurl *url.URL, adminSecret, migrationDir, metad
 	{
 		apis.Use(setLogger(logger))
 		apis.Use(setFilePath(migrationDir))
-		apis.Use(setDataPath(nurl, getAdminSecretHeaderName(v), adminSecret))
+		apis.Use(setDataPath(nurl, util.GetAdminSecretHeaderName(v), adminSecret))
 		// Migrate api endpoints and middleware
 		migrateAPIs := apis.Group("/migrate")
 		{
@@ -199,7 +199,7 @@ func (router *cRouter) setRoutes(nurl *url.URL, adminSecret, migrationDir, metad
 
 func setDataPath(nurl *url.URL, adminSecretHeader, adminSecret string) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		host := getDataPath(nurl, adminSecretHeader, adminSecret)
+		host := util.GetDataPath(nurl, adminSecretHeader, adminSecret)
 
 		c.Set("dbpath", host)
 		c.Next()
@@ -208,7 +208,7 @@ func setDataPath(nurl *url.URL, adminSecretHeader, adminSecret string) gin.Handl
 
 func setFilePath(dir string) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		host := getFilePath(dir)
+		host := util.GetFilePath(dir)
 		c.Set("filedir", host)
 		c.Next()
 	}
@@ -231,8 +231,8 @@ func setLogger(logger *logrus.Logger) gin.HandlerFunc {
 func allowCors() gin.HandlerFunc {
 	config := cors.DefaultConfig()
 	config.AddAllowHeaders("X-Hasura-User-Id")
-	config.AddAllowHeaders(XHasuraAccessKey)
-	config.AddAllowHeaders(XHasuraAdminSecret)
+	config.AddAllowHeaders(util.XHasuraAccessKey)
+	config.AddAllowHeaders(util.XHasuraAdminSecret)
 	config.AddAllowHeaders("X-Hasura-Role")
 	config.AddAllowHeaders("X-Hasura-Allowed-Roles")
 	config.AddAllowMethods("DELETE")

--- a/cli/commands/metadata.go
+++ b/cli/commands/metadata.go
@@ -1,14 +1,7 @@
 package commands
 
 import (
-	"encoding/json"
-	"io/ioutil"
-	"os"
-
-	"github.com/ghodss/yaml"
 	"github.com/hasura/graphql-engine/cli"
-	"github.com/hasura/graphql-engine/cli/migrate"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -23,80 +16,8 @@ func NewMetadataCmd(ec *cli.ExecutionContext) *cobra.Command {
 		newMetadataClearCmd(ec),
 		newMetadataReloadCmd(ec),
 		newMetadataApplyCmd(ec),
+		newMetadataTrackCmd(ec),
+		newMetadataUnTrackCmd(ec),
 	)
 	return metadataCmd
-}
-
-func executeMetadata(cmd string, t *migrate.Migrate, ec *cli.ExecutionContext) error {
-	switch cmd {
-	case "export":
-		metaData, err := t.ExportMetadata()
-		if err != nil {
-			return errors.Wrap(err, "cannot export metadata")
-		}
-
-		t, err := json.Marshal(metaData)
-		if err != nil {
-			return errors.Wrap(err, "cannot Marshal metadata")
-		}
-
-		data, err := yaml.JSONToYAML(t)
-		if err != nil {
-			return err
-		}
-
-		metadataPath, err := ec.GetMetadataFilePath("yaml")
-		if err != nil {
-			return errors.Wrap(err, "cannot save metadata")
-		}
-
-		err = ioutil.WriteFile(metadataPath, data, 0644)
-		if err != nil {
-			return errors.Wrap(err, "cannot save metadata")
-		}
-	case "clear":
-		err := t.ResetMetadata()
-		if err != nil {
-			return errors.Wrap(err, "cannot clear Metadata")
-		}
-	case "reload":
-		err := t.ReloadMetadata()
-		if err != nil {
-			return errors.Wrap(err, "cannot reload Metadata")
-		}
-	case "apply":
-		var data interface{}
-		var metadataContent []byte
-		for _, format := range []string{"yaml", "json"} {
-			metadataPath, err := ec.GetMetadataFilePath(format)
-			if err != nil {
-				return errors.Wrap(err, "cannot apply metadata")
-			}
-
-			metadataContent, err = ioutil.ReadFile(metadataPath)
-			if err != nil {
-				if os.IsNotExist(err) {
-					continue
-				}
-				return err
-			}
-			break
-		}
-
-		if metadataContent == nil {
-			return errors.New("Unable to locate metadata.[yaml|json] file under migrations directory")
-		}
-
-		err := yaml.Unmarshal(metadataContent, &data)
-		if err != nil {
-			return errors.Wrap(err, "cannot parse metadata file")
-		}
-
-		err = t.ApplyMetadata(data)
-		if err != nil {
-			return errors.Wrap(err, "cannot apply metadata on the database")
-		}
-		return nil
-	}
-	return nil
 }

--- a/cli/commands/metadata_apply.go
+++ b/cli/commands/metadata_apply.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"github.com/hasura/graphql-engine/cli"
+	"github.com/hasura/graphql-engine/cli/metadata"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -10,8 +11,7 @@ import (
 func newMetadataApplyCmd(ec *cli.ExecutionContext) *cobra.Command {
 	v := viper.New()
 	opts := &metadataApplyOptions{
-		EC:         ec,
-		actionType: "apply",
+		EC: ec,
 	}
 
 	metadataApplyCmd := &cobra.Command{
@@ -52,14 +52,12 @@ func newMetadataApplyCmd(ec *cli.ExecutionContext) *cobra.Command {
 
 type metadataApplyOptions struct {
 	EC *cli.ExecutionContext
-
-	actionType string
 }
 
 func (o *metadataApplyOptions) run() error {
-	migrateDrv, err := newMigrate(o.EC.MigrationDir, o.EC.ServerConfig.ParsedEndpoint, o.EC.ServerConfig.AdminSecret, o.EC.Logger, o.EC.Version)
+	config, err := metadata.New(o.EC.MigrationDir, o.EC.ServerConfig.ParsedEndpoint, o.EC.ServerConfig.AdminSecret, o.EC.Version)
 	if err != nil {
 		return err
 	}
-	return executeMetadata(o.actionType, migrateDrv, o.EC)
+	return config.Apply()
 }

--- a/cli/commands/metadata_apply.go
+++ b/cli/commands/metadata_apply.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"os"
+
 	"github.com/hasura/graphql-engine/cli"
 	"github.com/hasura/graphql-engine/cli/metadata"
 	"github.com/pkg/errors"
@@ -58,6 +60,21 @@ func (o *metadataApplyOptions) run() error {
 	config, err := metadata.New(o.EC.MigrationDir, o.EC.ServerConfig.ParsedEndpoint, o.EC.ServerConfig.AdminSecret, o.EC.Version)
 	if err != nil {
 		return err
+	}
+	for _, format := range []string{"yaml", "json"} {
+		metadataPath, err := o.EC.GetMetadataFilePath(format)
+		if err != nil {
+			return errors.Wrap(err, "cannot apply metadata")
+		}
+
+		err = config.SetMetadataPath(metadataPath, true)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return err
+		}
+		break
 	}
 	return config.Apply()
 }

--- a/cli/commands/metadata_apply_test.go
+++ b/cli/commands/metadata_apply_test.go
@@ -25,7 +25,6 @@ func testMetadataApply(t *testing.T, metadataFile string, endpoint *url.URL) {
 				ParsedEndpoint: endpoint,
 			},
 		},
-		actionType: "apply",
 	}
 
 	opts.EC.Version = version.New()

--- a/cli/commands/metadata_clear.go
+++ b/cli/commands/metadata_clear.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"github.com/hasura/graphql-engine/cli"
+	"github.com/hasura/graphql-engine/cli/metadata"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -61,13 +62,9 @@ type metadataClearOptions struct {
 }
 
 func (o *metadataClearOptions) run() error {
-	migrateDrv, err := newMigrate(o.EC.MigrationDir, o.EC.ServerConfig.ParsedEndpoint, o.EC.ServerConfig.AdminSecret, o.EC.Logger, o.EC.Version)
+	config, err := metadata.New(o.EC.MigrationDir, o.EC.ServerConfig.ParsedEndpoint, o.EC.ServerConfig.AdminSecret, o.EC.Version)
 	if err != nil {
 		return err
 	}
-	err = executeMetadata(o.actionType, migrateDrv, o.EC)
-	if err != nil {
-		return errors.Wrap(err, "Cannot clear metadata")
-	}
-	return nil
+	return config.Clear()
 }

--- a/cli/commands/metadata_clear.go
+++ b/cli/commands/metadata_clear.go
@@ -11,8 +11,7 @@ import (
 func newMetadataClearCmd(ec *cli.ExecutionContext) *cobra.Command {
 	v := viper.New()
 	opts := &metadataClearOptions{
-		EC:         ec,
-		actionType: "clear",
+		EC: ec,
 	}
 
 	metadataResetCmd := &cobra.Command{
@@ -57,8 +56,6 @@ func newMetadataClearCmd(ec *cli.ExecutionContext) *cobra.Command {
 
 type metadataClearOptions struct {
 	EC *cli.ExecutionContext
-
-	actionType string
 }
 
 func (o *metadataClearOptions) run() error {

--- a/cli/commands/metadata_clear_test.go
+++ b/cli/commands/metadata_clear_test.go
@@ -25,7 +25,6 @@ func testMetadataReset(t *testing.T, metadataFile string, endpoint *url.URL) {
 				ParsedEndpoint: endpoint,
 			},
 		},
-		actionType: "clear",
 	}
 
 	opts.EC.Version = version.New()

--- a/cli/commands/metadata_export.go
+++ b/cli/commands/metadata_export.go
@@ -67,7 +67,7 @@ func (o *metadataExportOptions) run() error {
 		return err
 	}
 
-	metadataPath, err := ec.GetMetadataFilePath("yaml")
+	metadataPath, err := o.EC.GetMetadataFilePath("yaml")
 	if err != nil {
 		return errors.Wrap(err, "cannot save metadata")
 	}

--- a/cli/commands/metadata_export.go
+++ b/cli/commands/metadata_export.go
@@ -17,8 +17,7 @@ on those tables.`
 func newMetadataExportCmd(ec *cli.ExecutionContext) *cobra.Command {
 	v := viper.New()
 	opts := &metadataExportOptions{
-		EC:         ec,
-		actionType: "export",
+		EC: ec,
 	}
 
 	metadataExportCmd := &cobra.Command{
@@ -60,8 +59,6 @@ func newMetadataExportCmd(ec *cli.ExecutionContext) *cobra.Command {
 
 type metadataExportOptions struct {
 	EC *cli.ExecutionContext
-
-	actionType string
 }
 
 func (o *metadataExportOptions) run() error {

--- a/cli/commands/metadata_export.go
+++ b/cli/commands/metadata_export.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"github.com/hasura/graphql-engine/cli"
+	"github.com/hasura/graphql-engine/cli/metadata"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -64,9 +65,9 @@ type metadataExportOptions struct {
 }
 
 func (o *metadataExportOptions) run() error {
-	migrateDrv, err := newMigrate(o.EC.MigrationDir, o.EC.ServerConfig.ParsedEndpoint, o.EC.ServerConfig.AdminSecret, o.EC.Logger, o.EC.Version)
+	config, err := metadata.New(o.EC.MigrationDir, o.EC.ServerConfig.ParsedEndpoint, o.EC.ServerConfig.AdminSecret, o.EC.Version)
 	if err != nil {
 		return err
 	}
-	return executeMetadata(o.actionType, migrateDrv, o.EC)
+	return config.Export()
 }

--- a/cli/commands/metadata_export.go
+++ b/cli/commands/metadata_export.go
@@ -66,5 +66,15 @@ func (o *metadataExportOptions) run() error {
 	if err != nil {
 		return err
 	}
+
+	metadataPath, err := ec.GetMetadataFilePath("yaml")
+	if err != nil {
+		return errors.Wrap(err, "cannot save metadata")
+	}
+
+	err = config.SetMetadataPath(metadataPath, false)
+	if err != nil {
+		return errors.Wrap(err, "cannot save metadata")
+	}
 	return config.Export()
 }

--- a/cli/commands/metadata_export_test.go
+++ b/cli/commands/metadata_export_test.go
@@ -25,7 +25,6 @@ func testMetadataExport(t *testing.T, metadataFile string, endpoint *url.URL) {
 				ParsedEndpoint: endpoint,
 			},
 		},
-		actionType: "export",
 	}
 
 	opts.EC.Version = version.New()

--- a/cli/commands/metadata_reload.go
+++ b/cli/commands/metadata_reload.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"github.com/hasura/graphql-engine/cli"
+	"github.com/hasura/graphql-engine/cli/metadata"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -57,13 +58,9 @@ type metadataReloadOptions struct {
 }
 
 func (o *metadataReloadOptions) run() error {
-	migrateDrv, err := newMigrate(o.EC.MigrationDir, o.EC.ServerConfig.ParsedEndpoint, o.EC.ServerConfig.AdminSecret, o.EC.Logger, o.EC.Version)
+	config, err := metadata.New(o.EC.MigrationDir, o.EC.ServerConfig.ParsedEndpoint, o.EC.ServerConfig.AdminSecret, o.EC.Version)
 	if err != nil {
 		return err
 	}
-	err = executeMetadata(o.actionType, migrateDrv, o.EC)
-	if err != nil {
-		return errors.Wrap(err, "Cannot reload metadata")
-	}
-	return nil
+	return config.Reload()
 }

--- a/cli/commands/metadata_reload.go
+++ b/cli/commands/metadata_reload.go
@@ -11,8 +11,7 @@ import (
 func newMetadataReloadCmd(ec *cli.ExecutionContext) *cobra.Command {
 	v := viper.New()
 	opts := &metadataReloadOptions{
-		EC:         ec,
-		actionType: "reload",
+		EC: ec,
 	}
 
 	metadataReloadCmd := &cobra.Command{
@@ -53,8 +52,6 @@ func newMetadataReloadCmd(ec *cli.ExecutionContext) *cobra.Command {
 
 type metadataReloadOptions struct {
 	EC *cli.ExecutionContext
-
-	actionType string
 }
 
 func (o *metadataReloadOptions) run() error {

--- a/cli/commands/metadata_reload_test.go
+++ b/cli/commands/metadata_reload_test.go
@@ -25,7 +25,6 @@ func testMetadataReload(t *testing.T, metadataFile string, endpoint *url.URL) {
 				ParsedEndpoint: endpoint,
 			},
 		},
-		actionType: "reload",
 	}
 
 	opts.EC.Version = version.New()

--- a/cli/commands/metadata_track.go
+++ b/cli/commands/metadata_track.go
@@ -1,0 +1,72 @@
+package commands
+
+import (
+	"github.com/hasura/graphql-engine/cli"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func newMetadataTrackCmd(ec *cli.ExecutionContext) *cobra.Command {
+	v := viper.New()
+	opts := &metadataTrackOptions{
+		EC: ec,
+	}
+
+	metadataTrackCmd := &cobra.Command{
+		Use:          "track",
+		Short:        "",
+		Example:      ``,
+		SilenceUsage: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			ec.Viper = v
+			return ec.Validate()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return opts.run()
+		},
+	}
+
+	f := metadataTrackCmd.Flags()
+
+	f.BoolVar(&opts.allTables, "all-tables", false, "track all tables in the given schemas")
+	f.BoolVar(&opts.allRelationships, "all-relationships", false, "track all relationships across the given tables")
+	f.StringSliceVar(&opts.schemas, "schema", []string{"public"}, "track tables from this schema")
+	f.StringSliceVar(&opts.tables, "table", []string{}, "track these tables in the given schema")
+	f.BoolVar(&opts.export, "export-as-migration", false, "export the changes as a migration file")
+
+	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
+	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
+	f.String("access-key", "", "access key for Hasura GraphQL Engine")
+	f.MarkDeprecated("access-key", "use --admin-secret instead")
+
+	// need to create a new viper because https://github.com/spf13/viper/issues/233
+	v.BindPFlag("endpoint", f.Lookup("endpoint"))
+	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
+	v.BindPFlag("access_key", f.Lookup("access-key"))
+
+	return metadataTrackCmd
+}
+
+type metadataTrackOptions struct {
+	EC *cli.ExecutionContext
+
+	allTables        bool
+	allRelationships bool
+	schemas          []string
+	tables           []string
+	export           bool
+}
+
+func (o *metadataTrackOptions) run() error {
+	if o.allTables && len(o.tables) != 0 {
+		return errors.New("cannot set both --all-tables && --table flags")
+	}
+
+	// TODO: why?
+	if len(o.tables) != 0 && len(o.schemas) > 1 {
+		return errors.New("can't set more than one schema if --table flag is set")
+	}
+
+	return nil
+}

--- a/cli/commands/metadata_untrack.go
+++ b/cli/commands/metadata_untrack.go
@@ -1,0 +1,61 @@
+package commands
+
+import (
+	"github.com/hasura/graphql-engine/cli"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func newMetadataUnTrackCmd(ec *cli.ExecutionContext) *cobra.Command {
+	v := viper.New()
+	opts := &metadataUnTrackOptions{
+		EC: ec,
+	}
+
+	metadataUnTrackCmd := &cobra.Command{
+		Use:          "untrack",
+		Short:        "",
+		Example:      ``,
+		SilenceUsage: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			ec.Viper = v
+			return ec.Validate()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return opts.run()
+		},
+	}
+
+	f := metadataUnTrackCmd.Flags()
+	f.BoolVar(&opts.allTables, "all-tables", false, "untrack all tables in the given schemas")
+	f.BoolVar(&opts.allRelationships, "all-relationships", false, "untrack all relationships across the given tables")
+	f.StringSliceVar(&opts.schemas, "schema", []string{"public"}, "untrack tables from this schema")
+	f.StringSliceVar(&opts.tables, "table", []string{}, "untrack these tables in the given schema")
+	f.BoolVar(&opts.export, "export-as-migration", false, "export the changes as a migration file")
+
+	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
+	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
+	f.String("access-key", "", "access key for Hasura GraphQL Engine")
+	f.MarkDeprecated("access-key", "use --admin-secret instead")
+
+	// need to create a new viper because https://github.com/spf13/viper/issues/233
+	v.BindPFlag("endpoint", f.Lookup("endpoint"))
+	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
+	v.BindPFlag("access_key", f.Lookup("access-key"))
+
+	return metadataUnTrackCmd
+}
+
+type metadataUnTrackOptions struct {
+	EC *cli.ExecutionContext
+
+	allTables        bool
+	allRelationships bool
+	schemas          []string
+	tables           []string
+	export           bool
+}
+
+func (o *metadataUnTrackOptions) run() error {
+	return nil
+}

--- a/cli/commands/migrate_apply.go
+++ b/cli/commands/migrate_apply.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hasura/graphql-engine/cli"
 	migrate "github.com/hasura/graphql-engine/cli/migrate"
+	"github.com/hasura/graphql-engine/cli/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -71,7 +72,7 @@ func (o *migrateApplyOptions) run() error {
 		return errors.Wrap(err, "error validating flags")
 	}
 
-	migrateDrv, err := newMigrate(o.EC.MigrationDir, o.EC.ServerConfig.ParsedEndpoint, o.EC.ServerConfig.AdminSecret, o.EC.Logger, o.EC.Version)
+	migrateDrv, err := util.NewMigrate(o.EC.MigrationDir, o.EC.ServerConfig.ParsedEndpoint, o.EC.ServerConfig.AdminSecret, o.EC.Logger, o.EC.Version)
 	if err != nil {
 		return err
 	}

--- a/cli/commands/migrate_create.go
+++ b/cli/commands/migrate_create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/hasura/graphql-engine/cli"
 	"github.com/hasura/graphql-engine/cli/migrate"
+	"github.com/hasura/graphql-engine/cli/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -109,7 +110,7 @@ func (o *migrateCreateOptions) run() (version int64, err error) {
 
 	var migrateDrv *migrate.Migrate
 	if o.sqlServer || o.metaDataServer {
-		migrateDrv, err = newMigrate(o.EC.MigrationDir, o.EC.ServerConfig.ParsedEndpoint, o.EC.ServerConfig.AdminSecret, o.EC.Logger, o.EC.Version)
+		migrateDrv, err = util.NewMigrate(o.EC.MigrationDir, o.EC.ServerConfig.ParsedEndpoint, o.EC.ServerConfig.AdminSecret, o.EC.Logger, o.EC.Version)
 		if err != nil {
 			return 0, errors.Wrap(err, "cannot create migrate instance")
 		}

--- a/cli/commands/migrate_status.go
+++ b/cli/commands/migrate_status.go
@@ -58,7 +58,7 @@ type migrateStatusOptions struct {
 }
 
 func (o *migrateStatusOptions) run() (*migrate.Status, error) {
-	migrateDrv, err := newMigrate(o.EC.MigrationDir, o.EC.ServerConfig.ParsedEndpoint, o.EC.ServerConfig.AdminSecret, o.EC.Logger, o.EC.Version)
+	migrateDrv, err := util.NewMigrate(o.EC.MigrationDir, o.EC.ServerConfig.ParsedEndpoint, o.EC.ServerConfig.AdminSecret, o.EC.Logger, o.EC.Version)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/metadata/apply.go
+++ b/cli/metadata/apply.go
@@ -1,0 +1,50 @@
+package metadata
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/hasura/graphql-engine/cli/util"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+func (c *config) Apply() error {
+	migrateDrv, err := util.NewMigrate(c.sourceDir, c.hasuraDBConfig.endpoint, c.hasuraDBConfig.adminSecret, c.Logger, c.hasuraDBConfig.version)
+	if err != nil {
+		return err
+	}
+
+	var data interface{}
+	var metadataContent []byte
+	for _, format := range []string{"yaml", "json"} {
+		metadataPath, err := c.getMetadataFilePath(format)
+		if err != nil {
+			return errors.Wrap(err, "cannot apply metadata")
+		}
+
+		metadataContent, err = ioutil.ReadFile(metadataPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return err
+		}
+		break
+	}
+
+	if metadataContent == nil {
+		return errors.New("Unable to locate metadata.[yaml|json] file under migrations directory")
+	}
+
+	err = yaml.Unmarshal(metadataContent, &data)
+	if err != nil {
+		return errors.Wrap(err, "cannot parse metadata file")
+	}
+
+	err = migrateDrv.ApplyMetadata(data)
+	if err != nil {
+		return errors.Wrap(err, "cannot apply metadata on the database")
+	}
+	return nil
+}

--- a/cli/metadata/apply.go
+++ b/cli/metadata/apply.go
@@ -3,9 +3,9 @@ package metadata
 import (
 	"io/ioutil"
 
+	"github.com/ghodss/yaml"
 	"github.com/hasura/graphql-engine/cli/util"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
 )
 
 func (c *config) Apply() error {

--- a/cli/metadata/apply.go
+++ b/cli/metadata/apply.go
@@ -4,12 +4,11 @@ import (
 	"io/ioutil"
 
 	"github.com/ghodss/yaml"
-	"github.com/hasura/graphql-engine/cli/util"
 	"github.com/pkg/errors"
 )
 
 func (c *config) Apply() error {
-	migrateDrv, err := util.NewMigrate(c.sourceDir, c.hasuraDBConfig.endpoint, c.hasuraDBConfig.adminSecret, c.Logger, c.hasuraDBConfig.version)
+	err := c.createMigrateInstance()
 	if err != nil {
 		return err
 	}
@@ -30,7 +29,7 @@ func (c *config) Apply() error {
 		return errors.Wrap(err, "cannot parse metadata file")
 	}
 
-	err = migrateDrv.ApplyMetadata(data)
+	err = c.migrateDrv.ApplyMetadata(data)
 	if err != nil {
 		return errors.Wrap(err, "cannot apply metadata on the database")
 	}

--- a/cli/metadata/apply.go
+++ b/cli/metadata/apply.go
@@ -2,7 +2,6 @@ package metadata
 
 import (
 	"io/ioutil"
-	"os"
 
 	"github.com/hasura/graphql-engine/cli/util"
 	"github.com/pkg/errors"
@@ -16,21 +15,10 @@ func (c *config) Apply() error {
 	}
 
 	var data interface{}
-	var metadataContent []byte
-	for _, format := range []string{"yaml", "json"} {
-		metadataPath, err := c.getMetadataFilePath(format)
-		if err != nil {
-			return errors.Wrap(err, "cannot apply metadata")
-		}
 
-		metadataContent, err = ioutil.ReadFile(metadataPath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return err
-		}
-		break
+	metadataContent, err := ioutil.ReadFile(c.metadataPath)
+	if err != nil {
+		return err
 	}
 
 	if metadataContent == nil {

--- a/cli/metadata/clear.go
+++ b/cli/metadata/clear.go
@@ -1,17 +1,16 @@
 package metadata
 
 import (
-	"github.com/hasura/graphql-engine/cli/util"
 	"github.com/pkg/errors"
 )
 
 func (c *config) Clear() error {
-	migrateDrv, err := util.NewMigrate(c.sourceDir, c.hasuraDBConfig.endpoint, c.hasuraDBConfig.adminSecret, c.Logger, c.hasuraDBConfig.version)
+	err := c.createMigrateInstance()
 	if err != nil {
 		return err
 	}
 
-	err = migrateDrv.ResetMetadata()
+	err = c.migrateDrv.ResetMetadata()
 	if err != nil {
 		return errors.Wrap(err, "cannot clear Metadata")
 	}

--- a/cli/metadata/clear.go
+++ b/cli/metadata/clear.go
@@ -1,0 +1,19 @@
+package metadata
+
+import (
+	"github.com/hasura/graphql-engine/cli/util"
+	"github.com/pkg/errors"
+)
+
+func (c *config) Clear() error {
+	migrateDrv, err := util.NewMigrate(c.sourceDir, c.hasuraDBConfig.endpoint, c.hasuraDBConfig.adminSecret, c.Logger, c.hasuraDBConfig.version)
+	if err != nil {
+		return err
+	}
+
+	err = migrateDrv.ResetMetadata()
+	if err != nil {
+		return errors.Wrap(err, "cannot clear Metadata")
+	}
+	return nil
+}

--- a/cli/metadata/export.go
+++ b/cli/metadata/export.go
@@ -1,0 +1,43 @@
+package metadata
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	"github.com/ghodss/yaml"
+	"github.com/hasura/graphql-engine/cli/util"
+	"github.com/pkg/errors"
+)
+
+func (c *config) Export() error {
+	migrateDrv, err := util.NewMigrate(c.sourceDir, c.hasuraDBConfig.endpoint, c.hasuraDBConfig.adminSecret, c.Logger, c.hasuraDBConfig.version)
+	if err != nil {
+		return err
+	}
+
+	metaData, err := migrateDrv.ExportMetadata()
+	if err != nil {
+		return errors.Wrap(err, "cannot export metadata")
+	}
+
+	t, err := json.Marshal(metaData)
+	if err != nil {
+		return errors.Wrap(err, "cannot Marshal metadata")
+	}
+
+	data, err := yaml.JSONToYAML(t)
+	if err != nil {
+		return err
+	}
+
+	metadataPath, err := c.getMetadataFilePath("yaml")
+	if err != nil {
+		return errors.Wrap(err, "cannot save metadata")
+	}
+
+	err = ioutil.WriteFile(metadataPath, data, 0644)
+	if err != nil {
+		return errors.Wrap(err, "cannot save metadata")
+	}
+	return nil
+}

--- a/cli/metadata/export.go
+++ b/cli/metadata/export.go
@@ -30,12 +30,7 @@ func (c *config) Export() error {
 		return err
 	}
 
-	metadataPath, err := c.getMetadataFilePath("yaml")
-	if err != nil {
-		return errors.Wrap(err, "cannot save metadata")
-	}
-
-	err = ioutil.WriteFile(metadataPath, data, 0644)
+	err = ioutil.WriteFile(c.metadataPath, data, 0644)
 	if err != nil {
 		return errors.Wrap(err, "cannot save metadata")
 	}

--- a/cli/metadata/export.go
+++ b/cli/metadata/export.go
@@ -5,17 +5,16 @@ import (
 	"io/ioutil"
 
 	"github.com/ghodss/yaml"
-	"github.com/hasura/graphql-engine/cli/util"
 	"github.com/pkg/errors"
 )
 
 func (c *config) Export() error {
-	migrateDrv, err := util.NewMigrate(c.sourceDir, c.hasuraDBConfig.endpoint, c.hasuraDBConfig.adminSecret, c.Logger, c.hasuraDBConfig.version)
+	err := c.createMigrateInstance()
 	if err != nil {
 		return err
 	}
 
-	metaData, err := migrateDrv.ExportMetadata()
+	metaData, err := c.migrateDrv.ExportMetadata()
 	if err != nil {
 		return errors.Wrap(err, "cannot export metadata")
 	}

--- a/cli/metadata/metadata.go
+++ b/cli/metadata/metadata.go
@@ -4,6 +4,8 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/hasura/graphql-engine/cli/migrate"
+	"github.com/hasura/graphql-engine/cli/util"
 	"github.com/hasura/graphql-engine/cli/version"
 	"github.com/sirupsen/logrus"
 )
@@ -24,6 +26,8 @@ type config struct {
 	metadataPath string
 
 	hasuraDBConfig *hasuraDBConfig
+
+	migrateDrv *migrate.Migrate
 }
 
 func New(dir string, endpoint *url.URL, adminSecret string, version *version.Version) (*config, error) {
@@ -45,5 +49,14 @@ func (c *config) SetMetadataPath(path string, checkExists bool) error {
 		}
 	}
 	c.metadataPath = path
+	return nil
+}
+
+func (c *config) createMigrateInstance() error {
+	migrateDrv, err := util.NewMigrate(c.sourceDir, c.hasuraDBConfig.endpoint, c.hasuraDBConfig.adminSecret, c.Logger, c.hasuraDBConfig.version)
+	if err != nil {
+		return err
+	}
+	c.migrateDrv = migrateDrv
 	return nil
 }

--- a/cli/metadata/metadata.go
+++ b/cli/metadata/metadata.go
@@ -1,0 +1,54 @@
+package metadata
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"path/filepath"
+
+	"github.com/hasura/graphql-engine/cli/version"
+	"github.com/sirupsen/logrus"
+)
+
+type hasuraDBConfig struct {
+	endpoint *url.URL
+
+	adminSecret string
+
+	version *version.Version
+}
+
+type config struct {
+	Logger *logrus.Logger
+
+	sourceDir string
+
+	hasuraDBConfig *hasuraDBConfig
+
+	metadataFiles []string
+}
+
+func New(dir string, endpoint *url.URL, adminSecret string, version *version.Version) (*config, error) {
+	files := make([]string, 0)
+	files = append(files, filepath.Join(dir, "metadata.yaml"))
+	files = append(files, filepath.Join(dir, "metadata.json"))
+	return &config{
+		hasuraDBConfig: &hasuraDBConfig{
+			endpoint:    endpoint,
+			adminSecret: adminSecret,
+			version:     version,
+		},
+		metadataFiles: files,
+	}, nil
+}
+
+func (c *config) getMetadataFilePath(format string) (string, error) {
+	ext := fmt.Sprintf(".%s", format)
+	for _, filePath := range c.metadataFiles {
+		switch p := filepath.Ext(filePath); p {
+		case ext:
+			return filePath, nil
+		}
+	}
+	return "", errors.New("unsupported file type")
+}

--- a/cli/metadata/metadata.go
+++ b/cli/metadata/metadata.go
@@ -1,10 +1,8 @@
 package metadata
 
 import (
-	"errors"
-	"fmt"
 	"net/url"
-	"path/filepath"
+	"os"
 
 	"github.com/hasura/graphql-engine/cli/version"
 	"github.com/sirupsen/logrus"
@@ -23,32 +21,29 @@ type config struct {
 
 	sourceDir string
 
-	hasuraDBConfig *hasuraDBConfig
+	metadataPath string
 
-	metadataFiles []string
+	hasuraDBConfig *hasuraDBConfig
 }
 
 func New(dir string, endpoint *url.URL, adminSecret string, version *version.Version) (*config, error) {
-	files := make([]string, 0)
-	files = append(files, filepath.Join(dir, "metadata.yaml"))
-	files = append(files, filepath.Join(dir, "metadata.json"))
 	return &config{
 		hasuraDBConfig: &hasuraDBConfig{
 			endpoint:    endpoint,
 			adminSecret: adminSecret,
 			version:     version,
 		},
-		metadataFiles: files,
 	}, nil
 }
 
-func (c *config) getMetadataFilePath(format string) (string, error) {
-	ext := fmt.Sprintf(".%s", format)
-	for _, filePath := range c.metadataFiles {
-		switch p := filepath.Ext(filePath); p {
-		case ext:
-			return filePath, nil
+func (c *config) SetMetadataPath(path string, checkExists bool) error {
+	// check if file exists
+	if checkExists {
+		_, err := os.Stat(path)
+		if err != nil {
+			return err
 		}
 	}
-	return "", errors.New("unsupported file type")
+	c.metadataPath = path
+	return nil
 }

--- a/cli/metadata/reload.go
+++ b/cli/metadata/reload.go
@@ -1,17 +1,16 @@
 package metadata
 
 import (
-	"github.com/hasura/graphql-engine/cli/util"
 	"github.com/pkg/errors"
 )
 
 func (c *config) Reload() error {
-	migrateDrv, err := util.NewMigrate(c.sourceDir, c.hasuraDBConfig.endpoint, c.hasuraDBConfig.adminSecret, c.Logger, c.hasuraDBConfig.version)
+	err := c.createMigrateInstance()
 	if err != nil {
 		return err
 	}
 
-	err = migrateDrv.ReloadMetadata()
+	err = c.migrateDrv.ReloadMetadata()
 	if err != nil {
 		return errors.Wrap(err, "cannot reload Metadata")
 	}

--- a/cli/metadata/reload.go
+++ b/cli/metadata/reload.go
@@ -1,0 +1,19 @@
+package metadata
+
+import (
+	"github.com/hasura/graphql-engine/cli/util"
+	"github.com/pkg/errors"
+)
+
+func (c *config) Reload() error {
+	migrateDrv, err := util.NewMigrate(c.sourceDir, c.hasuraDBConfig.endpoint, c.hasuraDBConfig.adminSecret, c.Logger, c.hasuraDBConfig.version)
+	if err != nil {
+		return err
+	}
+
+	err = migrateDrv.ReloadMetadata()
+	if err != nil {
+		return errors.Wrap(err, "cannot reload Metadata")
+	}
+	return nil
+}

--- a/cli/metadata/types.go
+++ b/cli/metadata/types.go
@@ -1,0 +1,62 @@
+package metadata
+
+type v1Query struct {
+	QueryType string      `json:"type" yaml:"type"`
+	Args      interface{} `json:"args" yaml:"args"`
+}
+
+type v1BulkQuery struct {
+	QueryType string    `json:"type" yaml:"type"`
+	Args      []v1Query `json:"args" yaml:"argss"`
+}
+
+type tableArg struct {
+	Schema string `json:"schema" yaml:"schema"`
+	Name   string `json:"name" yaml:"name"`
+}
+
+type trackTableArg struct {
+	Table tableArg `json:"table" yaml:"table"`
+}
+
+type unTrackTableArg struct {
+	Table   tableArg `json:"table" yaml:"table"`
+	Cascade bool     `json:"cascade,omitempty" yaml:"cascade,omitempty"`
+}
+
+type createObjectRelationship struct {
+	Table tableArg    `json:"table" yaml:"table"`
+	Name  string      `json:"name" yaml:"name"`
+	Using interface{} `json:"using" yaml:"using"`
+}
+
+type createArrayRelationship struct {
+	Table tableArg    `json:"table" yaml:"table"`
+	Name  string      `json:"name" yaml:"name"`
+	Using interface{} `json:"using" yaml:"using"`
+}
+
+type dropRelationship struct {
+	Table        tableArg `json:"table" yaml:"table"`
+	Relationship string   `json:"relationship" yaml:"relationship"`
+}
+
+type manualConfiguration struct {
+	RemoteTable   interface{}       `json:"remote_table" yaml:"remote_table"`
+	ColumnMapping map[string]string `json:"column_mapping" yaml:"column_mapping"`
+}
+
+type objectRelationshipUsing struct {
+	ForeignKeyConstraintOn string               `json:"foreign_key_constraint_on,omitempty" yaml:"foreign_key_constraint_on,omitempty"`
+	ManualConfiguration    *manualConfiguration `json:"manual_configuration,omitempty" yaml:"manual_configuration,omitempty"`
+}
+
+type foreignKeyConstraintOn struct {
+	Table  interface{} `json:"table" yaml:"table"`
+	Column string      `json:"column" yaml:"column"`
+}
+
+type arrayRelationshipUsing struct {
+	ForeignKeyConstraintOn *foreignKeyConstraintOn `json:"foreign_key_constraint_on,omitempty" yaml:"foreign_key_constraint_on,omitempty"`
+	ManualConfiguration    *manualConfiguration    `json:"manual_configuration,omitempty" yaml:"manual_configuration,omitempty"`
+}

--- a/cli/util/headers.go
+++ b/cli/util/headers.go
@@ -1,0 +1,22 @@
+package util
+
+import "github.com/hasura/graphql-engine/cli/version"
+
+const (
+	XHasuraAdminSecret = "X-Hasura-Admin-Secret"
+	XHasuraAccessKey   = "X-Hasura-Access-Key"
+)
+
+func GetAdminSecretHeaderName(v *version.Version) string {
+	if v.ServerSemver == nil {
+		return XHasuraAdminSecret
+	}
+	flags, err := v.GetServerFeatureFlags()
+	if err != nil {
+		return XHasuraAdminSecret
+	}
+	if flags.HasAccessKey {
+		return XHasuraAccessKey
+	}
+	return XHasuraAdminSecret
+}

--- a/cli/util/migrate.go
+++ b/cli/util/migrate.go
@@ -1,0 +1,57 @@
+package util
+
+import (
+	"fmt"
+	"net/url"
+	"runtime"
+	"strings"
+
+	"github.com/hasura/graphql-engine/cli/migrate"
+	"github.com/hasura/graphql-engine/cli/version"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+func NewMigrate(dir string, db *url.URL, adminSecretValue string, logger *logrus.Logger, v *version.Version) (*migrate.Migrate, error) {
+	dbURL := GetDataPath(db, GetAdminSecretHeaderName(v), adminSecretValue)
+	fileURL := GetFilePath(dir)
+	t, err := migrate.New(fileURL.String(), dbURL.String(), true, logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create migrate instance")
+	}
+	return t, nil
+}
+
+func GetDataPath(nurl *url.URL, adminSecretHeader, adminSecretValue string) *url.URL {
+	host := &url.URL{
+		Scheme: "hasuradb",
+		Host:   nurl.Host,
+		Path:   nurl.Path,
+	}
+	q := nurl.Query()
+	// Set sslmode in query
+	switch scheme := nurl.Scheme; scheme {
+	case "https":
+		q.Set("sslmode", "enable")
+	default:
+		q.Set("sslmode", "disable")
+	}
+	if adminSecretValue != "" {
+		q.Add("headers", fmt.Sprintf("%s:%s", adminSecretHeader, adminSecretValue))
+	}
+	host.RawQuery = q.Encode()
+	return host
+}
+
+func GetFilePath(dir string) *url.URL {
+	host := &url.URL{
+		Scheme: "file",
+		Path:   dir,
+	}
+
+	// Add Prefix / to path if runtime.GOOS equals to windows
+	if runtime.GOOS == "windows" && !strings.HasPrefix(host.Path, "/") {
+		host.Path = "/" + host.Path
+	}
+	return host
+}


### PR DESCRIPTION
### Description
CLI will be having the below command in order to track and untrack tables, relationships across schemas.

```
# track all tables in public schema
hasura metadata track --all-tables [--schema public]

# track all tables and relationships in public schema
hasura metadata track --all-tables --all-relationships

# track only 2 tables and relationships among them
hasura metadata track --table author --table article --all-relationships

# track all tables in schema1 and schema2
hasura metadata track --all-tables --schema schema1 --schema schema2

# track only one table table1 from schema1
hasura metadata track --table table1 --schema schema1

# track all tables relationships, but export as migration
hasura metadata track --export-as-migration
```

```
# untrack all tables in a schema
hasura metadata untrack --all-tables --schema schema1

# untrack only 1 table
hasura metadata untrack --table table1 --schema schema1
```

### Affected components 
<!-- Remove non-affected components from the list -->

- CLI
- Docs

### Related Issues
#1418 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
~~Table and relationships across schemas cannot be tracked~~
