### PR TITLE
fix to show error notification when run sql fails in cli mode, close #2438

### DIFF
--- a/console/src/components/Services/Data/RawSQL/Actions.js
+++ b/console/src/components/Services/Data/RawSQL/Actions.js
@@ -128,9 +128,14 @@ const executeSQL = (isMigration, migrationName) => (dispatch, getState) => {
       }
       response.json().then(
         errorMsg => {
+          const title = 'SQL Execution Failed';
           dispatch({ type: UPDATE_MIGRATION_STATUS_ERROR, data: errorMsg });
           dispatch({ type: REQUEST_ERROR, data: errorMsg });
-          dispatch(handleMigrationErrors('SQL Execution Failed', errorMsg));
+          if (isMigration) {
+            dispatch(handleMigrationErrors(title, errorMsg));
+          } else {
+            dispatch(showErrorNotification(title, errorMsg.code, errorMsg));
+          }
         },
         () => {
           dispatch(

--- a/console/src/components/Services/Data/RawSQL/RawSQL.js
+++ b/console/src/components/Services/Data/RawSQL/RawSQL.js
@@ -80,7 +80,7 @@ const RawSQL = ({
       const isMigration = checkboxElem ? checkboxElem.checked : false;
       const textboxElem = document.getElementById('migration-name');
       let migrationName = textboxElem ? textboxElem.value : '';
-      if (migrationName.length === 0) {
+      if (isMigration && migrationName.length === 0) {
         migrationName = 'run_sql_migration';
       }
       if (!isMigration && globals.consoleMode === 'cli') {


### PR DESCRIPTION
### Description
Hasura console doesn't show error notifications in RUN SQL in CLI mode.

### Affected components 
<!-- Remove non-affected components from the list -->

- Console

### Related Issues
#2438 

### Solution and Design
Call handleMigrationErrors only when isMigration is set to true.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
