### PR TITLE
Clarify a few steps involved in running the server test suite

### DIFF
--- a/server/CONTRIBUTING.md
+++ b/server/CONTRIBUTING.md
@@ -92,17 +92,12 @@ pip3 install -r tests-py/requirements.txt
 ```
 
 - Make sure postgres is running
-- Run the graphql-engine:
-
-```
-stack exec graphql-engine -- --database-url=<database-url> serve --enable-console
-```
-
-- Set the environmental variables for event-trigger tests
+- Set the environmental variables for event-trigger tests and run the graphql-engine:
 
 ```
 export EVENT_WEBHOOK_HEADER="MyEnvValue"
 export WEBHOOK_FROM_ENV="http://127.0.0.1:5592"
+stack exec graphql-engine -- --database-url=<database-url> serve --enable-console --stringify-numeric-types
 ```
 
 - Run tests:


### PR DESCRIPTION
### Description

This PR makes two tiny changes to `server/CONTRIBUTING.md` that clarify things I bumped into when trying to run the tests for the first time myself:

  1. The event trigger environment variables need to be set for the server, not the test client.

  2. The server needs to be given the `--stringify-numeric-types` flag (or the corresponding environment variable needs to be set) in order for responses to match the output expected by the test suite.

### Affected components 

- Server
