### PR TITLE
allow Postgres readonly user to view hdb_primary_key (close #2429)

### DIFF
--- a/server/src-exec/Migrate.hs
+++ b/server/src-exec/Migrate.hs
@@ -19,7 +19,7 @@ import qualified Data.Yaml.TH                as Y
 import qualified Database.PG.Query           as Q
 
 curCatalogVer :: T.Text
-curCatalogVer = "17"
+curCatalogVer = "18"
 
 migrateMetadata
   :: ( MonadTx m
@@ -327,6 +327,10 @@ from16To17 =
              AND  table_name = 'hdb_allowlist';
            |]
 
+from17To18 :: MonadTx m => m ()
+from17To18 = liftTx $ Q.multiQE defaultTxErrorHandler
+  $(Q.sqlFromFile "src-rsr/migrate_from_17_to_18.sql")
+
 migrateCatalog
   :: ( MonadTx m
      , CacheRWM m
@@ -358,10 +362,13 @@ migrateCatalog migrationTime = do
      | preVer == "14"  -> from14ToCurrent
      | preVer == "15"  -> from15ToCurrent
      | preVer == "16"  -> from16ToCurrent
+     | preVer == "17"  -> from17ToCurrent
      | otherwise -> throw400 NotSupported $
                     "unsupported version : " <> preVer
   where
-    from16ToCurrent = from16To17 >> postMigrate
+    from17ToCurrent = from17To18 >> postMigrate
+
+    from16ToCurrent = from16To17 >> from17ToCurrent
 
     from15ToCurrent = from15To16 >> from16ToCurrent
 

--- a/server/src-rsr/initialise.sql
+++ b/server/src-rsr/initialise.sql
@@ -159,9 +159,9 @@ GROUP BY
 
 CREATE VIEW hdb_catalog.hdb_primary_key AS
 SELECT
-  nr.nspname as table_schema,
-  r.relname as table_name,
-  c.conname as constraint_name,
+  (nr.nspname :: information_schema.sql_identifier) as table_schema,
+  (r.relname :: information_schema.sql_identifier) as table_name,
+  (c.conname :: information_schema.sql_identifier) as constraint_name,
   json_agg(a.attname) as "columns"
 FROM
   pg_namespace nr,

--- a/server/src-rsr/initialise.sql
+++ b/server/src-rsr/initialise.sql
@@ -159,124 +159,28 @@ GROUP BY
 
 CREATE VIEW hdb_catalog.hdb_primary_key AS
 SELECT
-  tc.table_schema,
-  tc.table_name,
-  tc.constraint_name,
-  json_agg(constraint_column_usage.column_name) AS columns
+  nr.nspname as table_schema,
+  r.relname as table_name,
+  c.conname as constraint_name,
+  json_agg(a.attname) as "columns"
 FROM
-  (
-    (
-      SELECT
-        nr.nspname::information_schema.sql_identifier AS table_schema,
-        r.relname::information_schema.sql_identifier AS table_name,
-        c.conname::information_schema.sql_identifier AS constraint_name,
-        c.contype AS constraint_type
-      FROM
-        pg_namespace nr,
-        pg_constraint c,
-        pg_class r
-      WHERE
-        nr.oid = r.relnamespace
-        AND c.conrelid = r.oid
-        AND c.contype = 'p'
-        AND (r.relkind = ANY (ARRAY['r'::"char", 'p'::"char"]))
-        AND NOT pg_is_other_temp_schema(nr.oid)
-    ) tc
-    JOIN (
-      SELECT
-        x.tblschema AS table_schema,
-        x.tblname AS table_name,
-        x.colname AS column_name,
-        x.cstrname AS constraint_name
-      FROM
-        (
-          SELECT
-            DISTINCT nr.nspname,
-            r.relname,
-            a.attname,
-            c.conname
-          FROM
-            pg_namespace nr,
-            pg_class r,
-            pg_attribute a,
-            pg_depend d,
-            pg_namespace nc,
-            pg_constraint c
-          WHERE
-            (
-              (nr.oid = r.relnamespace)
-              AND (r.oid = a.attrelid)
-              AND (d.refclassid = ('pg_class' :: regclass) :: oid)
-              AND (d.refobjid = r.oid)
-              AND (d.refobjsubid = a.attnum)
-              AND (d.classid = ('pg_constraint' :: regclass) :: oid)
-              AND (d.objid = c.oid)
-              AND (c.connamespace = nc.oid)
-              AND (c.contype = 'c' :: "char")
-              AND (
-                r.relkind = ANY (ARRAY ['r'::"char", 'p'::"char"])
-              )
-              AND (NOT a.attisdropped)
-            )
-          UNION ALL
-          SELECT
-            nr.nspname,
-            r.relname,
-            a.attname,
-            c.conname
-          FROM
-            pg_namespace nr,
-            pg_class r,
-            pg_attribute a,
-            pg_namespace nc,
-            pg_constraint c
-          WHERE
-            (
-              (nr.oid = r.relnamespace)
-              AND (r.oid = a.attrelid)
-              AND (nc.oid = c.connamespace)
-              AND (
-                r.oid = CASE
-                  c.contype
-                  WHEN 'f' :: "char" THEN c.confrelid
-                  ELSE c.conrelid
-                END
-              )
-              AND (
-                a.attnum = ANY (
-                  CASE
-                    c.contype
-                    WHEN 'f' :: "char" THEN c.confkey
-                    ELSE c.conkey
-                  END
-                )
-              )
-              AND (NOT a.attisdropped)
-              AND (
-                c.contype = ANY (ARRAY ['p'::"char", 'u'::"char", 'f'::"char"])
-              )
-              AND (
-                r.relkind = ANY (ARRAY ['r'::"char", 'p'::"char"])
-              )
-            )
-        ) x (
-          tblschema,
-          tblname,
-          colname,
-          cstrname
-        )
-    ) constraint_column_usage ON (
-      (
-        (tc.constraint_name) :: text = (constraint_column_usage.constraint_name) :: text
-        AND (tc.table_schema) :: text = (constraint_column_usage.table_schema) :: text
-        AND (tc.table_name) :: text = (constraint_column_usage.table_name) :: text
-      )
-    )
-  )
-GROUP BY
-  tc.table_schema,
-  tc.table_name,
-  tc.constraint_name;
+  pg_namespace nr,
+  pg_class r,
+  pg_attribute a,
+  pg_namespace nc,
+  pg_constraint c
+WHERE
+  nr.oid = r.relnamespace
+  AND (r.oid = a.attrelid)
+  AND (nc.oid = c.connamespace)
+  -- only primary key constraint
+  AND (c.contype = 'p')
+  AND (r.oid = c.conrelid)
+  AND (a.attnum = ANY (c.conkey))
+  AND (NOT a.attisdropped)
+  -- 'normal table or partitioned table'
+  AND (r.relkind = 'r' OR r.relkind = 'p')
+GROUP BY (nr.nspname, r.relname, c.conname);
 
 CREATE FUNCTION hdb_catalog.inject_table_defaults(view_schema text, view_name text, tab_schema text, tab_name text) RETURNS void
 LANGUAGE plpgsql AS $$

--- a/server/src-rsr/migrate_from_17_to_18.sql
+++ b/server/src-rsr/migrate_from_17_to_18.sql
@@ -1,120 +1,24 @@
 CREATE OR REPLACE VIEW hdb_catalog.hdb_primary_key AS
 SELECT
-  tc.table_schema,
-  tc.table_name,
-  tc.constraint_name,
-  json_agg(constraint_column_usage.column_name) AS columns
+  nr.nspname as table_schema,
+  r.relname as table_name,
+  c.conname as constraint_name,
+  json_agg(a.attname) as "columns"
 FROM
-  (
-    (
-      SELECT
-        nr.nspname::information_schema.sql_identifier AS table_schema,
-        r.relname::information_schema.sql_identifier AS table_name,
-        c.conname::information_schema.sql_identifier AS constraint_name,
-        c.contype AS constraint_type
-      FROM
-        pg_namespace nr,
-        pg_constraint c,
-        pg_class r
-      WHERE
-        nr.oid = r.relnamespace
-        AND c.conrelid = r.oid
-        AND c.contype = 'p'
-        AND (r.relkind = ANY (ARRAY['r'::"char", 'p'::"char"]))
-        AND NOT pg_is_other_temp_schema(nr.oid)
-    ) tc
-    JOIN (
-      SELECT
-        x.tblschema AS table_schema,
-        x.tblname AS table_name,
-        x.colname AS column_name,
-        x.cstrname AS constraint_name
-      FROM
-        (
-          SELECT
-            DISTINCT nr.nspname,
-            r.relname,
-            a.attname,
-            c.conname
-          FROM
-            pg_namespace nr,
-            pg_class r,
-            pg_attribute a,
-            pg_depend d,
-            pg_namespace nc,
-            pg_constraint c
-          WHERE
-            (
-              (nr.oid = r.relnamespace)
-              AND (r.oid = a.attrelid)
-              AND (d.refclassid = ('pg_class' :: regclass) :: oid)
-              AND (d.refobjid = r.oid)
-              AND (d.refobjsubid = a.attnum)
-              AND (d.classid = ('pg_constraint' :: regclass) :: oid)
-              AND (d.objid = c.oid)
-              AND (c.connamespace = nc.oid)
-              AND (c.contype = 'c' :: "char")
-              AND (
-                r.relkind = ANY (ARRAY ['r'::"char", 'p'::"char"])
-              )
-              AND (NOT a.attisdropped)
-            )
-          UNION ALL
-          SELECT
-            nr.nspname,
-            r.relname,
-            a.attname,
-            c.conname
-          FROM
-            pg_namespace nr,
-            pg_class r,
-            pg_attribute a,
-            pg_namespace nc,
-            pg_constraint c
-          WHERE
-            (
-              (nr.oid = r.relnamespace)
-              AND (r.oid = a.attrelid)
-              AND (nc.oid = c.connamespace)
-              AND (
-                r.oid = CASE
-                  c.contype
-                  WHEN 'f' :: "char" THEN c.confrelid
-                  ELSE c.conrelid
-                END
-              )
-              AND (
-                a.attnum = ANY (
-                  CASE
-                    c.contype
-                    WHEN 'f' :: "char" THEN c.confkey
-                    ELSE c.conkey
-                  END
-                )
-              )
-              AND (NOT a.attisdropped)
-              AND (
-                c.contype = ANY (ARRAY ['p'::"char", 'u'::"char", 'f'::"char"])
-              )
-              AND (
-                r.relkind = ANY (ARRAY ['r'::"char", 'p'::"char"])
-              )
-            )
-        ) x (
-          tblschema,
-          tblname,
-          colname,
-          cstrname
-        )
-    ) constraint_column_usage ON (
-      (
-        (tc.constraint_name) :: text = (constraint_column_usage.constraint_name) :: text
-        AND (tc.table_schema) :: text = (constraint_column_usage.table_schema) :: text
-        AND (tc.table_name) :: text = (constraint_column_usage.table_name) :: text
-      )
-    )
-  )
-GROUP BY
-  tc.table_schema,
-  tc.table_name,
-  tc.constraint_name;
+  pg_namespace nr,
+  pg_class r,
+  pg_attribute a,
+  pg_namespace nc,
+  pg_constraint c
+WHERE
+  nr.oid = r.relnamespace
+  AND (r.oid = a.attrelid)
+  AND (nc.oid = c.connamespace)
+  -- only primary key constraint
+  AND (c.contype = 'p')
+  AND (r.oid = c.conrelid)
+  AND (a.attnum = ANY (c.conkey))
+  AND (NOT a.attisdropped)
+  -- 'normal table or partitioned table'
+  AND (r.relkind = 'r' OR r.relkind = 'p')
+GROUP BY (nr.nspname, r.relname, c.conname);

--- a/server/src-rsr/migrate_from_17_to_18.sql
+++ b/server/src-rsr/migrate_from_17_to_18.sql
@@ -1,0 +1,120 @@
+CREATE OR REPLACE VIEW hdb_catalog.hdb_primary_key AS
+SELECT
+  tc.table_schema,
+  tc.table_name,
+  tc.constraint_name,
+  json_agg(constraint_column_usage.column_name) AS columns
+FROM
+  (
+    (
+      SELECT
+        nr.nspname::information_schema.sql_identifier AS table_schema,
+        r.relname::information_schema.sql_identifier AS table_name,
+        c.conname::information_schema.sql_identifier AS constraint_name,
+        c.contype AS constraint_type
+      FROM
+        pg_namespace nr,
+        pg_constraint c,
+        pg_class r
+      WHERE
+        nr.oid = r.relnamespace
+        AND c.conrelid = r.oid
+        AND c.contype = 'p'
+        AND (r.relkind = ANY (ARRAY['r'::"char", 'p'::"char"]))
+        AND NOT pg_is_other_temp_schema(nr.oid)
+    ) tc
+    JOIN (
+      SELECT
+        x.tblschema AS table_schema,
+        x.tblname AS table_name,
+        x.colname AS column_name,
+        x.cstrname AS constraint_name
+      FROM
+        (
+          SELECT
+            DISTINCT nr.nspname,
+            r.relname,
+            a.attname,
+            c.conname
+          FROM
+            pg_namespace nr,
+            pg_class r,
+            pg_attribute a,
+            pg_depend d,
+            pg_namespace nc,
+            pg_constraint c
+          WHERE
+            (
+              (nr.oid = r.relnamespace)
+              AND (r.oid = a.attrelid)
+              AND (d.refclassid = ('pg_class' :: regclass) :: oid)
+              AND (d.refobjid = r.oid)
+              AND (d.refobjsubid = a.attnum)
+              AND (d.classid = ('pg_constraint' :: regclass) :: oid)
+              AND (d.objid = c.oid)
+              AND (c.connamespace = nc.oid)
+              AND (c.contype = 'c' :: "char")
+              AND (
+                r.relkind = ANY (ARRAY ['r'::"char", 'p'::"char"])
+              )
+              AND (NOT a.attisdropped)
+            )
+          UNION ALL
+          SELECT
+            nr.nspname,
+            r.relname,
+            a.attname,
+            c.conname
+          FROM
+            pg_namespace nr,
+            pg_class r,
+            pg_attribute a,
+            pg_namespace nc,
+            pg_constraint c
+          WHERE
+            (
+              (nr.oid = r.relnamespace)
+              AND (r.oid = a.attrelid)
+              AND (nc.oid = c.connamespace)
+              AND (
+                r.oid = CASE
+                  c.contype
+                  WHEN 'f' :: "char" THEN c.confrelid
+                  ELSE c.conrelid
+                END
+              )
+              AND (
+                a.attnum = ANY (
+                  CASE
+                    c.contype
+                    WHEN 'f' :: "char" THEN c.confkey
+                    ELSE c.conkey
+                  END
+                )
+              )
+              AND (NOT a.attisdropped)
+              AND (
+                c.contype = ANY (ARRAY ['p'::"char", 'u'::"char", 'f'::"char"])
+              )
+              AND (
+                r.relkind = ANY (ARRAY ['r'::"char", 'p'::"char"])
+              )
+            )
+        ) x (
+          tblschema,
+          tblname,
+          colname,
+          cstrname
+        )
+    ) constraint_column_usage ON (
+      (
+        (tc.constraint_name) :: text = (constraint_column_usage.constraint_name) :: text
+        AND (tc.table_schema) :: text = (constraint_column_usage.table_schema) :: text
+        AND (tc.table_name) :: text = (constraint_column_usage.table_name) :: text
+      )
+    )
+  )
+GROUP BY
+  tc.table_schema,
+  tc.table_name,
+  tc.constraint_name;

--- a/server/src-rsr/migrate_from_17_to_18.sql
+++ b/server/src-rsr/migrate_from_17_to_18.sql
@@ -1,8 +1,8 @@
 CREATE OR REPLACE VIEW hdb_catalog.hdb_primary_key AS
 SELECT
-  nr.nspname as table_schema,
-  r.relname as table_name,
-  c.conname as constraint_name,
+  (nr.nspname :: information_schema.sql_identifier) as table_schema,
+  (r.relname :: information_schema.sql_identifier) as table_name,
+  (c.conname :: information_schema.sql_identifier) as constraint_name,
   json_agg(a.attname) as "columns"
 FROM
   pg_namespace nr,


### PR DESCRIPTION
### Description
Postgres users with readonly access to tables are currently unable to select from the `hdb_catalog.hdb_primary_key` view. This PR fixes this.

### Affected components 
- Server

### Related Issues
#2429 

### Solution and Design
This issue was caused by the reliance of the `hdb_catalog.hdb_primary_key` view on the builtin Postgres view `information_schema.table_constraints`, which was not accessible to readonly users. This has been fixed by making the view directly dependent on the builtin Postgres tables - `pg_namespace`, `pg_constraint`, and `pg_class`. 

### Steps to test and verify
A Postgres user with readonly access to `hdb_catalog.hdb_primary_key` should be able to see all primary key constraints with the query:
```sql
SELECT * FROM hdb_catalog.hdb_primary_key;
```

### Limitations, known bugs & workarounds
None

### To the Reviewer (server)
- No new modules have been added
- A new catalog version (version 18) has been created with the updated `hdb_catalog.hdb_primary_key` definition

**Critical files**
- `src-exec/Migrate.hs`
- `src-rsr/initialise.sql`
- `src-rsr/migrate_from_17_to_18.sql`
