### PR TITLE
fix sql to return empty array when there are no columns in a table, close #2481

### DIFF
--- a/console/src/components/Services/Data/utils.js
+++ b/console/src/components/Services/Data/utils.js
@@ -377,7 +377,7 @@ FROM
         ):: regclass, 
         'pg_class'
       ) as comment, 
-      json_agg(
+      COALESCE(json_agg(
         row_to_json(isc) :: JSONB || jsonb_build_object(
           'comment', 
           (
@@ -399,7 +399,7 @@ FROM
               AND c.relname = isc.table_name
           )
         )
-      ) AS columns,
+      ) FILTER (WHERE isc.column_name IS NOT NULL), '[]' :: JSON) AS columns,
       row_to_json(isc_views) as view_info
     from 
       information_schema.tables AS ist 


### PR DESCRIPTION
### Description
When table has no columns, console gets the list of columns as [null] which breaks parsing. The columns should be []

### Affected components 
<!-- Remove non-affected components from the list -->

- Console

### Related Issues
#2481 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
