### PR TITLE
expose gc stats through dev api

### DIFF
--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -132,8 +132,9 @@ library
                      -- pretty printer
                      , ansi-wl-pprint
 
-                     -- metrics in multiplexed subs
+                     -- for capturing various metrics
                      , ekg-core
+                     , ekg-json
 
                      -- metrics for CI integration
                      , ci-info

--- a/server/src-lib/Hasura/Server/App.hs
+++ b/server/src-lib/Hasura/Server/App.hs
@@ -8,14 +8,15 @@ import           Control.Arrow                          ((***))
 import           Control.Concurrent.MVar
 import           Control.Exception                      (IOException, try)
 import           Data.Aeson                             hiding (json)
+import           Data.Int                               (Int64)
 import           Data.IORef
 import           Data.Time.Clock                        (UTCTime,
                                                          getCurrentTime)
+import           Data.Time.Clock.POSIX                  (getPOSIXTime)
 import           Network.Mime                           (defaultMimeLookup)
 import           Network.Wai                            (requestHeaders,
                                                          strictRequestBody)
 import           System.Exit                            (exitFailure)
-
 import           System.FilePath                        (joinPath, takeFileName)
 import           Web.Spock.Core
 
@@ -28,6 +29,8 @@ import qualified Network.HTTP.Types                     as N
 import qualified Network.Wai                            as Wai
 import qualified Network.Wai.Handler.WebSockets         as WS
 import qualified Network.WebSockets                     as WS
+import qualified System.Metrics                         as EKG
+import qualified System.Metrics.Json                    as EKG
 import qualified Text.Mustache                          as M
 import qualified Text.Mustache.Compile                  as M
 
@@ -119,6 +122,7 @@ data ServerCtx
   , scPlanCache       :: !E.PlanCache
   , scLQState         :: !EL.LiveQueriesState
   , scEnableAllowlist :: !Bool
+  , scEkgStore        :: !EKG.Store
   }
 
 data HandlerCtx
@@ -418,11 +422,18 @@ mkWaiApp isoLevel loggerCtx sqlGenCtx enableAL pool ci httpManager mode corsCfg
     wsServerEnv <- WS.createWSServerEnv logger pgExecCtx lqState cacheRef
                    httpManager corsPolicy sqlGenCtx enableAL planCache
 
+    ekgStore <- EKG.newStore
+
     let schemaCacheRef =
           SchemaCacheRef cacheLock cacheRef (E.clearPlanCache planCache)
         serverCtx = ServerCtx pgExecCtx ci logger
                     schemaCacheRef mode httpManager
-                    sqlGenCtx apis instanceId planCache lqState enableAL
+                    sqlGenCtx apis instanceId planCache
+                    lqState enableAL ekgStore
+
+    when (isDeveloperAPIEnabled serverCtx) $ do
+      EKG.registerGcMetrics ekgStore
+      EKG.registerCounter "ekg.server_timestamp_ms" getTimeMs ekgStore
 
     spockApp <- spockAsApp $ spockT id $
                 httpApp corsCfg serverCtx enableConsole
@@ -433,6 +444,9 @@ mkWaiApp isoLevel loggerCtx sqlGenCtx enableAL pool ci httpManager mode corsCfg
            , schemaCacheRef
            , cacheBuiltTime
            )
+  where
+    getTimeMs :: IO Int64
+    getTimeMs = (round . (* 1000)) `fmap` getPOSIXTime
 
 httpApp :: CorsConfig -> ServerCtx -> Bool -> Maybe Text -> Bool -> SpockT IO ()
 httpApp corsCfg serverCtx enableConsole consoleAssetsDir enableTelemetry = do
@@ -497,6 +511,11 @@ httpApp corsCfg serverCtx enableConsole consoleAssetsDir enableTelemetry = do
           v1GQHandler query
 
     when (isDeveloperAPIEnabled serverCtx) $ do
+      get "dev/ekg" $ mkSpockAction encodeQErr id serverCtx $
+        mkAPIRespHandler $ do
+          onlyAdmin
+          respJ <- liftIO $ EKG.sampleAll $ scEkgStore serverCtx
+          return $ HttpResponse (encJFromJValue $ EKG.sampleToJson respJ) Nothing
       get "dev/plan_cache" $ mkSpockAction encodeQErr id serverCtx $
         mkAPIRespHandler $ do
           onlyAdmin


### PR DESCRIPTION
This is not a user facing change. A new dev api `/dev/ekg` serves the gc statistics in json.  However unlike the `ekg` package, no UI is served to visualise this data. The dev apis are automatically enabled if you build with `stack build --flag graphql-engine:developer`. You'll then need to run graphql-engine with `-T` rts option.

I'm working on a small command line tool built using the assets in `ekg` package which would take graphql-engine's url as an argument and serves the ekg UI to visualise the data. Till then, you can do this instead:
```bash
git clone https://github.com/tibbe/ekg
cd ekg
```
change [this line](https://github.com/tibbe/ekg/blob/master/assets/monitor.js#L127) in `monitor.js` to `$.ajax("http://127.0.0.1:8080/dev/ekg", {`. Open `index.html` in your browser. 
