### PR TITLE
use all available cpu cores by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,6 +401,7 @@ jobs:
     - image: hasura/graphql-engine-console-builder:v0.3
       environment:
         CYPRESS_KEY: 983be0db-0f19-40cc-bfc4-194fcacd85e1
+        GHCRTS: -N1
     - image: circleci/postgres:10-alpine-postgis
       environment:
         POSTGRES_USER: gql_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,8 @@ refs:
     - run:
         name: Run Python tests
         environment:
+          # hpc report seems to fail with the default -N
+          GHCRTS: -N1
           HASURA_GRAPHQL_DATABASE_URL: 'postgres://gql_test:@localhost:5432/gql_test'
           HASURA_GRAPHQL_DATABASE_URL_2: 'postgres://gql_test:@localhost:5432/gql_test2'
           GRAPHQL_ENGINE: '/build/_server_output/graphql-engine'

--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -364,3 +364,4 @@ executable graphql-engine
                -Wincomplete-uni-patterns
                -Wredundant-constraints
                -threaded -rtsopts
+               -with-rtsopts=-N


### PR DESCRIPTION
graphql-engine now uses all the available cores on the machine (previously it had to be explicitly configured by setting `GHCRTS` env variable to `-N`). This behaviour can be changed by setting `GHCRTS` to `-N<n>` to restrict `graphql-engine` to `n` cores. For example, setting `GHCRTS` to `-N1` restricts graphql-engine to one core which was the behaviour till `beta.2`. 

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Affected components 
<!-- Remove non-affected components from the list -->

- Server


### Related Issues
#2316

### Solution and Design
Uses `-with-rtsopts` to set `-N` as the RTS option at compile time. 