### PR TITLE
fix: correct typo in 'Idea #2' section (close#2513)

### DIFF
--- a/architecture/live-queries.md
+++ b/architecture/live-queries.md
@@ -92,7 +92,7 @@ Incidentally, because we had started the engineering work behind Hasura many yea
 
 Because of implementing authorization at the application layer in Hasura (instead of using RLS and passing user-details via current session settings in the postgres connection) had significant benefits, which we’ll soon see.
 
-To summarise, wow that authorization is declarative and available at a table, view or even a function (if the function returns SETOF) it is possible to create a single SQL query that has the authorization rules.
+To summarise, now that authorization is declarative and available at a table, view or even a function (if the function returns SETOF) it is possible to create a single SQL query that has the authorization rules.
 
 GraphQL query → GraphQL AST → Internal AST with authorization rules → SQL AST → SQL
 


### PR DESCRIPTION
This change fixes a typo found on line 95 where the word 'wow' had been used instead of 'now'

### Description
N/A

### Affected components 
- Docs

### Related Issues
#2513 

### Solution and Design
<img width="1018" alt="Screen Shot 2019-07-11 at 6 15 12 PM" src="https://user-images.githubusercontent.com/14793389/61089113-1d503480-a408-11e9-9fc5-dcacb2689c38.png">


### Steps to test and verify
Look at screenshot above. 

### Limitations, known bugs & workarounds
None. 