### PR TITLE
community: learn: use cloudflare dns challenge

### DIFF
--- a/community/learn/graphql-tutorials/hasura-secret.yaml.sample
+++ b/community/learn/graphql-tutorials/hasura-secret.yaml.sample
@@ -7,3 +7,5 @@ stringData:
   adminSecret: ""
   jwtSecret: ""
   customJwtSecret: ""
+  cloudflareAPIKey: ""
+  cloudflareEmail: ""

--- a/community/learn/graphql-tutorials/manifests/caddy-config.yaml
+++ b/community/learn/graphql-tutorials/manifests/caddy-config.yaml
@@ -6,6 +6,9 @@ metadata:
 data:
   Caddyfile: |
     learn.hasura.io {
+      tls {
+        dns cloudflare
+      }
       redir 301 {
         /graphql/react/boilerplate.zip https://graphql-engine-cdn.hasura.io/learn-hasura/boilerplates/react/react-boilerplate.zip
       }
@@ -33,10 +36,6 @@ data:
 
       redir 301 {
         /graphql/elm/ /graphql/elm-graphql/introduction
-      }
-
-      redir 301 {
-        /graphql/elm/introduction /graphql/elm-graphql/introduction
       }
 
       redir 301 {

--- a/community/learn/graphql-tutorials/manifests/caddy.yaml
+++ b/community/learn/graphql-tutorials/manifests/caddy.yaml
@@ -21,7 +21,18 @@ spec:
         app: caddy
     spec:
       containers:
-      - image: abiosoft/caddy:0.11.5
+      - image: hasura/caddy-cf:latest
+        env:
+        - name: CLOUDFLARE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: cloudflareAPIKey
+              name: hasura-secret
+        - name: CLOUDFLARE_EMAIL
+          valueFrom:
+            secretKeyRef:
+              key: cloudflareEmail
+              name: hasura-secret
         command:
         - caddy
         - -conf


### PR DESCRIPTION
### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

This PR changes caddy configuration to use Cloudflare DNS challenge to
generate certificates for learn.hasura.io in light of the downtime
yesterday.

### Affected components 
<!-- Remove non-affected components from the list -->

- Community Content