### PR TITLE
change exported metadata filename (close #1772)

### DIFF
--- a/console/src/components/Services/Metadata/MetadataOptions/ExportMetadata.js
+++ b/console/src/components/Services/Metadata/MetadataOptions/ExportMetadata.js
@@ -48,7 +48,10 @@ class ExportMetadata extends Component {
                       encodeURIComponent(JSON.stringify(data));
                     const anchorElem = document.createElement('a');
                     anchorElem.setAttribute('href', dataStr);
-                    anchorElem.setAttribute('download', 'metadata.json');
+                    anchorElem.setAttribute(
+                      'download',
+                      `hasura_metadata_${Date.now()}.json`
+                    );
                     // The following fixes the download issue on firefox
                     document.body.appendChild(anchorElem);
                     anchorElem.click();

--- a/console/src/components/Services/Metadata/MetadataOptions/ExportMetadata.js
+++ b/console/src/components/Services/Metadata/MetadataOptions/ExportMetadata.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Endpoints, { globalCookiePolicy } from '../../../../Endpoints';
 import Button from '../../../Common/Button/Button';
+import { getCurrTimeForFileName } from './utils';
 
 import {
   showSuccessNotification,
@@ -46,19 +47,23 @@ class ExportMetadata extends Component {
                     const dataStr =
                       'data:text/json;charset=utf-8,' +
                       encodeURIComponent(JSON.stringify(data));
+
+                    const fileName =
+                      'hasura_metadata_' + getCurrTimeForFileName() + '.json';
+
                     const anchorElem = document.createElement('a');
                     anchorElem.setAttribute('href', dataStr);
-                    anchorElem.setAttribute(
-                      'download',
-                      `hasura_metadata_${Date.now()}.json`
-                    );
+                    anchorElem.setAttribute('download', fileName);
                     // The following fixes the download issue on firefox
                     document.body.appendChild(anchorElem);
                     anchorElem.click();
                     anchorElem.remove();
                     this.setState({ isExporting: false });
                     this.props.dispatch(
-                      showSuccessNotification('Metadata exported successfully!')
+                      showSuccessNotification(
+                        'Metadata exported successfully!',
+                        `Metadata file "${fileName}"`
+                      )
                     );
                   } else {
                     const parsedErrorMsg = data;

--- a/console/src/components/Services/Metadata/MetadataOptions/utils.js
+++ b/console/src/components/Services/Metadata/MetadataOptions/utils.js
@@ -6,23 +6,29 @@ export const getCurrTimeForFileName = () => {
     .getFullYear()
     .toString()
     .padStart(4, '0');
+
   const month = (currTime.getMonth() + 1).toString().padStart(2, '0');
+
   const date = currTime
     .getDate()
     .toString()
     .padStart(2, '0');
+
   const hours = currTime
     .getHours()
     .toString()
     .padStart(2, '0');
+
   const minutes = currTime
     .getMinutes()
     .toString()
     .padStart(2, '0');
+
   const seconds = currTime
     .getSeconds()
     .toString()
     .padStart(2, '0');
+
   const milliSeconds = currTime
     .getMilliseconds()
     .toString()

--- a/console/src/components/Services/Metadata/MetadataOptions/utils.js
+++ b/console/src/components/Services/Metadata/MetadataOptions/utils.js
@@ -1,0 +1,32 @@
+// return time in format YYYY_MM_DD_hh_mm_ss_s
+export const getCurrTimeForFileName = () => {
+  const currTime = new Date();
+
+  const year = currTime
+    .getFullYear()
+    .toString()
+    .padStart(4, '0');
+  const month = (currTime.getMonth() + 1).toString().padStart(2, '0');
+  const date = currTime
+    .getDate()
+    .toString()
+    .padStart(2, '0');
+  const hours = currTime
+    .getHours()
+    .toString()
+    .padStart(2, '0');
+  const minutes = currTime
+    .getMinutes()
+    .toString()
+    .padStart(2, '0');
+  const seconds = currTime
+    .getSeconds()
+    .toString()
+    .padStart(2, '0');
+  const milliSeconds = currTime
+    .getMilliseconds()
+    .toString()
+    .padStart(3, '0');
+
+  return [year, month, date, hours, minutes, seconds, milliSeconds].join('_');
+};

--- a/docs/graphql/manual/migrations/manage-metadata.rst
+++ b/docs/graphql/manual/migrations/manage-metadata.rst
@@ -30,7 +30,7 @@ Exporting Hasura metadata
 
      1. Click on the Settings gear icon at the top right corner of the console screen.
      2. In the Settings page that open, click on the ``Export Metadata`` button.
-     3. This will prompt a file download for ``metadata.json``. Save the file. 
+     3. This will prompt a file download for ``hasura_metadata_<timestamp>.json``. Save the file.
 
   .. tab:: API
 
@@ -41,9 +41,9 @@ Exporting Hasura metadata
 
      .. code-block:: bash
 
-        curl -d'{"type": "export_metadata", "args": {}}' http://localhost:8080/v1/query -o metadata.json
+        curl -d'{"type": "export_metadata", "args": {}}' http://localhost:8080/v1/query -o hasura_metadata.json
 
-     This command will create a ``metadata.json`` file. If admin secret is set,
+     This command will create a ``hasura_metadata.json`` file. If admin secret is set,
      add ``-H 'X-Hasura-Admin-Secret: <your-admin-secret>'`` as the API is an
      admin-only API.
 
@@ -61,7 +61,7 @@ the existing metadata with that instance.
 
      1. Click on the Settings gear icon at the top right corner of the console screen.
      2. Click on ``Import Metadata`` button.
-     3. Choose a ``metadata.json`` file that was exported earlier.
+     3. Choose a ``hasura_metadata.json`` file that was exported earlier.
      4. A notification should appear indicating the success or error.
 
   .. tab:: API
@@ -72,9 +72,9 @@ the existing metadata with that instance.
 
      .. code-block:: bash
 
-        curl -d'{"type":"replace_metadata", "args":'$(cat metadata.json)'}' http://localhost:8080/v1/query
+        curl -d'{"type":"replace_metadata", "args":'$(cat hasura_metadata.json)'}' http://localhost:8080/v1/query
 
-     This command will read ``metadata.json`` file and makes a POST request to
+     This command will read ``hasura_metadata.json`` file and makes a POST request to
      replace the metadata. If admin secret is set, add ``-H
      'X-Hasura-Admin-Secret: <your-admin-secret>'`` as the API is an admin-only
      API.

--- a/docs/graphql/manual/migrations/reference/how-it-works.rst
+++ b/docs/graphql/manual/migrations/reference/how-it-works.rst
@@ -27,7 +27,7 @@ data. One thing to note is that all the Postgres resources the metadata refers
 to should already exist when the import happens, otherwise Hasura will throw an
 error. 
 
-To understand the format of the ``metadata.json`` file, refer to :ref:`metadata_file_format`.
+To understand the format of the ``hasura_metadata.json`` file, refer to :ref:`metadata_file_format`.
 
 For more details on how to import and export metadata, refer to :ref:`manage_hasura_metadata`.
 

--- a/docs/graphql/manual/migrations/reference/metadata-file-format.rst
+++ b/docs/graphql/manual/migrations/reference/metadata-file-format.rst
@@ -9,7 +9,7 @@ Metadata file format reference
   :local:
 
 The metadata file that is exported from the server is a JSON/YAML representation
-of the Hausra metadata stored in ``hdb_catalog`` schema on the Postgres
+of the Hasura metadata stored in ``hdb_catalog`` schema on the Postgres
 database.
 
 The top level keys will be the following arrays:


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->


### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

**[THIS CHANGES EXISTING BEHAVIOUR]**

The current metadata file exported from the console has the filename `metadata.json` which is too generic and does not help finding the latest metadata file. This PR updates the name of metadata file to the format `hasura_metadata_<YYYY_MM_DD_hh_mm_ss_s>.json`.

 eg: `hasura_metadata_2019_07_23_17_28_03_225.json`

TODO:
- this breaks `metadata apply` on the CLI, will need to add support for the new format so that users can just export it and put it in the migrations image.

### Affected components 
<!-- Remove non-affected components from the list -->

- Console
- Docs
- CLI

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#1772

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Head to `/metadata/actions` page and hit Export Metadata. Observe downloaded file filename

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
