### PR TITLE
cli-migrations docker: use nc zero-i/o mode when waiting for port (close #1168)

### DIFF
--- a/scripts/cli-migrations/docker-entrypoint.sh
+++ b/scripts/cli-migrations/docker-entrypoint.sh
@@ -27,7 +27,7 @@ wait_for_port() {
     log "waiting $HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT for $PORT to be ready"
     for i in `seq 1 $HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT`;
     do
-        nc localhost $PORT > /dev/null 2>&1 && log "port $PORT is ready" && return
+        nc -z localhost $PORT > /dev/null 2>&1 && log "port $PORT is ready" && return
         sleep 1
     done
     log "failed waiting for $PORT" && exit 1


### PR DESCRIPTION
### Description
This change adds the `-z` option to the nc command when waiting for
a port to be ready. This ensures that we exit correctly reporting
connection status.

This ensures that the `nc` command returns fast, in all container run-time
scenarios.

### Affected components 
- docker/cli-migrations

### Related Issues
N/A

### Solution and Design
N/A

### Steps to test and verify
The original issue that lead to this fix was encountered when executing cli migration container as a secondary container within a CircleCI job. In this scenario, with the previous code, the service container would startup the temporary API server, and `nc` would connect to the expected port on `localhost` and wait for I/O. This caused the main job to fail as the migrations would have never run.

Verifying that there are no regressions in the cli-migration image should suffice.

### Limitations, known bugs & workarounds
N/A
