### PR TITLE
add flag to disable ci colors (close #2072)

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -21,7 +21,7 @@ import (
 	"github.com/briandowns/spinner"
 	"github.com/gofrs/uuid"
 	"github.com/hasura/graphql-engine/cli/version"
-	colorable "github.com/mattn/go-colorable"
+	"github.com/mattn/go-colorable"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -348,15 +348,19 @@ func (ec *ExecutionContext) setupLogger() {
 		logger := logrus.New()
 
 		logger.Formatter = &logrus.TextFormatter{
-			DisableColors:    ec.NoColor,
-			ForceColors:      !ec.NoColor,
+			ForceColors:      true,
 			DisableTimestamp: true,
 		}
 		logger.Out = colorable.NewColorableStdout()
 		ec.Logger = logger
 	}
 
-	println(ec.LogLevel)
+	if ec.NoColor {
+		ec.Logger.Formatter = &logrus.TextFormatter{
+			DisableColors:    true,
+			DisableTimestamp: true,
+		}
+	}
 
 	if ec.LogLevel != "" {
 		level, err := logrus.ParseLevel(ec.LogLevel)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -171,7 +171,7 @@ type ExecutionContext struct {
 	// LogLevel indicates the logrus default logging level
 	LogLevel string
 
-	// NoColor indicates if the outputs are colorized
+	// NoColor indicates if the outputs shouldn't be colorized
 	NoColor bool
 
 	// Telemetry collects the telemetry data throughout the execution

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -171,6 +171,9 @@ type ExecutionContext struct {
 	// LogLevel indicates the logrus default logging level
 	LogLevel string
 
+	// NoColor indicates if the outputs are colorized
+	NoColor bool
+
 	// Telemetry collects the telemetry data throughout the execution
 	Telemetry *telemetry.Data
 
@@ -343,13 +346,17 @@ func (ec *ExecutionContext) Spin(message string) {
 func (ec *ExecutionContext) setupLogger() {
 	if ec.Logger == nil {
 		logger := logrus.New()
+
 		logger.Formatter = &logrus.TextFormatter{
-			ForceColors:      true,
+			DisableColors:    ec.NoColor,
+			ForceColors:      !ec.NoColor,
 			DisableTimestamp: true,
 		}
 		logger.Out = colorable.NewColorableStdout()
 		ec.Logger = logger
 	}
+
+	println(ec.LogLevel)
 
 	if ec.LogLevel != "" {
 		level, err := logrus.ParseLevel(ec.LogLevel)

--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -70,6 +70,7 @@ func init() {
 	f.StringVar(&ec.LogLevel, "log-level", "INFO", "log level (DEBUG, INFO, WARN, ERROR, FATAL)")
 	f.StringVar(&ec.ExecutionDirectory, "project", "", "directory where commands are executed (default: current dir)")
 	f.BoolVar(&ec.SkipUpdateCheck, "skip-update-check", false, "Skip automatic update check on command execution")
+	f.BoolVar(&ec.NoColor, "no-color", false, "do not colorize output (default: false)")
 }
 
 // Execute executes the command and returns the error


### PR DESCRIPTION
Added a `--no-color` flag to address: (fix #2072 )

Makes it so that outputs wont get colorized

### Affected components 
- CLI

### Solution and Design
Used logrus' `DisableColor`

### Steps to test and verify
1. run `make build`
2. run the `$PATH_TO_OUTPUT/cli-hasura-{{.OS}}-{{.Arch}} version` to produce the colored output
3. run the `$PATH_TO_OUTPUT/cli-hasura-{{.OS}}-{{.Arch}} version --no-color` to produce the non colored output
