### PR TITLE
Properly wait for port 8080 to come up (fix #1168)

### DIFF
--- a/scripts/cli-migrations/docker-entrypoint.sh
+++ b/scripts/cli-migrations/docker-entrypoint.sh
@@ -27,7 +27,7 @@ wait_for_port() {
     log "waiting $HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT for $PORT to be ready"
     for i in `seq 1 $HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT`;
     do
-        nc localhost $PORT > /dev/null 2>&1 && log "port $PORT is ready" && return
+        nc -z localhost $PORT > /dev/null 2>&1 && log "port $PORT is ready" && return
         sleep 1
     done
     log "failed waiting for $PORT" && exit 1


### PR DESCRIPTION
From https://github.com/hasura/graphql-engine/issues/1168,
it seems that the `nc` command in this Docker entrypoint
doesn't include a necessary `-z` option.

See:
https://www.tutorialspoint.com/unix_commands/nc.htm