### PR TITLE
subscriptions can now be explained

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Explain.hs
+++ b/server/src-lib/Hasura/GraphQL/Explain.hs
@@ -3,12 +3,12 @@ module Hasura.GraphQL.Explain
   , GQLExplain
   ) where
 
-import qualified Data.Aeson                             as J
-import qualified Data.Aeson.Casing                      as J
-import qualified Data.Aeson.TH                          as J
-import qualified Data.HashMap.Strict                    as Map
-import qualified Database.PG.Query                      as Q
-import qualified Language.GraphQL.Draft.Syntax          as G
+import qualified Data.Aeson                                   as J
+import qualified Data.Aeson.Casing                            as J
+import qualified Data.Aeson.TH                                as J
+import qualified Data.HashMap.Strict                          as Map
+import qualified Database.PG.Query                            as Q
+import qualified Language.GraphQL.Draft.Syntax                as G
 
 import           Hasura.EncJSON
 import           Hasura.GraphQL.Context
@@ -20,11 +20,13 @@ import           Hasura.RQL.Types
 import           Hasura.SQL.Types
 import           Hasura.SQL.Value
 
-import qualified Hasura.GraphQL.Execute                 as E
-import qualified Hasura.GraphQL.Resolve                 as RS
-import qualified Hasura.GraphQL.Transport.HTTP.Protocol as GH
-import qualified Hasura.GraphQL.Validate                as GV
-import qualified Hasura.SQL.DML                         as S
+import qualified Hasura.GraphQL.Execute                       as E
+import qualified Hasura.GraphQL.Execute.LiveQuery             as EL
+import qualified Hasura.GraphQL.Execute.LiveQuery.Multiplexed as ELM
+import qualified Hasura.GraphQL.Resolve                       as RS
+import qualified Hasura.GraphQL.Transport.HTTP.Protocol       as GH
+import qualified Hasura.GraphQL.Validate                      as GV
+import qualified Hasura.SQL.DML                               as S
 
 data GQLExplain
   = GQLExplain
@@ -36,14 +38,14 @@ $(J.deriveJSON (J.aesonDrop 4 J.camelCase){J.omitNothingFields=True}
   ''GQLExplain
  )
 
-data FieldPlan
-  = FieldPlan
-  { _fpField :: !G.Name
-  , _fpSql   :: !(Maybe Text)
-  , _fpPlan  :: !(Maybe [Text])
+data QueryFieldPlan
+  = QueryFieldPlan
+  { _qfpField :: !G.Name
+  , _qfpSql   :: !(Maybe Text)
+  , _qfpPlan  :: !(Maybe [Text])
   } deriving (Show, Eq)
 
-$(J.deriveJSON (J.aesonDrop 3 J.camelCase) ''FieldPlan)
+$(J.deriveJSON (J.aesonDrop 3 J.camelCase) ''QueryFieldPlan)
 
 type Explain r =
   (ReaderT r (Except QErr))
@@ -79,31 +81,48 @@ getSessVarVal userInfo sessVar =
     rn = userRole userInfo
     usrVars = userVars userInfo
 
-explainField
-  :: (MonadTx m)
-  => UserInfo -> GCtx -> SQLGenCtx -> Field -> m FieldPlan
-explainField userInfo gCtx sqlGenCtx fld =
-  case fName of
-    "__type"     -> return $ FieldPlan fName Nothing Nothing
-    "__schema"   -> return $ FieldPlan fName Nothing Nothing
-    "__typename" -> return $ FieldPlan fName Nothing Nothing
-    _            -> do
-      unresolvedAST <-
-        runExplain (opCtxMap, userInfo, fldMap, orderByCtx, sqlGenCtx) $
-        RS.queryFldToPGAST fld
-      resolvedAST <- RS.traverseQueryRootFldAST (resolveVal userInfo)
-                     unresolvedAST
-      let txtSQL = Q.getQueryText $ RS.toPGQuery resolvedAST
-          withExplain = "EXPLAIN (FORMAT TEXT) " <> txtSQL
-      planLines <- liftTx $ map runIdentity <$>
-        Q.listQE dmlTxErrorHandler (Q.fromText withExplain) () True
-      return $ FieldPlan fName (Just txtSQL) $ Just planLines
+getUnresolvedAST
+  :: (MonadError QErr m)
+  => UserInfo -> GCtx -> SQLGenCtx
+  -> Field -> m RS.QueryRootFldUnresolved
+getUnresolvedAST userInfo gCtx sqlGenCtx fld =
+  runExplain (opCtxMap, userInfo, fldMap, orderByCtx, sqlGenCtx) $
+  RS.queryFldToPGAST fld
   where
-    fName = _fName fld
-
     opCtxMap = _gOpCtxMap gCtx
     fldMap = _gFields gCtx
     orderByCtx = _gOrdByCtx gCtx
+
+explainHasuraField
+  :: (MonadTx m)
+  => UserInfo -> RS.QueryRootFldUnresolved
+  -> m (Text, [Text])
+explainHasuraField userInfo unresolvedAST = do
+  resolvedAST <- RS.traverseQueryRootFldAST (resolveVal userInfo)
+                 unresolvedAST
+  explainPgQuery (RS.toPGQuery resolvedAST) ()
+
+explainPgQuery
+  :: (MonadTx m, Q.ToPrepArgs a)
+  => Q.Query
+  -> a
+  -> m (Text, [Text])
+explainPgQuery query args = do
+  let txtSQL = Q.getQueryText query
+      withExplain = "EXPLAIN (FORMAT TEXT) " <> txtSQL
+  planLines <- liftTx $ map runIdentity <$>
+    Q.listQE dmlTxErrorHandler (Q.fromText withExplain) args True
+  return (txtSQL, planLines)
+
+data SubscriptionExplainOutput
+  = SubscriptionExplainOutput
+  { _seoIsMultiplexable :: !Bool
+  -- only exists when subscription is not multiplexed
+  , _seoReason          :: !(Maybe Text)
+  , _seoSql             :: !Text
+  , _seoPlan            :: ![Text]
+  } deriving (Show, Eq)
+$(J.deriveJSON (J.aesonDrop 4 J.camelCase) ''SubscriptionExplainOutput)
 
 explainGQLQuery
   :: (MonadError QErr m, MonadIO m)
@@ -113,23 +132,70 @@ explainGQLQuery
   -> Bool
   -> GQLExplain
   -> m EncJSON
-explainGQLQuery pgExecCtx sc sqlGenCtx enableAL (GQLExplain query userVarsRaw) = do
-  execPlan <- E.getExecPlanPartial userInfo sc enableAL query
-  (gCtx, rootSelSet) <- case execPlan of
-    E.GExPHasura (gCtx, rootSelSet, _) ->
-      return (gCtx, rootSelSet)
-    E.GExPRemote _ _  ->
+explainGQLQuery pgExecCtx sc sqlGenCtx enableAllowList
+  (GQLExplain query userVarsRaw) = do
+
+  execPlan <- E.getExecPlanPartial userInfo sc enableAllowList query
+  (gCtx, rootSelSet, varDefs) <- case execPlan of
+    E.GExPHasura ctx -> return ctx
+    E.GExPRemote _ _ ->
       throw400 InvalidParams "only hasura queries can be explained"
   case rootSelSet of
     GV.RQuery selSet -> do
-      let tx = mapM (explainField userInfo gCtx sqlGenCtx) (toList selSet)
-      plans <- liftIO (runExceptT $ runLazyTx pgExecCtx tx) >>= liftEither
+      let tx = mapM (explainQueryField gCtx) (toList selSet)
+      plans <- runTx tx
       return $ encJFromJValue plans
     GV.RMutation _ ->
-      throw400 InvalidParams "only queries can be explained"
-    GV.RSubscription _ ->
-      throw400 InvalidParams "only queries can be explained"
-
+      throw400 InvalidParams "only queries/subscriptions can be explained"
+    GV.RSubscription subsField ->
+      encJFromJValue <$> explainSubscriptionField gCtx subsField varDefs
   where
     usrVars  = mkUserVars $ maybe [] Map.toList userVarsRaw
     userInfo = mkUserInfo (fromMaybe adminRole $ roleFromVars usrVars) usrVars
+
+    runTx :: (MonadIO m, MonadError QErr m) => LazyTx QErr a -> m a
+    runTx tx = liftIO (runExceptT $ runLazyTx pgExecCtx tx) >>= liftEither
+
+    explainQueryField :: (MonadTx m) => GCtx -> Field -> m QueryFieldPlan
+    explainQueryField gCtx fld =
+      case fName of
+        "__type"     -> return $ QueryFieldPlan fName Nothing Nothing
+        "__schema"   -> return $ QueryFieldPlan fName Nothing Nothing
+        "__typename" -> return $ QueryFieldPlan fName Nothing Nothing
+        _            -> do
+          unresolvedAST <- getUnresolvedAST userInfo gCtx sqlGenCtx fld
+          (txtSQL, planLines) <- explainHasuraField userInfo unresolvedAST
+          return $ QueryFieldPlan fName (Just txtSQL) $ Just planLines
+      where
+        fName = _fName fld
+
+    explainSubscriptionField
+      :: (MonadIO m, MonadError QErr m)
+      => GCtx -> Field -> [G.VariableDefinition] -> m SubscriptionExplainOutput
+    explainSubscriptionField gCtx subsField varDefs = do
+
+      -- we only partially resolve the live query operation so that
+      -- we have the necessary information to explain the underlying queries
+      astUnresolved      <- getUnresolvedAST userInfo gCtx sqlGenCtx subsField
+      liveQueryOpPartial <- EL.getLiveQueryOpPartial pgExecCtx varDefs astUnresolved
+
+      (isMultiPlexed, reasonM, explainTx) <- case liveQueryOpPartial of
+
+        -- in case of fallback, the output will be the same as that of the query
+        EL.LQFallback (_, nonConfirmingVariables) -> do
+          let reason = "the following variables are not non-nullable scalars: " <>
+                       GV.showVars (toList nonConfirmingVariables)
+          return (False, Just reason, explainHasuraField userInfo astUnresolved)
+
+        -- in case of multiplexed, we show the multiplexed query that is
+        -- used for all such subscirptions, but it is 'explain analyz'ed with
+        -- only the arguments of the given subscription
+        EL.LQMultiplexed (_, mxQuery, txtEncodedVars) -> do
+          -- every mx subscription needs a unique id
+          respId <- liftIO ELM.newRespId
+          let respVars    = ELM.getRespVars usrVars txtEncodedVars
+              mxQueryArgs = ELM.mkMxQueryArgs [(respId, respVars)]
+              explainTx   = explainPgQuery mxQuery mxQueryArgs
+          return (True, Nothing, explainTx)
+      (txtSQL, planLines) <- runTx explainTx
+      return $ SubscriptionExplainOutput isMultiPlexed reasonM txtSQL planLines

--- a/server/src-lib/Hasura/GraphQL/Resolve.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve.hs
@@ -2,6 +2,7 @@ module Hasura.GraphQL.Resolve
   ( mutFldToTx
   , queryFldToPGAST
   , RS.traverseQueryRootFldAST
+  , RS.QueryRootFldResolved
   , RS.toPGQuery
   , UnresolvedVal(..)
   , AnnPGVal(..)

--- a/server/stack.yaml
+++ b/server/stack.yaml
@@ -2,7 +2,7 @@
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
 # resolver: lts-10.8
-resolver: lts-13.20
+resolver: lts-13.30
 # Local packages, usually specified by relative directory name
 packages:
 - '.'

--- a/server/stack.yaml.lock
+++ b/server/stack.yaml.lock
@@ -97,7 +97,7 @@ packages:
     hackage: Spock-core-0.13.0.0
 snapshots:
 - completed:
-    size: 498167
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/20.yaml
-    sha256: cda928d57b257a5f17bcad796843c9daa674fef47d600dbea3aa7b0e49d64a11
-  original: lts-13.20
+    size: 500539
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/30.yaml
+    sha256: 59ad6b944c9903847fecdc1d4815e8500c1f9999d80fd1b4d2d66e408faec44b
+  original: lts-13.30


### PR DESCRIPTION
Currently the 'Analyze' button only works with queries. This PR adds support for subscriptions which lets one check 
1. If a subscription can be multiplexed (and why it if can't be). 
2. The underlying query 
3. The postgres plan. 

### Affected components 
<!-- Remove non-affected components from the list -->

- Server
- Console

### Related Issues
#2541 

### Solution and Design
This is part of the current `v1/graphql/explain` endpoint. For a subscription the response structure will be as follows:
```json
{
  "is_multiplexable": true,
  "reason": null,
  "sql": "\n        select\n          _subs.result_id, _fld_resp.root as result\n          from\n            unnest(\n              $1::uuid[], $2::json[]\n            ) _subs (result_id, result_vars)\n          left outer join lateral\n            (\n        SELECT  coalesce(json_agg(\"root\" ), '[]' ) AS \"root\" FROM  (SELECT  row_to_json((SELECT  \"_1_e\"  FROM  (SELECT  \"_0_root.base\".\"id\" AS \"id\", \"_0_root.base\".\"name\" AS \"name\"       ) AS \"_1_e\"      ) ) AS \"root\" FROM  (SELECT  *  FROM \"public\".\"artists\"  WHERE ((\"public\".\"artists\".\"id\") = (((\"_subs\".\"result_vars\"#>>ARRAY['variables', 'artist_id']))::integer))     ) AS \"_0_root.base\"      ) AS \"_2_root\"      \n            ) _fld_resp ON ('true')\n        ",
  "plan": [
    "Nested Loop Left Join  (cost=2.40..243.00 rows=100 width=48)",
    "  ->  Function Scan on _subs  (cost=0.01..1.00 rows=100 width=48)",
    "  ->  Aggregate  (cost=2.39..2.40 rows=1 width=32)",
    "        ->  Index Scan using pk_artists on artists  (cost=0.15..2.37 rows=1 width=25)",
    "              Index Cond: (id = ((_subs.result_vars #>> '{variables,artist_id}'::text[]))::integer)",
    "        SubPlan 1",
    "          ->  Result  (cost=0.00..0.01 rows=1 width=32)"
  ]
}
```
The fields are:
1. `is_multiplexable`: If `true` the subscription can be multiplexed.
2. `reason`: Why the server thinks that the subscription cannot be multiplexed (`null` if `is_multiplexed` is `true`).
3. `sql`: The sql used in fetching the results for the subscription. In case of multiplexed subscriptions, the query will be different (to accommodate fetching the results of multiple subscriptions in the same query). 
4. `plan`: Postgres's `explain analyze` for the above `sql`. 

### Steps to test and verify
Needs console changes

### Limitations, known bugs & workarounds
None

