### PR TITLE
improve console logic for view updatability check (fix #2667)

### DIFF
--- a/console/src/components/Services/Data/TablePermissions/Permissions.js
+++ b/console/src/components/Services/Data/TablePermissions/Permissions.js
@@ -239,8 +239,10 @@ class Permissions extends Component {
           tableType === 'view' &&
           !(
             tableSchema.view_info &&
-            tableSchema.view_info.is_insertable_into === 'YES' &&
-            tableSchema.view_info.is_updatable === 'YES'
+            (tableSchema.view_info.is_insertable_into === 'YES' ||
+              tableSchema.view_info.is_trigger_insertable_into === 'YES') &&
+            (tableSchema.view_info.is_updatable === 'YES' ||
+              tableSchema.view_info.is_trigger_updatable === 'YES')
           )
         ) {
           hasPermissions = false;
@@ -1770,7 +1772,10 @@ class Permissions extends Component {
 
       // Add insert/update permission if it is insertable/updatable as returned by pg
       if (tSchema.view_info) {
-        if (tSchema.view_info.is_insertable_into === 'YES') {
+        if (
+          tSchema.view_info.is_insertable_into === 'YES' ||
+          tSchema.view_info.is_trigger_insertable_into === 'YES'
+        ) {
           qTypes.push('insert');
         }
 
@@ -1779,6 +1784,14 @@ class Permissions extends Component {
         if (tSchema.view_info.is_updatable === 'YES') {
           qTypes.push('update');
           qTypes.push('delete');
+        } else {
+          if (tSchema.view_info.is_trigger_updatable === 'YES') {
+            qTypes.push('update');
+          }
+
+          if (tSchema.view_info.is_trigger_deletable === 'YES') {
+            qTypes.push('delete');
+          }
         }
       } else {
         qTypes.push('select');


### PR DESCRIPTION
### Description
Currently, the console checks `is_updatable`, and `is_insertable_into` to check whether to display permissions for insert, update and delete. However, for slightly more complex view with an associated `INSTEAD OF` trigger, the `is_updatable`, and `is_insertable_into` might be `'NO'`, while the is_trigger_insertable_into, is_trigger_updatable, is_trigger_deletable columns might be `'YES'`. In this case, we would still like to be able to set permissions for these operations.

### Affected components 
- Console

### Related Issues
#2667 

### Solution and Design
This PR adds in checks for the is_trigger_* columns when determining whether to display insert, update, and delete permissions.

### Steps to test and verify
See #2667 for an example schema for testing and verifying the fix.

### Limitations, known bugs & workarounds
This PR is fairly minimal in terms of adding in use of the necessary columns. However, given that `hdb_catalog.hdb_table_info_agg.view_info` also exposes required information more concisely, it might be worth looking into replacing the entire `information_schema` query with one to `hdb_catalog.hdb_table_info_agg`, for the purposes of centralising logic, but that's well out of scope for this PR.
