### PR TITLE
capture Postgres error code 22025 as HTTP 400 bad request  (close #2486)

### DIFF
--- a/server/src-lib/Hasura/RQL/DML/Internal.hs
+++ b/server/src-lib/Hasura/RQL/DML/Internal.hs
@@ -322,6 +322,8 @@ simplifyError txErr = do
       ("42704", msg) -> return (ConstraintError, msg)
       -- invalid input values
       ("22007", msg) -> return (DataException, msg)
+      -- invalid escape sequence
+      ("22025", msg) -> return (BadRequest, msg)
       _              -> Nothing
 
 -- validate limit and offset int values

--- a/server/src-lib/Hasura/RQL/Types/Error.hs
+++ b/server/src-lib/Hasura/RQL/Types/Error.hs
@@ -72,6 +72,7 @@ data Code
   | AlreadyInit
   | ConstraintViolation
   | DataException
+  | BadRequest
   -- Graphql error
   | NoTables
   | ValidationFailed
@@ -92,6 +93,7 @@ instance Show Code where
   show = \case
     NotNullViolation      -> "not-null-violation"
     DataException         -> "data-exception"
+    BadRequest            -> "bad-request"
     ConstraintViolation   -> "constraint-violation"
     PermissionDenied      -> "permission-denied"
     NotExists             -> "not-exists"

--- a/server/tests-py/queries/graphql_query/basic/select_query_invalid_escape_sequence.yaml
+++ b/server/tests-py/queries/graphql_query/basic/select_query_invalid_escape_sequence.yaml
@@ -1,0 +1,18 @@
+description: GraphQL query with invalid escape sequence
+url: /v1/graphql
+status: 200
+response:
+  errors:
+  - extensions:
+      code: bad-request
+      path: $
+    message: |-
+      LIKE pattern must not end with escape character
+query:
+  query: |
+    query {
+      person(where: {name: {_like: "John\\"}}) {
+        id
+        name
+      }
+    }

--- a/server/tests-py/queries/graphql_query/basic/setup.yaml
+++ b/server/tests-py/queries/graphql_query/basic/setup.yaml
@@ -271,6 +271,23 @@ args:
     - name: User 2
       number: '123456780'
 
+- type: run_sql
+  args:
+    sql: |
+      create table person (
+          id serial primary key,
+          name text
+      );
+- type: track_table
+  args:
+    schema: public
+    name: person
+- type: insert
+  args:
+    table: person
+    objects:
+    - name: "John\\"
+
 #Set timezone
 - type: run_sql
   args:

--- a/server/tests-py/queries/graphql_query/basic/teardown.yaml
+++ b/server/tests-py/queries/graphql_query/basic/teardown.yaml
@@ -32,6 +32,11 @@ args:
 - type: run_sql
   args:
     sql: |
+      drop table person
+
+- type: run_sql
+  args:
+    sql: |
       drop type complex
 
 - type: run_sql

--- a/server/tests-py/test_graphql_queries.py
+++ b/server/tests-py/test_graphql_queries.py
@@ -50,6 +50,10 @@ class TestGraphQLQueryBasic(DefaultTestSelectQueries):
         transport = 'http'
         check_query_f(hge_ctx, self.dir() + "/nested_select_with_foreign_key_alter.yaml", transport)
 
+    def test_select_query_invalid_escape_sequence(self, hge_ctx, transport):
+        transport = 'http'
+        check_query_f(hge_ctx, self.dir() + "/select_query_invalid_escape_sequence.yaml", transport)
+
     @classmethod
     def dir(cls):
         return 'queries/graphql_query/basic'


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

The server used to throw HTTP `500` exception for invalid `_like` pattern. Change it to
`400 Bad Request`.

### Affected components 
<!-- Remove non-affected components from the list -->

- Server
- Tests

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

fix #2486 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

Capture `22025` Postgres error code and convert it into `400 Bad Request`.


### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

Follow the reproduction guide in #2486 

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
