### PR TITLE
Use SIGINT as the stopsignal in the dockerfile

### DIFF
--- a/server/packaging/Dockerfile
+++ b/server/packaging/Dockerfile
@@ -23,4 +23,5 @@ RUN upx /packaging/build/rootfs/bin/${project}
 
 # Stage 3: copy the rootfs into a scratch container
 FROM scratch
+STOPSIGNAL SIGINT
 COPY --from=packager /packaging/build/rootfs /


### PR DESCRIPTION
### Description
Haskell expects the signal to be `SIGINT`, but the docker default is
`SIGTERM`.

Correcting this.
### Affected components 
<!-- Remove non-affected components from the list -->

- Server
- Build System