### PR TITLE
fix typo in cli

### DIFF
--- a/cli/commands/migrate_apply.go
+++ b/cli/commands/migrate_apply.go
@@ -39,7 +39,7 @@ func newMigrateApplyCmd(ec *cli.ExecutionContext) *cobra.Command {
 
 	f.StringVar(&opts.upMigration, "up", "", "apply all or N up migration steps")
 	f.StringVar(&opts.downMigration, "down", "", "apply all or N down migration steps")
-	f.StringVar(&opts.versionMigration, "version", "", "migrate the database to a specific version")
+	f.StringVar(&opts.versionMigration, "version", "", "only apply this particular migration")
 	f.StringVar(&opts.migrationType, "type", "up", "type of migration (up, down) to be used with version flag")
 	f.BoolVar(&opts.skipExecution, "skip-execution", false, "skip executing the migration action, but mark them as applied")
 

--- a/cli/commands/update-cli.go
+++ b/cli/commands/update-cli.go
@@ -67,7 +67,7 @@ func (o *updateOptions) run(showPrompt bool) error {
 	if showPrompt {
 		ok := ask2confirm(latestVersion.String(), o.EC.Logger)
 		if !ok {
-			o.EC.Logger.Info("skippig update, run 'hasura update-cli' to update manually")
+			o.EC.Logger.Info("skipping update, run 'hasura update-cli' to update manually")
 			return nil
 		}
 	}


### PR DESCRIPTION
### Affected components 
- CLI

### Related Issues
This was small enough that it seemed like unnecessary overhead to create an issue.