### PR TITLE
Fix websocket race condition in server test suite (fix #2710)

### DIFF
--- a/server/tests-py/validate.py
+++ b/server/tests-py/validate.py
@@ -206,7 +206,6 @@ def validate_gql_ws_q(hge_ctx, endpoint, query, headers, exp_http_response, retr
             #Got query complete before payload. Retry once more
             print("Got query complete before getting query response payload. Retrying")
             ws_client.recreate_conn()
-            time.sleep(3)
             return validate_gql_ws_q(hge_ctx, query, headers, exp_http_response, False)
         else:
             assert resp['type'] in ['data', 'error'], resp


### PR DESCRIPTION
### Description

This fixes a race condition in the server tests that has been causing regular test failures in CI. I can’t explain

  1. why exactly this race condition, which intuitively seems very unlikely to happen, has been manifesting so consistently,

  2. why it only started happening recently despite no relevant code changes I can see,

  3. or why it only seems to have affected one particular test that does not seem any more likely to trigger it than either of two other tests in the same file.

Based on some logging I put into the test suite to investigate this issue, my guess as to point 1 is that Python’s thread scheduler was doing something funky, and my explanation for point 3 is that it’s the first test of its group to run, which somehow changed enough state someplace (whether in a CPU cache somewhere or otherwise) to avoid the race. I have no explanation at all for point 2.

### Affected components 

- Tests (Server)

### Related Issues

#2710

### Solution and Design

The existing code has some sketchy uses of `sleep` that assume certain things will happen in particular amounts of time. Usually, those assumptions are right, but sometimes they aren’t. This removes those calls to `sleep` in favor of using `threading.Event`, an explicit synchronization primitive.