### PR TITLE
get all Set-Cookie headers (fix # 2688)

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Execute.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute.hs
@@ -378,8 +378,8 @@ execRemoteGQ reqId userInfo reqHdrs q rsi opDef = do
   liftIO $ logGraphqlQuery logger $ QueryLog q Nothing reqId
   res  <- liftIO $ try $ Wreq.postWith options (show url) (J.toJSON q)
   resp <- either httpThrow return res
-  let cookieHdr = getCookieHdr (resp ^? Wreq.responseHeader "Set-Cookie")
-      respHdrs  = Just $ mkRespHeaders cookieHdr
+  let cookieHdrs = getCookieHdr (resp ^.. Wreq.responseHeader "Set-Cookie")
+      respHdrs  = Just $ mkRespHeaders cookieHdrs
   return $ HttpResponse (encJFromLBS $ resp ^. Wreq.responseBody) respHdrs
 
   where
@@ -396,7 +396,7 @@ execRemoteGQ reqId userInfo reqHdrs q rsi opDef = do
       in map (\(k, v) -> (CI.mk $ CS.cs k, CS.cs v)) $
          filter (not . isUserVar . fst) txHdrs
 
-    getCookieHdr = maybe [] (\h -> [("Set-Cookie", h)])
+    getCookieHdr = fmap (\h -> ("Set-Cookie", h))
 
     mkRespHeaders hdrs =
       map (\(k, v) -> Header (bsToTxt $ CI.original k, bsToTxt v)) hdrs


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description

Read all `Set-Cookie` headers from Remote Schema response and fwd them to the client. 

### Affected components 
<!-- Remove non-affected components from the list -->

- Server

### Related Issues

#2688 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

Read all `Set-Cookie` headers.


