### PR TITLE
accept null values in order_by input field (fix #2754)

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Resolve/InputValue.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/InputValue.hs
@@ -4,6 +4,7 @@ module Hasura.GraphQL.Resolve.InputValue
   , asPGColValM
   , asPGColVal
   , asEnumVal
+  , asEnumValM
   , withObject
   , asObject
   , withObjectM
@@ -69,6 +70,13 @@ asEnumVal v = case _aivValue v of
   AGEnum ty (Just val) -> return (ty, val)
   AGEnum ty Nothing ->
     throw500 $ "unexpected null for ty " <> showNamedTy ty
+  _              -> tyMismatch "enum" v
+
+asEnumValM
+  :: (MonadError QErr m)
+  => AnnInpVal -> m (G.NamedType, Maybe G.EnumValue)
+asEnumValM v = case _aivValue v of
+  AGEnum ty valM -> return (ty, valM)
   _              -> tyMismatch "enum" v
 
 withObject

--- a/server/tests-py/queries/graphql_query/order_by/articles_order_by_null.yaml
+++ b/server/tests-py/queries/graphql_query/order_by/articles_order_by_null.yaml
@@ -1,0 +1,23 @@
+description: Fetch articles by using null values in order_by
+url: /v1/graphql
+status: 200
+response:
+  data:
+    article:
+    - title: Article 1
+    - title: Article 2
+    - title: Article 3
+query:
+  variables:
+    author_order_by: null
+  query: |
+    query ($order_by: order_by, $author_order_by: author_order_by){
+      article(
+        order_by: [ {id: $order_by}
+                  , {author: $author_order_by}
+                  , {author: {articles_aggregate: {count: $order_by}}}
+                  ]
+      ){
+        title
+      }
+    }

--- a/server/tests-py/test_graphql_queries.py
+++ b/server/tests-py/test_graphql_queries.py
@@ -364,6 +364,9 @@ class TestGraphQLQueryOrderBy(DefaultTestSelectQueries):
     def test_articles_order_by_rel_author_rel_contact_phone(self, hge_ctx, transport):
         check_query_f(hge_ctx, self.dir() + '/articles_order_by_rel_author_rel_contact_phone.yaml', transport)
 
+    def test_articles_order_by_null(self, hge_ctx, transport):
+        check_query_f(hge_ctx, self.dir() + '/articles_order_by_null.yaml', transport)
+
     def test_album_order_by_tracks_count(self, hge_ctx, transport):
         check_query_f(hge_ctx, self.dir() + '/album_order_by_tracks_count.yaml', transport)
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

The server used to throw `500 Internal` error when `null` value is provided against input fields in `<table-name>_order_by` input object.

Query:-
```graphql
query {
  article(order_by: [{id: null}]) {
    title
  }
}
```

Response:-
```json
{
  "errors": [
    {
      "extensions": {
        "path": "$.selectionSet.article.args.order_by",
        "code": "unexpected"
      },
      "message": "unexpected null for ty 'order_by'"
    }
  ]
}

This PR fixes this issue.
```

### Affected components 
<!-- Remove non-affected components from the list -->

- Server
- Tests

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
fixes #2754 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

- Consider `Maybe` values for all input fields under `order_by` input. The value is `Nothing` when `null` is provided. Omit the input if `Nothing` is found. 

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Follow the test case added in this PR
