### PR TITLE
fix issue with editing boolean fields (fix #2536)

### DIFF
--- a/console/src/components/Services/Data/TableBrowseRows/EditItem.js
+++ b/console/src/components/Services/Data/TableBrowseRows/EditItem.js
@@ -82,7 +82,9 @@ class EditItem extends Component {
         refs[colName].valueNode = node;
       };
       const clicker = e => {
-        e.target.closest('.radio-inline').click();
+        e.target
+          .closest('.radio-inline')
+          .querySelector('input[type="radio"]').checked = true;
         e.target.focus();
       };
 

--- a/console/src/components/Services/Data/TableInsertItem/InsertItem.js
+++ b/console/src/components/Services/Data/TableInsertItem/InsertItem.js
@@ -9,8 +9,6 @@ import TextInput from '../../../Common/CustomInputTypes/TextInput';
 import Button from '../../../Common/Button/Button';
 import { getPlaceholder, BOOLEAN, JSONB, JSONDTYPE, TEXT } from '../utils';
 
-import { getParentNodeByClass } from '../../../../utils/domFunctions';
-
 import { NotFoundError } from '../../../Error/PageNotFound';
 
 class InsertItem extends Component {
@@ -81,12 +79,9 @@ class InsertItem extends Component {
       refs[colName] = { valueNode: null, nullNode: null, defaultNode: null };
       const inputRef = node => (refs[colName].valueNode = node);
       const clicker = e => {
-        const checkboxLabel = getParentNodeByClass(e.target, 'radio-inline');
-        if (checkboxLabel) {
-          checkboxLabel.click();
-        } else {
-          e.target.parentNode.click();
-        }
+        e.target
+          .closest('.radio-inline')
+          .querySelector('input[type="radio"]').checked = true;
         e.target.focus();
       };
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Clicking on the boolean field value dropdown would open a select box but it got closed automatically, therefore, users were unable to edit boolean fields values. 

### Affected components 
<!-- Remove non-affected components from the list -->

- Console

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#2536 #2798 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
The new code checks the radio button by changing its `checked` property instead of simulating a click on it (which would lead to the loss of focus and automatic closure of dropdown).

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
You can follow the exact reproduction steps that have been written in the original issue.

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
