### PR TITLE
disable auto-update checks in cli-migrations container entrypoint

### DIFF
--- a/scripts/cli-migrations/docker-entrypoint.sh
+++ b/scripts/cli-migrations/docker-entrypoint.sh
@@ -57,6 +57,7 @@ if [ -d "$HASURA_GRAPHQL_MIGRATIONS_DIR" ]; then
     cp -a "$HASURA_GRAPHQL_MIGRATIONS_DIR/." "$TEMP_MIGRATIONS_DIR/migrations/"
     cd "$TEMP_MIGRATIONS_DIR"
     echo "endpoint: http://localhost:$HASURA_GRAPHQL_SERVER_PORT" > config.yaml
+    echo "show_update_notification: false" >> config.yaml
     hasura-cli migrate apply
     # check if metadata.[yaml|json] exist and apply
     if [ -f migrations/metadata.yaml ]; then


### PR DESCRIPTION
### Description
This change disables auto-update checks when the cli is used in the entrypoint script for the cli-migrations container. This serves no real purpose in this context and adds additional delays.

### Affected components 
- Docker Container (cli-migrations)

### Solution and Design
The fix was to add an additional configuration `show_update_notification` into the generated temporary `config.yaml` file.
