### PR TITLE
Add "without time zone" types for PGTypes.dateTime (close #2842)

### DIFF
--- a/console/src/components/Services/Data/TablePermissions/PermissionBuilder/utils.js
+++ b/console/src/components/Services/Data/TablePermissions/PermissionBuilder/utils.js
@@ -7,9 +7,11 @@ export const PGTypes = {
   dateTime: [
     'timestamp',
     'timestamp with time zone',
+    'timestamp without time zone',
     'date',
     'time',
     'time with time zone',
+    'time without time zone',
     'interval',
   ],
   geometry: ['geometry'],


### PR DESCRIPTION
fix #2842 

### Description
Add "timestamp without time zone" and "time without time zone" to the `PGTypes.dateTime` array.

### Affected components 

- Console

### Related Issues
#2842 

### Solution and Design
It seems that `timestamp without time zone` is not recognized as a `PGTypes.dateTime` and therefore the PermissionBuilder offered no options for the column.

### Steps to test and verify
In case the PG version is relevant: server 11.2

1. Create a column of type `timestamp without time zone`.
2. Select permissions for the table
3. Try to set a permission based on the column

If there are any test cases I should add, please let me know and point me to where they're at. Happy to add them, if you'd like.

### Limitations, known bugs & workarounds
