### PR TITLE
allow nested inserts for one-to-one relationships (fix #2576)

### DIFF
--- a/docs/graphql/manual/api-reference/schema-metadata-api/relationship.rst
+++ b/docs/graphql/manual/api-reference/schema-metadata-api/relationship.rst
@@ -31,8 +31,8 @@ table. There cannot be an existing column or relationship with the same name.
 
 There are 3 ways in which you can create an object relationship.
 
-1. Using foreign key constraint on a column
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+1. Many-to-One object relationship using a foreign key constraint on a column
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Create an ``object relationship`` ``author`` on ``article`` *table*,  *using* the
 *foreign_key_constraint_on* the ``author_id`` column:
@@ -54,11 +54,11 @@ Create an ``object relationship`` ``author`` on ``article`` *table*,  *using* th
        }
    }
 
-2. One-to-One object relationship using foreign key constraint
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2. One-to-One object relationship using a foreign key constraint on the remote table's column
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A one-to-one object relationship can be created using foreign key constraint
-on remote table's column. The condition is that the remote table's column alone
+A one-to-one object relationship can be created using a foreign key constraint
+on the remote table's column. The condition is that the remote table's column alone
 should have either ``primary key`` or ``unique`` constraint.
 
 .. code-block:: http
@@ -119,12 +119,12 @@ follows:
        }
    }
 
-If we want to define a one-to-one object relationship using manual configuration
-then we've to specify ``insertion_order`` as ``after_parent`` in ``manual_configuration``.
+To define a one-to-one object relationship manually, we have to specify ``after_parent``
+for ``insertion_order`` in ``manual_configuration``.
 ``insertion_order`` is the order in which the object relationship inserted
 in a nested insert in respect of the parent. It expects either ``before_parent`` or
-``after_parent`` string value. It is optional and by default it is ``before_parent`` which
-indicates many-to-one relationship.
+``after_parent`` string value. It is optional, but by default it is ``before_parent``,
+which defines a many-to-one relationship.
 
 .. code-block:: http
 

--- a/docs/graphql/manual/api-reference/schema-metadata-api/relationship.rst
+++ b/docs/graphql/manual/api-reference/schema-metadata-api/relationship.rst
@@ -121,9 +121,9 @@ follows:
 
 To define a one-to-one object relationship manually, we have to specify ``after_parent``
 for ``insertion_order`` in ``manual_configuration``.
-``insertion_order`` is the order in which the object relationship inserted
-in a nested insert in respect of the parent. It expects either ``before_parent`` or
-``after_parent`` string value. It is optional, but by default it is ``before_parent``,
+``insertion_order`` is the order in which the object relationship is inserted
+in a nested insert in respect of the parent. It expects either the ``before_parent`` or
+the ``after_parent`` string value. It is optional, but by default it is ``before_parent``,
 which defines a many-to-one relationship.
 
 .. code-block:: http

--- a/server/src-exec/Migrate.hs
+++ b/server/src-exec/Migrate.hs
@@ -19,7 +19,7 @@ import qualified Data.Yaml.TH               as Y
 import qualified Database.PG.Query          as Q
 
 curCatalogVer :: T.Text
-curCatalogVer = "22"
+curCatalogVer = "23"
 
 migrateMetadata
   :: ( MonadTx m
@@ -360,6 +360,12 @@ from21To22 = do
     $(Q.sqlFromFile "src-rsr/migrate_from_21_to_22.sql")
   pure ()
 
+from22To23 :: (MonadTx m) => m ()
+from22To23 = do
+  Q.Discard () <- liftTx $ Q.multiQE defaultTxErrorHandler
+    $(Q.sqlFromFile "src-rsr/migrate_from_22_to_23.sql")
+  pure ()
+
 migrateCatalog
   :: ( MonadTx m
      , CacheRWM m
@@ -403,6 +409,7 @@ migrateCatalog migrationTime = migrateFrom =<< getCatalogVersion
           , ("19", from19To20)
           , ("20", from20To21)
           , ("21", from21To22)
+          , ("22", from22To23)
           ]
 
     postMigrate = do

--- a/server/src-lib/Hasura/GraphQL/Execute.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute.hs
@@ -24,7 +24,6 @@ import           Data.Has
 import qualified Data.Aeson                             as J
 import qualified Data.CaseInsensitive                   as CI
 import qualified Data.HashMap.Strict                    as Map
-import qualified Data.HashSet                           as Set
 import qualified Data.String.Conversions                as CS
 import qualified Data.Text                              as T
 import qualified Language.GraphQL.Draft.Syntax          as G
@@ -44,7 +43,7 @@ import           Hasura.Prelude
 import           Hasura.RQL.DDL.Headers
 import           Hasura.RQL.Types
 import           Hasura.Server.Context
-import           Hasura.Server.Utils                    (RequestId,
+import           Hasura.Server.Utils                    (RequestId, distinct,
                                                          filterRequestHeaders)
 
 import qualified Hasura.GraphQL.Execute.LiveQuery       as EL
@@ -82,7 +81,7 @@ data ExecutionCtx
 assertSameLocationNodes
   :: (MonadError QErr m) => [VT.TypeLoc] -> m VT.TypeLoc
 assertSameLocationNodes typeLocs =
-  case Set.toList (Set.fromList typeLocs) of
+  case distinct typeLocs of
     -- this shouldn't happen
     []    -> return VT.TLHasuraType
     [loc] -> return loc
@@ -409,5 +408,5 @@ execRemoteGQ reqId userInfo reqHdrs q rsi opDef = do
 
     getCookieHdr = fmap (\h -> ("Set-Cookie", h))
 
-    mkRespHeaders hdrs =
-      map (\(k, v) -> Header (bsToTxt $ CI.original k, bsToTxt v)) hdrs
+    mkRespHeaders =
+      map (\(k, v) -> Header (bsToTxt $ CI.original k, bsToTxt v))

--- a/server/src-lib/Hasura/GraphQL/Schema.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema.hs
@@ -89,9 +89,9 @@ getValidCols = fst . validPartitionFieldInfoMap
 getValidRels :: FieldInfoMap PGColumnInfo -> [RelInfo]
 getValidRels = snd . validPartitionFieldInfoMap
 
-mkValidConstraints :: [ConstraintName] -> [ConstraintName]
-mkValidConstraints =
-  filter (isValidName . G.Name . getConstraintTxt)
+mkValidConstraintNames :: TableConstraints -> [ConstraintName]
+mkValidConstraintNames =
+  filter (isValidName . G.Name . getConstraintTxt) . getConstraintNames
 
 isRelNullable :: FieldInfoMap PGColumnInfo -> RelInfo -> Bool
 isRelNullable fim ri = isNullable
@@ -544,8 +544,9 @@ mkGCtxMapTable tableCache funcCache tabInfo = do
       adminInsCtxMap = Map.singleton tn adminInsCtx
   return $ Map.insert adminRole (adminCtx, adminRootFlds, adminInsCtxMap) m
   where
-    TableInfo tn _ fields rolePerms constraints pkeyCols viewInfo _ enumValues = tabInfo
-    validConstraints = mkValidConstraints constraints
+    TableInfo tn _ fields rolePerms constraints viewInfo _ enumValues = tabInfo
+    validConstraints = mkValidConstraintNames constraints
+    pkeyCols = getPrimarykeyColumns constraints
     colInfos = getValidCols fields
     validColNames = map pgiName colInfos
     pkeyColInfos = getColInfos pkeyCols colInfos

--- a/server/src-lib/Hasura/GraphQL/Schema.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema.hs
@@ -71,7 +71,7 @@ isValidRel rn rt = isValidName (mkRelName rn) && isValidObjectName rt
 isValidField :: FieldInfo PGColumnInfo -> Bool
 isValidField = \case
   FIColumn (PGColumnInfo col _ _) -> isValidCol col
-  FIRelationship (RelInfo rn _ _ remTab _) -> isValidRel rn remTab
+  FIRelationship (RelInfo rn _ _ remTab _ _) -> isValidRel rn remTab
 
 upsertable :: [ConstraintName] -> Bool -> Bool -> Bool
 upsertable uniqueOrPrimaryCons isUpsertAllowed isAView =

--- a/server/src-lib/Hasura/GraphQL/Schema/BoolExp.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema/BoolExp.hs
@@ -285,5 +285,5 @@ mkBoolExpInp tn fields =
     mkFldExpInp = \case
       Left (PGColumnInfo colName colTy _) ->
         mk (mkColName colName) (mkCompExpTy colTy)
-      Right (RelInfo relName _ _ remTab _, _, _, _, _) ->
+      Right (RelInfo relName _ _ remTab _ _, _, _, _, _) ->
         mk (mkRelName relName) (mkBoolExpTy remTab)

--- a/server/src-lib/Hasura/GraphQL/Schema/Select.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema/Select.hs
@@ -16,8 +16,8 @@ import qualified Data.HashMap.Strict           as Map
 import qualified Data.HashSet                  as Set
 import qualified Language.GraphQL.Draft.Syntax as G
 
-import           Hasura.GraphQL.Schema.Common
 import           Hasura.GraphQL.Schema.BoolExp
+import           Hasura.GraphQL.Schema.Common
 import           Hasura.GraphQL.Schema.OrderBy
 import           Hasura.GraphQL.Validate.Types
 import           Hasura.Prelude
@@ -108,7 +108,7 @@ mkRelFld
   -> RelInfo
   -> Bool
   -> [ObjFldInfo]
-mkRelFld allowAgg (RelInfo rn rTy _ remTab isManual) isNullable = case rTy of
+mkRelFld allowAgg (RelInfo rn rTy _ remTab isManual _) isNullable = case rTy of
   ArrRel -> bool [arrRelFld] [arrRelFld, aggArrRelFld] allowAgg
   ObjRel -> [objRelFld]
   where

--- a/server/src-lib/Hasura/RQL/DDL/Schema/Diff.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Diff.hs
@@ -48,9 +48,8 @@ $(deriveJSON (aesonDrop 3 snakeCase){omitNothingFields=True} ''PGColMeta)
 
 data ConstraintMeta
   = ConstraintMeta
-  { cmName :: !ConstraintName
-  , cmOid  :: !Int
-  , cmType :: !ConstraintType
+  { cmOid        :: !Int
+  , cmConstraint :: !RawConstraint
   } deriving (Show, Eq)
 
 $(deriveJSON (aesonDrop 2 snakeCase){omitNothingFields=True} ''ConstraintMeta)
@@ -93,7 +92,7 @@ data TableDiff
   -- The final list of uniq/primary constraint names
   -- used for generating types on_conflict clauses
   -- TODO: this ideally should't be part of TableDiff
-  , _tdUniqOrPriCons   :: ![ConstraintName]
+  , _tdUniqOrPriCons   :: !TableConstraints
   } deriving (Show, Eq)
 
 getTableDiff :: TableMeta -> TableMeta -> TableDiff
@@ -105,8 +104,8 @@ getTableDiff oldtm newtm =
     oldCols = tmColumns oldtm
     newCols = tmColumns newtm
 
-    uniqueOrPrimaryCons =
-      [cmName cm | cm <- tmConstraints newtm, isUniqueOrPrimary (cmType cm)]
+    uniqueOrPrimaryCons = rawConstraintsToTableConstraints
+                          [cmConstraint cm | cm <- tmConstraints newtm]
 
     droppedCols =
       map pcmColumnName $ getDifference pcmOrdinalPosition oldCols newCols

--- a/server/src-lib/Hasura/RQL/DML/Insert.hs
+++ b/server/src-lib/Hasura/RQL/DML/Insert.hs
@@ -140,7 +140,7 @@ buildConflictClause sessVarBldr tableInfo inpCols (OnConflict mTCol mTCons act) 
         \pgCol -> askPGType fieldInfoMap pgCol ""
 
     validateConstraint c = do
-      let tableConsNames = _tiUniqOrPrimConstraints tableInfo
+      let tableConsNames = getConstraintNames $ _tiConstraints tableInfo
       withPathK "constraint" $
        unless (c `elem` tableConsNames) $
        throw400 Unexpected $ "constraint " <> getConstraintTxt c

--- a/server/src-lib/Hasura/RQL/DML/Select.hs
+++ b/server/src-lib/Hasura/RQL/DML/Select.hs
@@ -39,9 +39,8 @@ convSelCol _ _ (SCExtSimple cn) =
 convSelCol fieldInfoMap _ (SCExtRel rn malias selQ) = do
   -- Point to the name key
   let pgWhenRelErr = "only relationships can be expanded"
-  relInfo <- withPathK "name" $
+  relTab <- fmap riRTable $ withPathK "name" $
     askRelType fieldInfoMap rn pgWhenRelErr
-  let (RelInfo _ _ _ relTab _) = relInfo
   (rfim, rspi) <- fetchRelDet rn relTab
   resolvedSelQ <- resolveStar rfim rspi selQ
   return [ECRel rn malias resolvedSelQ]
@@ -223,7 +222,7 @@ convExtRel fieldInfoMap relName mAlias selQ sessVarBldr prepValBldr = do
   -- Point to the name key
   relInfo <- withPathK "name" $
     askRelType fieldInfoMap relName pgWhenRelErr
-  let (RelInfo _ relTy colMapping relTab _) = relInfo
+  let (RelInfo _ relTy colMapping relTab _ _) = relInfo
   (relCIM, relSPI) <- fetchRelDet relName relTab
   annSel <- convSelectQ relCIM relSPI selQ sessVarBldr prepValBldr
   case relTy of

--- a/server/src-lib/Hasura/RQL/DML/Select/Internal.hs
+++ b/server/src-lib/Hasura/RQL/DML/Select/Internal.hs
@@ -291,7 +291,7 @@ processAnnOrderByCol pfx parAls arrRelCtx strfyNum = \case
        , OBNNothing
        )
   -- "pfx.or.relname"."pfx.ob.or.relname.rest" AS "pfx.ob.or.relname.rest"
-  AOCObj (RelInfo rn _ colMapping relTab _) relFltr rest ->
+  AOCObj (RelInfo rn _ colMapping relTab _ _) relFltr rest ->
     let relPfx  = mkObjRelTableAls pfx rn
         ((nesAls, nesCol), ordByNode) =
           processAnnOrderByCol relPfx ordByFldName emptyArrRelCtx strfyNum rest
@@ -311,7 +311,7 @@ processAnnOrderByCol pfx parAls arrRelCtx strfyNum = \case
     in ( (nesAls, qualCol)
        , OBNObjNode rn relNode
        )
-  AOCAgg (RelInfo rn _ colMapping relTab _ ) relFltr annAggOb ->
+  AOCAgg (RelInfo rn _ colMapping relTab _ _) relFltr annAggOb ->
     let ArrNodeInfo arrAls arrPfx _ =
           mkArrNodeInfo pfx parAls arrRelCtx $ ANIAggOrdBy rn
         fldName = mkAggObFld annAggOb

--- a/server/src-lib/Hasura/RQL/GBoolExp.hs
+++ b/server/src-lib/Hasura/RQL/GBoolExp.hs
@@ -330,7 +330,7 @@ convColRhs tableQual = \case
     let bExps = map (mkColCompExp tableQual cn) opExps
     return $ foldr (S.BEBin S.AndOp) (S.BELit True) bExps
 
-  AVRel (RelInfo _ _ colMapping relTN _) nesAnn -> do
+  AVRel (RelInfo _ _ colMapping relTN _ _) nesAnn -> do
     -- Convert the where clause on the relationship
     curVarNum <- get
     put $ curVarNum + 1

--- a/server/src-lib/Hasura/RQL/Types/Catalog.hs
+++ b/server/src-lib/Hasura/RQL/Types/Catalog.hs
@@ -30,10 +30,9 @@ import           Hasura.SQL.Types
 
 data CatalogTableInfo
   = CatalogTableInfo
-  { _ctiColumns           :: ![PGRawColumnInfo]
-  , _ctiConstraints       :: ![ConstraintName]
-  , _ctiPrimaryKeyColumns :: ![PGCol]
-  , _ctiViewInfo          :: !(Maybe ViewInfo)
+  { _ctiColumns     :: ![PGRawColumnInfo]
+  , _ctiConstraints :: ![RawConstraint]
+  , _ctiViewInfo    :: !(Maybe ViewInfo)
   } deriving (Show, Eq)
 $(deriveJSON (aesonDrop 4 snakeCase) ''CatalogTableInfo)
 

--- a/server/src-lib/Hasura/RQL/Types/Common.hs
+++ b/server/src-lib/Hasura/RQL/Types/Common.hs
@@ -197,28 +197,25 @@ newtype FunctionArgName =
   deriving (Show, Eq, ToJSON)
 
 data ConstraintType
-  = CTCHECK
-  | CTFOREIGNKEY
-  | CTPRIMARYKEY
-  | CTUNIQUE
-  deriving Eq
+  = CtCheck
+  | CtForeignKey
+  | CtPrimaryKey
+  | CtUnique
+  deriving (Show, Eq)
 
 constraintTyToTxt :: ConstraintType -> T.Text
 constraintTyToTxt ty = case ty of
-  CTCHECK      -> "CHECK"
-  CTFOREIGNKEY -> "FOREIGN KEY"
-  CTPRIMARYKEY -> "PRIMARY KEY"
-  CTUNIQUE     -> "UNIQUE"
-
-instance Show ConstraintType where
-  show = T.unpack . constraintTyToTxt
+  CtCheck      -> "CHECK"
+  CtForeignKey -> "FOREIGN KEY"
+  CtPrimaryKey -> "PRIMARY KEY"
+  CtUnique     -> "UNIQUE"
 
 instance FromJSON ConstraintType where
   parseJSON = withText "ConstraintType" $ \case
-    "CHECK"       -> return CTCHECK
-    "FOREIGN KEY" -> return CTFOREIGNKEY
-    "PRIMARY KEY" -> return CTPRIMARYKEY
-    "UNIQUE"      -> return CTUNIQUE
+    "CHECK"       -> return CtCheck
+    "FOREIGN KEY" -> return CtForeignKey
+    "PRIMARY KEY" -> return CtPrimaryKey
+    "UNIQUE"      -> return CtUnique
     c             -> fail $ "unexpected ConstraintType: " <> T.unpack c
 
 instance ToJSON ConstraintType where

--- a/server/src-lib/Hasura/RQL/Types/Common.hs
+++ b/server/src-lib/Hasura/RQL/Types/Common.hs
@@ -4,6 +4,7 @@ module Hasura.RQL.Types.Common
        , RelType(..)
        , rootRelName
        , relTypeToTxt
+       , RelInsertOrd(..)
        , RelInfo(..)
 
        , FieldName(..)
@@ -106,15 +107,26 @@ instance Q.FromCol RelType where
   fromCol bs = flip Q.fromColHelper bs $ PD.enum $ \case
     "object" -> Just ObjRel
     "array"  -> Just ArrRel
-    _   -> Nothing
+    _        -> Nothing
+
+data RelInsertOrd
+  = RIOBeforeParent
+  | RIOAfterParent
+  deriving (Show, Eq, Lift)
+$(deriveJSON
+  defaultOptions { constructorTagModifier = snakeCase . drop 3
+                 , allNullaryToStringTag = True
+                 }
+   ''RelInsertOrd)
 
 data RelInfo
   = RelInfo
-  { riName     :: !RelName
-  , riType     :: !RelType
-  , riMapping  :: ![(PGCol, PGCol)]
-  , riRTable   :: !QualifiedTable
-  , riIsManual :: !Bool
+  { riName        :: !RelName
+  , riType        :: !RelType
+  , riMapping     :: ![(PGCol, PGCol)]
+  , riRTable      :: !QualifiedTable
+  , riIsManual    :: !Bool
+  , riInsertOrder :: !RelInsertOrd
   } deriving (Show, Eq)
 
 $(deriveToJSON (aesonDrop 2 snakeCase) ''RelInfo)

--- a/server/src-lib/Hasura/RQL/Types/SchemaCache.hs
+++ b/server/src-lib/Hasura/RQL/Types/SchemaCache.hs
@@ -288,7 +288,7 @@ data TableConstraints
 
 instance ToJSON TableConstraints where
   toJSON (TableConstraints pkeys uniques) =
-    toJSON $ toRaw CTPRIMARYKEY pkeys <> toRaw CTUNIQUE uniques
+    toJSON $ toRaw CtPrimaryKey pkeys <> toRaw CtUnique uniques
     where
       toRaw constraintType constraintMap = flip map (M.toList constraintMap) $
         \(name, cols) -> RawConstraint name constraintType cols
@@ -304,8 +304,8 @@ rawConstraintsToTableConstraints :: [RawConstraint] -> TableConstraints
 rawConstraintsToTableConstraints rawConstraints =
   TableConstraints (mkMap primaryKeys) (mkMap uniques)
   where
-    primaryKeys = filter ((== CTPRIMARYKEY) . _rcType) rawConstraints
-    uniques = filter ((== CTUNIQUE) . _rcType) rawConstraints
+    primaryKeys = filter ((== CtPrimaryKey) . _rcType) rawConstraints
+    uniques = filter ((== CtUnique) . _rcType) rawConstraints
     mkMap = M.fromList . map (\rc -> (_rcName rc, _rcColumns rc))
 
 data TableInfo columnInfo

--- a/server/src-lib/Hasura/Server/Utils.hs
+++ b/server/src-lib/Hasura/Server/Utils.hs
@@ -2,7 +2,7 @@ module Hasura.Server.Utils where
 
 import           Data.Aeson
 import           Data.Char
-import           Data.List                  (find)
+import           Data.List                  (find, nub)
 import           Data.Time.Clock
 import           System.Environment
 import           System.Exit
@@ -108,9 +108,9 @@ duplicates = mapMaybe greaterThanOne . group . sort
   where
     greaterThanOne l = bool Nothing (Just $ head l) $ length l > 1
 
--- distinct items
-distinct :: (Hashable a, Eq a) => [a] -> [a]
-distinct = Set.toList . Set.fromList
+-- distinct items, an alias to `nub` function
+distinct :: Eq a => [a] -> [a]
+distinct = nub
 
 _1 :: (a, b, c) -> a
 _1 (x, _, _) = x

--- a/server/src-lib/Hasura/Server/Utils.hs
+++ b/server/src-lib/Hasura/Server/Utils.hs
@@ -108,6 +108,10 @@ duplicates = mapMaybe greaterThanOne . group . sort
   where
     greaterThanOne l = bool Nothing (Just $ head l) $ length l > 1
 
+-- distinct items
+distinct :: (Hashable a, Eq a) => [a] -> [a]
+distinct = Set.toList . Set.fromList
+
 _1 :: (a, b, c) -> a
 _1 (x, _, _) = x
 

--- a/server/src-rsr/catalog_metadata.sql
+++ b/server/src-rsr/catalog_metadata.sql
@@ -30,7 +30,6 @@ from
         table_name,
         jsonb_build_object(
           'columns', columns,
-          'primary_key_columns', primary_key_columns,
           'constraints', constraints,
           'view_info', view_info
         ) as info

--- a/server/src-rsr/migrate_from_22_to_23.sql
+++ b/server/src-rsr/migrate_from_22_to_23.sql
@@ -1,0 +1,213 @@
+-- Modify hdb_primary_key and hdb_unique_constraint views to have constraint_oid
+CREATE OR REPLACE VIEW hdb_catalog.hdb_primary_key AS
+SELECT
+  tc.table_schema,
+  tc.table_name,
+  tc.constraint_name,
+  json_agg(constraint_column_usage.column_name) AS columns,
+  constraint_column_usage.constraint_oid
+FROM
+  (
+    information_schema.table_constraints tc
+    JOIN (
+      SELECT
+        x.tblschema AS table_schema,
+        x.tblname AS table_name,
+        x.colname AS column_name,
+        x.cstrname AS constraint_name,
+        x.cstroid AS constraint_oid
+      FROM
+        (
+          SELECT
+            DISTINCT nr.nspname,
+            r.relname,
+            a.attname,
+            c.conname,
+            c.oid
+          FROM
+            pg_namespace nr,
+            pg_class r,
+            pg_attribute a,
+            pg_depend d,
+            pg_namespace nc,
+            pg_constraint c
+          WHERE
+            (
+              (nr.oid = r.relnamespace)
+              AND (r.oid = a.attrelid)
+              AND (d.refclassid = ('pg_class' :: regclass) :: oid)
+              AND (d.refobjid = r.oid)
+              AND (d.refobjsubid = a.attnum)
+              AND (d.classid = ('pg_constraint' :: regclass) :: oid)
+              AND (d.objid = c.oid)
+              AND (c.connamespace = nc.oid)
+              AND (c.contype = 'c' :: "char")
+              AND (
+                r.relkind = ANY (ARRAY ['r'::"char", 'p'::"char"])
+              )
+              AND (NOT a.attisdropped)
+            )
+          UNION ALL
+          SELECT
+            nr.nspname,
+            r.relname,
+            a.attname,
+            c.conname,
+            c.oid
+          FROM
+            pg_namespace nr,
+            pg_class r,
+            pg_attribute a,
+            pg_namespace nc,
+            pg_constraint c
+          WHERE
+            (
+              (nr.oid = r.relnamespace)
+              AND (r.oid = a.attrelid)
+              AND (nc.oid = c.connamespace)
+              AND (
+                r.oid = CASE
+                  c.contype
+                  WHEN 'f' :: "char" THEN c.confrelid
+                  ELSE c.conrelid
+                END
+              )
+              AND (
+                a.attnum = ANY (
+                  CASE
+                    c.contype
+                    WHEN 'f' :: "char" THEN c.confkey
+                    ELSE c.conkey
+                  END
+                )
+              )
+              AND (NOT a.attisdropped)
+              AND (
+                c.contype = ANY (ARRAY ['p'::"char", 'u'::"char", 'f'::"char"])
+              )
+              AND (
+                r.relkind = ANY (ARRAY ['r'::"char", 'p'::"char"])
+              )
+            )
+        ) x(
+          tblschema,
+          tblname,
+          colname,
+          cstrname,
+          cstroid
+        )
+    ) constraint_column_usage ON (
+      (
+        (tc.constraint_name) :: text = (constraint_column_usage.constraint_name) :: text
+        AND (tc.table_schema) :: text = (constraint_column_usage.table_schema) :: text
+        AND (tc.table_name) :: text = (constraint_column_usage.table_name) :: text
+      )
+    )
+  )
+WHERE
+  ((tc.constraint_type) :: text = 'PRIMARY KEY' :: text)
+GROUP BY
+  tc.table_schema,
+  tc.table_name,
+  tc.constraint_name,
+  constraint_column_usage.constraint_oid;
+
+CREATE OR REPLACE VIEW hdb_catalog.hdb_unique_constraint AS
+  SELECT
+    tc.table_name,
+    tc.constraint_schema AS table_schema,
+    tc.constraint_name as constraint_name,
+    json_agg(kcu.column_name) AS columns,
+    pc.oid as constraint_oid
+    FROM
+        information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage AS kcu
+            USING (constraint_schema, constraint_name)
+        JOIN pg_constraint pc ON (pc.conname = tc.constraint_name)
+   WHERE
+    constraint_type = 'UNIQUE'
+   GROUP BY
+    tc.table_name, tc.constraint_schema, tc.constraint_name, pc.oid;
+
+-- Drop primary_key_columns column from hdb_table_info_agg view
+DROP VIEW hdb_catalog.hdb_table_info_agg;
+
+CREATE VIEW hdb_catalog.hdb_table_info_agg AS (
+select
+  tables.table_name as table_name,
+  tables.table_schema as table_schema,
+  coalesce(columns.columns, '[]') as columns,
+  coalesce(constraints.constraints, '[]') as constraints,
+  coalesce(views.view_info, 'null') as view_info
+from
+  information_schema.tables as tables
+  left outer join (
+    select
+      c.table_name,
+      c.table_schema,
+      json_agg(
+        json_build_object(
+          'name', name,
+          'type', type,
+          'is_nullable', is_nullable :: boolean,
+          'references', primary_key_references
+        )
+      ) as columns
+    from
+      hdb_catalog.hdb_column c
+    group by
+      c.table_schema,
+      c.table_name
+  ) columns on (
+    tables.table_schema = columns.table_schema
+    AND tables.table_name = columns.table_name
+  )
+  left outer join (
+    select
+      tc.table_schema,
+      tc.table_name,
+      json_agg(json_build_object('type', tc.type, 'name', tc.constraint_name, 'columns', tc.columns)) as constraints
+    from
+        (
+          select
+            table_schema,
+            table_name,
+            constraint_name,
+            columns,
+            'PRIMARY KEY' AS type
+          from hdb_catalog.hdb_primary_key
+          union all
+          select
+            table_schema,
+            table_name,
+            constraint_name,
+            columns,
+            'UNIQUE' AS type
+          from hdb_catalog.hdb_unique_constraint
+        ) tc
+     group by
+      tc.table_schema,
+      tc.table_name
+  ) constraints on (
+    tables.table_schema = constraints.table_schema
+    AND tables.table_name = constraints.table_name
+  )
+  left outer join (
+    select
+      table_schema,
+      table_name,
+      json_build_object(
+        'is_updatable',
+        (is_updatable::boolean OR is_trigger_updatable::boolean),
+        'is_deletable',
+        (is_updatable::boolean OR is_trigger_deletable::boolean),
+        'is_insertable',
+        (is_insertable_into::boolean OR is_trigger_insertable_into::boolean)
+      ) as view_info
+    from
+      information_schema.views v
+  ) views on (
+    tables.table_schema = views.table_schema
+    AND tables.table_name = views.table_name
+  )
+);

--- a/server/tests-py/queries/graphql_mutation/insert/nested/articles_with_config_one_to_one_fkey.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/nested/articles_with_config_one_to_one_fkey.yaml
@@ -1,0 +1,49 @@
+description: Insert articles with their configuration using fkey one-to-one relationship
+url: /v1/graphql
+status: 200
+query:
+  query: |
+    mutation {
+      insert_article(
+        objects: [
+          {
+            title: "Inserting article with config"
+            content: "Config article content"
+            config_fkey:{
+              data: {likes: 1}
+            }
+            author: {
+              data: {name: "Dummy author"}
+            }
+          }
+        ]
+      ){
+        affected_rows
+        returning{
+          title
+          content
+          config_fkey{
+            id
+            likes
+          }
+          author{
+            id
+            name
+          }
+        }
+      }
+    }
+
+response:
+  data:
+    insert_article:
+      affected_rows: 3
+      returning:
+      - content: Config article content
+        config_fkey:
+          id: 1
+          likes: 1
+        author:
+          name: Dummy author
+          id: 3
+        title: Inserting article with config

--- a/server/tests-py/queries/graphql_mutation/insert/nested/articles_with_config_one_to_one_manual.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/nested/articles_with_config_one_to_one_manual.yaml
@@ -1,0 +1,49 @@
+description: Insert articles with their configuration using manual one-to-one relationship
+url: /v1/graphql
+status: 200
+query:
+  query: |
+    mutation {
+      insert_article(
+        objects: [
+          {
+            title: "Inserting article with config"
+            content: "Config article content"
+            config_manual:{
+              data: {likes: 1}
+            }
+            author: {
+              data: {name: "Dummy author"}
+            }
+          }
+        ]
+      ){
+        affected_rows
+        returning{
+          title
+          content
+          config_manual{
+            id
+            likes
+          }
+          author{
+            id
+            name
+          }
+        }
+      }
+    }
+
+response:
+  data:
+    insert_article:
+      affected_rows: 3
+      returning:
+      - content: Config article content
+        config_manual:
+          id: 1
+          likes: 1
+        author:
+          name: Dummy author
+          id: 3
+        title: Inserting article with config

--- a/server/tests-py/queries/graphql_mutation/insert/nested/schema_setup.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/nested/schema_setup.yaml
@@ -49,3 +49,40 @@ args:
         table: article
         column: author_id
 
+# Article Config table
+- type: run_sql
+  args:
+    sql: |
+      CREATE TABLE article_config (
+        id SERIAL PRIMARY KEY,
+        article_id INTEGER UNIQUE REFERENCES article(id),
+        last_updated TIMESTAMP NOT NULL DEFAULT NOW(),
+        likes INTEGER NOT NULL DEFAULT 0
+      )
+- type: track_table
+  args:
+    name: article_config
+    schema: public
+
+# Create one-to-one object relationships
+- type: create_object_relationship
+  args:
+    table: article
+    name: config_fkey
+    using:
+      foreign_key_constraint_on:
+        table: article_config
+        column: article_id
+
+- type: create_object_relationship
+  args:
+    table: article
+    name: config_manual
+    using:
+      manual_configuration:
+        remote_table:
+          schema: public
+          name: article_config
+        column_mapping:
+          id: article_id
+        insertion_order: after_parent

--- a/server/tests-py/queries/graphql_mutation/insert/nested/schema_teardown.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/nested/schema_teardown.yaml
@@ -1,18 +1,9 @@
 type: bulk
 args:
-#Drop relationship first
-- type: drop_relationship
-  args:
-    relationship: articles
-    table:
-      schema: public
-      name: author
-
 - type: run_sql
   args:
     sql: |
-      drop table article
-- type: run_sql
-  args:
-    sql: |
-      drop table author
+      DROP TABLE article_config;
+      DROP TABLE article;
+      DROP TABLE author;
+    cascade: true

--- a/server/tests-py/queries/graphql_mutation/insert/nested/values_teardown.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/nested/values_teardown.yaml
@@ -5,6 +5,9 @@ args:
 - type: run_sql
   args:
     sql: |
+      delete from article_config;
+      SELECT setval('article_config_id_seq', 1, FALSE);
+
       delete from article;
       SELECT setval('article_id_seq', 1, FALSE);
 

--- a/server/tests-py/test_graphql_mutations.py
+++ b/server/tests-py/test_graphql_mutations.py
@@ -242,6 +242,12 @@ class TestGraphqlNestedInserts(DefaultTestMutations):
     def test_articles_with_author_returning(self, hge_ctx, transport):
         check_query_f(hge_ctx, self.dir() + "/articles_with_author_returning.yaml")
 
+    def test_articles_with_config_one_to_one_fkey(self, hge_ctx, transport):
+        check_query_f(hge_ctx, self.dir() + "/articles_with_config_one_to_one_fkey.yaml")
+
+    def test_articles_with_config_one_to_one_manual(self, hge_ctx, transport):
+        check_query_f(hge_ctx, self.dir() + "/articles_with_config_one_to_one_manual.yaml")
+
     @classmethod
     def dir(cls):
         return "queries/graphql_mutation/insert/nested"


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

This PR extends existing `create_object_relationship` query API to support nested inserts for one-to-one object relationships.

**Console changes are must as relationship tab fails to load if any relationships are defined using new API**
Refer [here](https://deploy-preview-2852--hasura-docs.netlify.com/graphql/manual/api-reference/schema-metadata-api/relationship.html#create-object-relationship-syntax) to learn more about the new API.

### Affected components 
<!-- Remove non-affected components from the list -->

- Server
- Docs
- Tests

TODO:
- [ ] console

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
fix #2576 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

- Distinct manual configuration types for object and array relationships
- Define `ObjRelUsingFKeyOn` for one-to-one object relationships
- Now `RelInfo` carries the information of `insertion order`
- The `insertion order` of array relationships are always `after_parent`
- In `Hasura.GraphQL.Resolve.Insert`, while inserting a nested object, the object relationships are inserted according to their insertion order.
- Just `ConstraintName` is not enough to validate the remote table's column uniqueness. Hence, `TableInfo` carries a primary key and unique constraints along with their associated column names.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Follow and test the reproduction guide given in issue #2576 
