### PR TITLE
fix hostname in pgAdmin docker compose (close #2865)

### DIFF
--- a/install-manifests/docker-compose-pgadmin/README.md
+++ b/install-manifests/docker-compose-pgadmin/README.md
@@ -18,8 +18,8 @@ This Docker Compose setup runs [Hasura GraphQL Engine](https://github.com/hasura
 - `docker-compose up -d`
 - Navigate to `http://localhost:5050`, login and add a new server with the following parameters:  
   General - Name: Hasura  
-  Connection - Host: postgres  
-  Username: postgres  
+  Connection - Host: `postgres`
+  Username: `postgres`
   Password: leave empty  
 
 ## Important endpoints

--- a/install-manifests/docker-compose-pgadmin/README.md
+++ b/install-manifests/docker-compose-pgadmin/README.md
@@ -18,8 +18,8 @@ This Docker Compose setup runs [Hasura GraphQL Engine](https://github.com/hasura
 - `docker-compose up -d`
 - Navigate to `http://localhost:5050`, login and add a new server with the following parameters:  
   General - Name: Hasura  
-  Connection - Host: `hasura`  
-  Username: `postgres`  
+  Connection - Host: postgres  
+  Username: postgres  
   Password: leave empty  
 
 ## Important endpoints


### PR DESCRIPTION
Originally, the Connection - Host name was `hasura`, but the server is actually the postgres server which sits on `postgres`. Also removed single quotes for consistency.

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->
close #2865 

### Affected components 
<!-- Remove non-affected components from the list -->

- Docs

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#2865 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
Connects to the postgresql server's host name rather than the hasura endpoint.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Follow the original instructions by first using the "hasura" host name, which should throw an error. Then try the new instructions with "postgres" as the endpoint, which should succeed.