### PR TITLE
check for empty response on migration settings

### DIFF
--- a/cli/migrate/database/hasuradb/settings.go
+++ b/cli/migrate/database/hasuradb/settings.go
@@ -160,13 +160,13 @@ func (h *HasuraDB) GetSetting(name string) (value string, err error) {
 		return value, fmt.Errorf("Invalid result Type %s", hres.ResultType)
 	}
 
-	if len(hres.Result) == 0 {
+	if len(hres.Result) < 2 {
 		for _, setting := range h.settings {
 			if setting.GetName() == name {
 				return setting.GetDefaultValue(), nil
 			}
 		}
-		return "", nil
+		return value, fmt.Errorf("Invalid setting name: %s", name)
 	}
 
 	return hres.Result[1][0], nil


### PR DESCRIPTION
### Description
Fixing run_sql result checking while fetching migration setting in cli.

### Affected components 
<!-- Remove non-affected components from the list -->
- CLI

### Related Issues
#2872 
#2862 

### Solution and Design

### Steps to test and verify
1. Open console using cli
2. Delete all the rows in ```hdb_catalog.migration_settings``` table.
3. Open the console again using cli and panic shouldn't happen.

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
