### PR TITLE
docs: swap manual_mapping for manual_configuration (close #2887)

### DIFF
--- a/docs/graphql/manual/api-reference/schema-metadata-api/relationship.rst
+++ b/docs/graphql/manual/api-reference/schema-metadata-api/relationship.rst
@@ -155,7 +155,7 @@ ObjRelUsing
 .. note::
 
    There has to be at least one and only one of ``foreign_key_constraint_on``
-   and ``manual_mapping``. 
+   and ``manual_configuration``. 
 
 
 ObjRelUsingManualMapping
@@ -304,7 +304,7 @@ ArrRelUsing
      - false
      - ArrRelUsingFKeyOn_
      - The column with foreign key constraint
-   * - manual_mapping
+   * - manual_configuration
      - false
      - ArrRelUsingManualMapping_
      - Manual mapping of table and columns


### PR DESCRIPTION
### Description

The docs specify `manual_mapping` for array relationship manual configs, and also mention the attribute in a note. However, using `manual_mapping` errors; `manual_configuration` is the correct attribute name.

### Affected components 
<!-- Remove non-affected components from the list -->

- Docs

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

#2887

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
