### PR TITLE
server: Don’t allow warnings when building in CI

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -54,10 +54,9 @@ release-image: $(project).cabal
 # assumes this is built in circleci
 ci-binary:
 	mkdir -p packaging/build/rootfs
-	stack $(STACK_FLAGS) build $(BUILD_FLAGS)
+	stack $(STACK_FLAGS) build --ghc-options=-Werror $(BUILD_FLAGS)
 	mkdir -p $(build_output)
 	cp $(build_dir)/$(project)/$(project) $(build_output)
-# cp "$(build_dir)/$(project)-test/$(project)-test" $(build_output)
 	echo "$(VERSION)" > $(build_output)/version.txt
 
 # assumes this is built in circleci

--- a/server/src-lib/Hasura/RQL/Types/SchemaCache.hs
+++ b/server/src-lib/Hasura/RQL/Types/SchemaCache.hs
@@ -16,6 +16,7 @@ module Hasura.RQL.Types.SchemaCache
 
        , TableInfo(..)
        , tiName
+       , tiDescription
        , tiSystemDefined
        , tiFieldInfoMap
        , tiRolePermInfoMap


### PR DESCRIPTION
### Description

Currently, CI does not build the server with the `-Werror` GHC option set, so warnings are not treated as errors. This allowed https://github.com/hasura/graphql-engine/commit/99174cca9b99ebb4b7d55d02fa1dcda150a3d57c to get merged with an unfixed warning. This PR fixes that.

### Affected components 

- Server
- Build System
