### PR TITLE
Correct argument type for `insert_todos` mutation (close #2901)

### DIFF
--- a/community/learn/graphql-tutorials/tutorials/reason-react-apollo/tutorial-site/content/intro-to-graphql/3-writing-data-mutations.md
+++ b/community/learn/graphql-tutorials/tutorials/reason-react-apollo/tutorial-site/content/intro-to-graphql/3-writing-data-mutations.md
@@ -89,7 +89,7 @@ Now that we know how to parametrise using query variables, let's use that:
 
 ```graphql
 # The parametrised GraphQL mutation
-mutation($todo: insert_todo_input!){
+mutation($todo: todos_insert_input!){
   insert_todos(objects: [$todo]) {
     returning {
       id


### PR DESCRIPTION
### Description
Correct the argument type for `insert_todos` mutation to conform with the schema documentation in the [Try it out in GraphiQL](https://learn.hasura.io/graphql/graphiql) environment.

### Affected components 

- Docs
- Community Content

### Related Issues
#2901  


