### PR TITLE
add brotli library dependencies to graphql-engine-packager image

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -6,7 +6,7 @@ nproc    := $(shell nproc)
 
 # TODO: needs to be replaced with something like yq
 stack_resolver := $(shell awk '/^resolver:/ {print $$2;}' stack.yaml)
-packager_ver := 20190731
+packager_ver := 20190923
 pg_dump_ver := 11
 project_dir := $(shell pwd)
 build_dir := $(project_dir)/$(shell stack path --dist-dir)/build

--- a/server/packaging/packager.df
+++ b/server/packaging/packager.df
@@ -1,8 +1,14 @@
 FROM hasura/haskell-docker-packager:20190731
 MAINTAINER vamshi@hasura.io
 
-RUN apt-get update && apt-get install -y libpq5 upx \
+RUN apt-get update && apt-get install -y libpq5 upx git cmake pkgconf \
  && update-ca-certificates \
  && mkdir -p /usr/src/busybox/rootfs/etc/ssl/certs \
  && cp -L /etc/ssl/certs/* /usr/src/busybox/rootfs/etc/ssl/certs/ \
+ && git clone https://github.com/google/brotli.git && cd brotli && mkdir out && cd out && ../configure-cmake \
+ && make && make test && make install && ldconfig && cd ../../ \
+ && rm -rf brotli \
+ && cp /usr/local/lib/libbrotlienc.so.1 /usr/src/busybox/rootfs/usr/lib/x86_64-linux-gnu \
+ && cp /usr/local/lib/libbrotlidec.so.1 /usr/src/busybox/rootfs/usr/lib/x86_64-linux-gnu \
+ && cp /usr/local/lib/libbrotlicommon.so.1 /usr/src/busybox/rootfs/usr/lib/x86_64-linux-gnu \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Add `brotli` library dependencies to the server docker image.

The compression feature introduced in https://github.com/hasura/graphql-engine/pull/2751 requires `brotli` shared libraries at runtime. In original PR, adding them to server packager image was missing.


### Affected components 
<!-- Remove non-affected components from the list -->

- Server

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
Install brotli from [source](https://github.com/google/brotli) and copy shared object files to `rootfs`.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Open Heroku preview app.

