### PR TITLE
update custom column names on renaming/dropping columns

### DIFF
--- a/server/src-lib/Hasura/RQL/DDL/Schema/Rename.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Rename.hs
@@ -16,6 +16,7 @@ import qualified Hasura.RQL.DDL.EventTrigger        as DS
 import           Hasura.RQL.DDL.Permission
 import           Hasura.RQL.DDL.Permission.Internal
 import           Hasura.RQL.DDL.Relationship.Types
+import           Hasura.RQL.DDL.Schema.Catalog
 import           Hasura.RQL.Types
 import           Hasura.SQL.Types
 
@@ -97,6 +98,8 @@ renameColInCatalog oCol nCol qt ti = do
     SOTableObj _ (TOTrigger triggerName) ->
       updateColInEventTriggerDef triggerName $ RenameItem qt oCol nCol
     d -> otherDeps errMsg d
+  -- Update custom column names
+  possiblyUpdateCustomColumnNames qt oCol nCol
   where
     errMsg = "cannot rename column " <> oCol <<> " to " <>> nCol
     assertFldNotExists =
@@ -414,6 +417,16 @@ updateColMap fromQT toQT rnCol colMap =
     RenameItem qt oCol nCol = rnCol
     modCol colQt col = if colQt == qt && col == oCol then nCol else col
 
+possiblyUpdateCustomColumnNames
+  :: MonadTx m => QualifiedTable -> PGCol -> PGCol -> m ()
+possiblyUpdateCustomColumnNames qt oCol nCol = do
+  TableConfig customRootFields customColumns <- liftTx $ getTableConfig qt
+  let updatedCustomColumns =
+        M.fromList $ flip map (M.toList customColumns) $
+        \(dbCol, val) -> (, val) $ if dbCol == oCol then nCol else dbCol
+  when (updatedCustomColumns /= customColumns) $
+    updateTableConfig qt $ TableConfig customRootFields updatedCustomColumns
+
 -- database functions for relationships
 getRelDef :: QualifiedTable -> RelName -> Q.TxE QErr Value
 getRelDef (QualifiedObject sn tn) rn =
@@ -433,3 +446,11 @@ updateRel (QualifiedObject sn tn) rn relDef =
               AND table_name = $3
               AND rel_name = $4
                 |] (Q.AltJ relDef, sn , tn, rn) True
+
+getTableConfig :: QualifiedTable -> Q.TxE QErr TableConfig
+getTableConfig (QualifiedObject sn tn) =
+  Q.getAltJ . runIdentity . Q.getRow <$> Q.withQE defaultTxErrorHandler
+    [Q.sql|
+       SELECT configuration::json FROM hdb_catalog.hdb_table
+        WHERE table_schema = $1 AND table_name = $2
+    |] (sn, tn) True

--- a/server/src-lib/Hasura/RQL/DDL/Schema/Table.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Table.hs
@@ -286,7 +286,7 @@ processTableChanges ti tableDiff = do
 
     possiblyDropCustomColumnNames tn = do
       let TableConfig customFields customColumnNames = _tiCustomConfig ti
-          modifiedCustomColumnNames = foldl (flip M.delete) customColumnNames droppedCols
+          modifiedCustomColumnNames = foldl' (flip M.delete) customColumnNames droppedCols
       if modifiedCustomColumnNames == customColumnNames then
         pure customColumnNames
       else do

--- a/server/tests-py/queries/v1/set_table_custom_fields/alter_column.yaml
+++ b/server/tests-py/queries/v1/set_table_custom_fields/alter_column.yaml
@@ -1,0 +1,47 @@
+- description: Set custom column names
+  url: /v1/query
+  status: 200
+  response:
+    message: success
+  query:
+    type: set_table_custom_fields
+    version: 2
+    args:
+      table: author
+      custom_root_fields:
+        select: Authors
+      custom_column_names:
+        id: AuthorId
+        name: AuthorName
+
+- description: "Rename column 'id' and drop column 'name'"
+  url: /v1/query
+  status: 200
+  response:
+    result_type: CommandOk
+    result: null
+  query:
+    type: run_sql
+    args:
+      sql: |
+        ALTER TABLE author DROP COLUMN name;
+        ALTER TABLE author RENAME COLUMN id to author_id;
+
+- description: Test if custom column names are updated
+  url: /v1/graphql
+  status: 200
+  response:
+    data:
+      Authors:
+      - AuthorId: 1
+        age: 23
+      - AuthorId: 2
+        age: null
+  query:
+    query: |
+      query {
+        Authors{
+          AuthorId
+          age
+        }
+      }

--- a/server/tests-py/test_v1_queries.py
+++ b/server/tests-py/test_v1_queries.py
@@ -646,3 +646,6 @@ class TestSetTableCustomFields(DefaultTestQueries):
 
     def test_set_invalid_table(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + '/set_invalid_table.yaml')
+
+    def test_alter_column(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + '/alter_column.yaml')


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

Update custom column names in catalogue on dropping/renaming columns. 

Customising column names in generated GraphQL schema is introduced in https://github.com/hasura/graphql-engine/pull/2509. However, handling the `custom column names` metadata during altering/dropping columns was not included in original PR.

### Affected components 
<!-- Remove non-affected components from the list -->

- Server
- Tests

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
N/A. Follow up PR for https://github.com/hasura/graphql-engine/pull/2509

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

1. Remove dropped columns (if any) from custom column names map
2. Update custom column names map with renamed columns (if any)

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Follow the added test case
or
Defined custom column names on a table and try to alter through console.
