### PR TITLE
optimise brotli and gzip compression speed

### DIFF
--- a/server/src-lib/Hasura/Server/Compression.hs
+++ b/server/src-lib/Hasura/Server/Compression.hs
@@ -24,6 +24,14 @@ compressionTypeToTxt :: CompressionType -> T.Text
 compressionTypeToTxt CTGZip   = "gzip"
 compressionTypeToTxt CTBrotli = "brotli"
 
+brotliCompressionParams :: BR.CompressParams
+brotliCompressionParams =
+  BR.defaultCompressParams{BR.compressLevel = BR.CompressionLevel4}
+
+gzipCompressionParams :: GZ.CompressParams
+gzipCompressionParams =
+  GZ.defaultCompressParams{GZ.compressLevel = GZ.compressionLevel 1}
+
 compressResponse
   :: NH.RequestHeaders
   -> BL.ByteString
@@ -32,8 +40,8 @@ compressResponse reqHeaders unCompressedResp =
   let compressionTypeM = getRequestedCompression reqHeaders
       appendCompressionType (res, headerM) = (res, headerM, compressionTypeM)
   in appendCompressionType $ case compressionTypeM of
-       Just CTBrotli -> (BR.compress unCompressedResp, Just brHeader)
-       Just CTGZip   -> (GZ.compress unCompressedResp, Just gzipHeader)
+       Just CTBrotli -> (BR.compressWith brotliCompressionParams unCompressedResp, Just brHeader)
+       Just CTGZip   -> (GZ.compressWith gzipCompressionParams unCompressedResp, Just gzipHeader)
        Nothing       -> (unCompressedResp, Nothing)
 
 getRequestedCompression :: NH.RequestHeaders -> Maybe CompressionType

--- a/server/src-lib/Hasura/Server/Compression.hs
+++ b/server/src-lib/Hasura/Server/Compression.hs
@@ -24,14 +24,6 @@ compressionTypeToTxt :: CompressionType -> T.Text
 compressionTypeToTxt CTGZip   = "gzip"
 compressionTypeToTxt CTBrotli = "brotli"
 
-brotliCompressionParams :: BR.CompressParams
-brotliCompressionParams =
-  BR.defaultCompressParams{BR.compressLevel = BR.CompressionLevel4}
-
-gzipCompressionParams :: GZ.CompressParams
-gzipCompressionParams =
-  GZ.defaultCompressParams{GZ.compressLevel = GZ.compressionLevel 1}
-
 compressResponse
   :: NH.RequestHeaders
   -> BL.ByteString
@@ -39,10 +31,15 @@ compressResponse
 compressResponse reqHeaders unCompressedResp =
   let compressionTypeM = getRequestedCompression reqHeaders
       appendCompressionType (res, headerM) = (res, headerM, compressionTypeM)
+      brotliCompressionParams =
+        BR.defaultCompressParams{BR.compressLevel = BR.CompressionLevel4}
+      gzipCompressionParams =
+        GZ.defaultCompressParams{GZ.compressLevel = GZ.compressionLevel 1}
   in appendCompressionType $ case compressionTypeM of
        Just CTBrotli -> (BR.compressWith brotliCompressionParams unCompressedResp, Just brHeader)
        Just CTGZip   -> (GZ.compressWith gzipCompressionParams unCompressedResp, Just gzipHeader)
        Nothing       -> (unCompressedResp, Nothing)
+
 
 getRequestedCompression :: NH.RequestHeaders -> Maybe CompressionType
 getRequestedCompression reqHeaders


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

The default compression level is max bound for Brotli and Gzip. This PR reduces the compression level to `4` for brotli and `1` for gzip. Refer to [this article](https://paulcalvano.com/index.php/2018/07/25/brotli-compression-how-much-will-it-reduce-your-content/) to learn more about compression speeds vs level.

### Affected components 
<!-- Remove non-affected components from the list -->

- Server

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
N/A

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
Use compression params for brotli and gzip compression.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Add onegraph as a remote schema and check the introspection query time in console.

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
