### PR TITLE
add flag to generate migrations in sql (fix #2239)

### DIFF
--- a/cli/commands/migrate_create.go
+++ b/cli/commands/migrate_create.go
@@ -56,6 +56,7 @@ func newMigrateCreateCmd(ec *cli.ExecutionContext) *cobra.Command {
 	opts.flags = f
 	f.BoolVar(&opts.fromServer, "from-server", false, "get SQL statements and hasura metadata from the server")
 	f.StringVar(&opts.sqlFile, "sql-from-file", "", "path to an sql file which contains the SQL statements")
+	f.BoolVar(&opts.sqlFormat, "sql", false, "create up and down sql files")
 	f.BoolVar(&opts.sqlServer, "sql-from-server", false, "take pg_dump from server and save it as a migration")
 	f.StringArrayVar(&opts.schemaNames, "schema", []string{"public"}, "name of Postgres schema to export as migration")
 	f.StringVar(&opts.metaDataFile, "metadata-from-file", "", "path to a hasura metadata file to be used for up actions")
@@ -89,6 +90,7 @@ type migrateCreateOptions struct {
 	metaDataFile   string
 	metaDataServer bool
 	schemaNames    []string
+	sqlFormat      bool
 }
 
 func (o *migrateCreateOptions) run() (version int64, err error) {
@@ -172,6 +174,11 @@ func (o *migrateCreateOptions) run() (version int64, err error) {
 		// Set empty data for [up|down].yaml
 		createOptions.MetaUp = []byte(`[]`)
 		createOptions.MetaDown = []byte(`[]`)
+
+		if o.sqlFormat {
+			createOptions.SQLUp = []byte(``)
+			createOptions.SQLDown = []byte(``)
+		}
 	}
 
 	defer func() {

--- a/cli/commands/migrate_create_test.go
+++ b/cli/commands/migrate_create_test.go
@@ -15,21 +15,57 @@ import (
 )
 
 func TestMigrateCreateCmd(t *testing.T) {
-	logger, _ := test.NewNullLogger()
-	opts := &migrateCreateOptions{
-		EC: &cli.ExecutionContext{
-			Logger:       logger,
-			Spinner:      spinner.New(spinner.CharSets[7], 100*time.Millisecond),
-			MigrationDir: filepath.Join(os.TempDir(), "hasura-cli-test-"+strconv.Itoa(rand.Intn(1000))),
-		},
-		name:  "create_article",
-		flags: pflag.NewFlagSet("migrate-create-test", pflag.ContinueOnError),
-	}
+	t.Run("should run create migration", func(t *testing.T) {
+		logger, _ := test.NewNullLogger()
+		opts := &migrateCreateOptions{
+			EC: &cli.ExecutionContext{
+				Logger:       logger,
+				Spinner:      spinner.New(spinner.CharSets[7], 100*time.Millisecond),
+				MigrationDir: filepath.Join(os.TempDir(), "hasura-cli-test-"+strconv.Itoa(rand.Intn(1000))),
+			},
+			name:  "create_article",
+			flags: pflag.NewFlagSet("migrate-create-test", pflag.ContinueOnError),
+		}
 
-	_, err := opts.run()
-	if err != nil {
-		t.Fatalf("failed creating migration: %v", err)
-	}
+		_, err := opts.run()
+		if err != nil {
+			t.Fatalf("failed creating migration: %v", err)
+		}
 
-	os.RemoveAll(opts.EC.MigrationDir)
+		_ = os.RemoveAll(opts.EC.MigrationDir)
+	})
+
+	t.Run("should run create migration with sql files", func(t *testing.T) {
+		logger, _ := test.NewNullLogger()
+		opts := &migrateCreateOptions{
+			EC: &cli.ExecutionContext{
+				Logger:       logger,
+				Spinner:      spinner.New(spinner.CharSets[7], 100*time.Millisecond),
+				MigrationDir: filepath.Join(os.TempDir(), "hasura-cli-test-"+strconv.Itoa(rand.Intn(1000))),
+			},
+			name:      "create_article",
+			flags:     pflag.NewFlagSet("migrate-create-test", pflag.ContinueOnError),
+			sqlFormat: true,
+		}
+
+		version, err := opts.run()
+		if err != nil {
+			t.Fatalf("failed creating migration: %v", err)
+		}
+
+		baseName := strconv.FormatInt(version, 10) + "_" + "create_article"
+		upSqlFile := filepath.Join(opts.EC.MigrationDir, baseName+".up.sql")
+		downSqlFile := filepath.Join(opts.EC.MigrationDir, baseName+".down.sql")
+		_, err = os.Stat(upSqlFile)
+		if err != nil {
+			t.Fatalf("up sql file not present: %v", err)
+		}
+
+		_, err = os.Stat(downSqlFile)
+		if err != nil {
+			t.Fatalf("down sql file not present: %v", err)
+		}
+
+		_ = os.RemoveAll(opts.EC.MigrationDir)
+	})
 }


### PR DESCRIPTION
Fixes #2239 

### Description
When I run `hasura migrate create "new-migration"`, two sql files (`up` and `down`) are also created along with two yamls (as before). The sql files are easy for the user to c

### Affected components 

- CLI
- Tests

### Related Issues
#2239

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
1. Run the graphql engine and the postgres db
2. Run `hasura init; cd hasura`
3. Configure things in `config.yaml`
3. Run `hasura migrate create "new-migration" --sql`
3. Run `ls migrations` and notice the two sql and yaml files for the migration

### Limitations, known bugs & workarounds
None that I know of. We can discuss if you think of anything 😄 
