### PR TITLE
fix query is logged as string on authz errors (close #2963)

### DIFF
--- a/server/src-lib/Hasura/Server/Logging.hs
+++ b/server/src-lib/Hasura/Server/Logging.hs
@@ -239,7 +239,7 @@ mkHttpErrorLog userInfoM reqId req err query mTimeT compressTypeM =
                         (decodeStrict $ T.encodeUtf8 s)
       v -> toJSON v
       where
-        -- validate if query is nested
+        -- try to parse nested query field
         parseQuery :: Value -> Parser Value
         parseQuery value = do
           qry <- withObject "operation" (.: "query") value
@@ -248,7 +248,7 @@ mkHttpErrorLog userInfoM reqId req err query mTimeT compressTypeM =
             _        -> value
 
         toQuery :: Value -> Value
-        toQuery o = fromMaybe (String "failed") $ parseMaybe parseQuery o
+        toQuery o = fromMaybe o $ parseMaybe parseQuery o
 
 computeTimeDiff :: Maybe (UTCTime, UTCTime) -> Maybe Double
 computeTimeDiff = fmap (realToFrac . uncurry (flip diffUTCTime))

--- a/server/tests-py/test_logging.py
+++ b/server/tests-py/test_logging.py
@@ -40,6 +40,32 @@ class TestLogging():
                                  headers=headers)
         assert resp.status_code == 200 and 'errors' in resp.json()
 
+        # make an unthorized query where admin secret/access token is empty
+        q = {'query': 'query { hello {code name} }'}
+        headers = {'x-request-id': 'unauthorized-query-test'}
+        resp = hge_ctx.http.post(hge_ctx.hge_url + '/v1/graphql', json=q,
+                                 headers=headers)
+        assert resp.status_code == 200 and 'errors' in resp.json()
+
+        # make an unthorized metadata request where admin secret/access token is empty
+        q = {
+            'query': {
+                'type': 'sekect',
+                'args': {
+                        "table": {
+                            "name": "hdb_function",
+                            "schema": "hdb_catalog"
+                        },
+                        "columns": ["function_name", "function_schema", "is_system_defined"],
+                        "where": { "function_schema": "public" }
+                    }
+                }
+            }
+        }
+        headers = {'x-request-id': 'unauthorized-metadata-test'}
+        resp = hge_ctx.http.post(hge_ctx.hge_url + '/v1/query', json=q)
+        assert resp.status_code == 200 and 'errors' in resp.json()
+
         # gather and parse the logs now
         self.logs = self._parse_logs(hge_ctx)
         # sometimes the log might take time to buffer
@@ -140,3 +166,33 @@ class TestLogging():
         print(http_logs[0])
         assert 'error' in http_logs[0]['detail']['operation']
         assert http_logs[0]['detail']['operation']['error']['code'] == 'parse-failed'
+
+    def test_http_unthorized_query(self, hge_ctx):
+        def _get_failed_logs(x):
+            return x['type'] == 'http-log' and \
+                x['detail']['operation']['request_id'] == 'unauthorized-query-test'
+
+        http_logs = list(filter(_get_failed_logs, self.logs))
+        print('unauthorized failed logs', http_logs)
+        assert len(http_logs) > 0
+        print(http_logs[0])
+        assert 'error' in http_logs[0]['detail']['operation']
+        assert http_logs[0]['detail']['operation']['error']['code'] == 'access-denied'
+        assert http_logs[0]['detail']['operation']['query']['variables'] == None
+        assert http_logs[0]['detail']['operation']['query']['query'] != ''
+
+    def test_http_unthorized_query(self, hge_ctx):
+        def _get_failed_logs(x):
+            return x['type'] == 'http-log' and \
+                x['detail']['operation']['request_id'] == 'unauthorized-metadata-test'
+
+        http_logs = list(filter(_get_failed_logs, self.logs))
+        print('unauthorized failed logs', http_logs)
+        assert len(http_logs) > 0
+        print(http_logs[0])
+        assert 'error' in http_logs[0]['detail']['operation']
+        assert http_logs[0]['detail']['operation']['error']['code'] == 'access-denied'
+        assert http_logs[0]['detail']['operation']['query']['variables'] == None
+        assert http_logs[0]['detail']['operation']['query']['args'] is not None 
+        assert http_logs[0]['detail']['operation']['query']['args']['where'] is not None 
+        assert http_logs[0]['detail']['operation']['query']['columns'] is not None 

--- a/server/tests-py/test_logging.py
+++ b/server/tests-py/test_logging.py
@@ -191,7 +191,6 @@ class TestLogging():
         print(http_logs[0])
         assert 'error' in http_logs[0]['detail']['operation']
         assert http_logs[0]['detail']['operation']['error']['code'] == 'access-denied'
-        assert http_logs[0]['detail']['operation']['query']['variables'] == None
         assert http_logs[0]['detail']['operation']['query']['args'] is not None 
         assert http_logs[0]['detail']['operation']['query']['args']['where'] is not None 
         assert http_logs[0]['detail']['operation']['query']['columns'] is not None 

--- a/server/tests-py/test_logging.py
+++ b/server/tests-py/test_logging.py
@@ -63,7 +63,7 @@ class TestLogging():
         }
         headers = {'x-request-id': 'unauthorized-metadata-test'}
         resp = hge_ctx.http.post(hge_ctx.hge_url + '/v1/query', json=q)
-        assert resp.status_code == 200 and 'errors' in resp.json()
+        assert resp.status_code == 401 and 'errors' in resp.json()
 
         # gather and parse the logs now
         self.logs = self._parse_logs(hge_ctx)

--- a/server/tests-py/test_logging.py
+++ b/server/tests-py/test_logging.py
@@ -62,7 +62,8 @@ class TestLogging():
             }
         }
         headers = {'x-request-id': 'unauthorized-metadata-test'}
-        resp = hge_ctx.http.post(hge_ctx.hge_url + '/v1/query', json=q)
+        resp = hge_ctx.http.post(hge_ctx.hge_url + '/v1/query', json=q,
+                                 headers=headers)
         assert resp.status_code == 401 and 'error' in resp.json()
 
         # gather and parse the logs now

--- a/server/tests-py/test_logging.py
+++ b/server/tests-py/test_logging.py
@@ -63,7 +63,7 @@ class TestLogging():
         }
         headers = {'x-request-id': 'unauthorized-metadata-test'}
         resp = hge_ctx.http.post(hge_ctx.hge_url + '/v1/query', json=q)
-        assert resp.status_code == 401 and 'errors' in resp.json()
+        assert resp.status_code == 401 and 'error' in resp.json()
 
         # gather and parse the logs now
         self.logs = self._parse_logs(hge_ctx)

--- a/server/tests-py/test_logging.py
+++ b/server/tests-py/test_logging.py
@@ -193,4 +193,4 @@ class TestLogging():
         assert http_logs[0]['detail']['operation']['error']['code'] == 'access-denied'
         assert http_logs[0]['detail']['operation']['query']['args'] is not None 
         assert http_logs[0]['detail']['operation']['query']['args']['where'] is not None 
-        assert http_logs[0]['detail']['operation']['query']['columns'] is not None 
+        assert http_logs[0]['detail']['operation']['query']['args']['columns'] is not None 

--- a/server/tests-py/test_logging.py
+++ b/server/tests-py/test_logging.py
@@ -49,16 +49,15 @@ class TestLogging():
 
         # make an unthorized metadata request where admin secret/access token is empty
         q = {
-            'query': {
-                'type': 'sekect',
-                'args': {
-                        "table": {
-                            "name": "hdb_function",
-                            "schema": "hdb_catalog"
-                        },
-                        "columns": ["function_name", "function_schema", "is_system_defined"],
-                        "where": { "function_schema": "public" }
-                    }
+        'query': {
+            'type': 'select',
+            'args': {
+                    "table": {
+                        "name": "hdb_function",
+                        "schema": "hdb_catalog"
+                    },
+                    "columns": ["function_name", "function_schema", "is_system_defined"],
+                    "where": { "function_schema": "public" }
                 }
             }
         }
@@ -181,7 +180,7 @@ class TestLogging():
         assert http_logs[0]['detail']['operation']['query']['variables'] == None
         assert http_logs[0]['detail']['operation']['query']['query'] != ''
 
-    def test_http_unthorized_query(self, hge_ctx):
+    def test_http_unthorized_metadata(self, hge_ctx):
         def _get_failed_logs(x):
             return x['type'] == 'http-log' and \
                 x['detail']['operation']['request_id'] == 'unauthorized-metadata-test'

--- a/server/tests-py/test_logging.py
+++ b/server/tests-py/test_logging.py
@@ -177,7 +177,6 @@ class TestLogging():
         print(http_logs[0])
         assert 'error' in http_logs[0]['detail']['operation']
         assert http_logs[0]['detail']['operation']['error']['code'] == 'access-denied'
-        assert http_logs[0]['detail']['operation']['query']['variables'] == None
         assert http_logs[0]['detail']['operation']['query']['query'] != ''
 
     def test_http_unthorized_metadata(self, hge_ctx):


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

For errors like invalid-jwt etc, the http-log contains detail.operation.query as a string, instead of the parsed JSON. This is causing trouble in analysing logs.

### Affected components 
<!-- Remove non-affected components from the list -->

- Server
- Tests

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#2963 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
Parse JSON `http-log.detail.operation.query` when query is JSON string

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
- Do some unauthorized (empty x-hasura-admin-secret) request 
- Run automation test

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
