### PR TITLE
support where clause in on_conflict of insert mutation (close #2795)

### DIFF
--- a/docs/graphql/manual/api-reference/graphql-api/mutation.rst
+++ b/docs/graphql/manual/api-reference/graphql-api/mutation.rst
@@ -52,7 +52,7 @@ Insert / upsert syntax
 **E.g. INSERT**:
 
 .. code-block:: graphql
-    
+
     mutation insert_article {
       insert_article(
         objects: [
@@ -73,7 +73,7 @@ Insert / upsert syntax
 **E.g. UPSERT**:
 
 .. code-block:: graphql
-    
+
     mutation upsert_author {
       insert_author (
         objects: [
@@ -161,7 +161,7 @@ Update syntax
 **E.g. UPDATE**:
 
 .. code-block:: graphql
-    
+
     mutation update_author{
       update_author(
         where: {id: {_eq: 3}},
@@ -212,7 +212,7 @@ Delete syntax
 **E.g. DELETE**:
 
 .. code-block:: graphql
-    
+
     mutation delete_articles {
       delete_article(
         where: {author: {id: {_eq: 7}}}
@@ -226,7 +226,7 @@ Delete syntax
 
 
 .. note::
-    
+
     For more examples and details of usage, please see :doc:`this <../../mutations/index>`.
 
 Syntax definitions
@@ -287,7 +287,7 @@ E.g.:
 E.g.:
 
 .. code-block:: graphql
-    
+
     objects: [
       {
         title: "Software is eating the world",
@@ -310,10 +310,11 @@ permissions before editing an existing row in case of a conflict. Hence the conf
 table has *update* permissions defined.
 
 .. code-block:: none
-    
+
     on_conflict: {
       constraint: table_constraint!
       update_columns: [table_update_column!]!
+      where: table_bool_exp
     }
 
 E.g.:
@@ -323,6 +324,7 @@ E.g.:
     on_conflict: {
       constraint: author_name_key
       update_columns: [name]
+      where: {id: {_lt: 1}}
     }
 
 .. _whereArgExp:

--- a/docs/graphql/manual/mutations/upsert.rst
+++ b/docs/graphql/manual/mutations/upsert.rst
@@ -107,7 +107,7 @@ The ``published_on`` column is left unchanged as it wasn't present in ``update_c
 Update selected columns on conflict using a filter
 --------------------------------------------------
 Insert a new object in the ``article`` table, or if the primary key constraint ``article_pkey`` is violated, update
-the columns specified in ``update_columns`` only if provided the ``where`` condition is met:
+the columns specified in ``update_columns`` only if the provided ``where`` condition is met:
 
 
 .. graphiql::

--- a/docs/graphql/manual/mutations/upsert.rst
+++ b/docs/graphql/manual/mutations/upsert.rst
@@ -44,11 +44,11 @@ The upsert functionality is sometimes confused with the update functionality. Ho
 differently. An upsert mutation is used in the case when it's not clear if the respective row is already present
 in the database. If it's known that the row is present in the database, ``update`` is the functionality to use.
 
-For an upsert, **all columns need to be passed**. 
+For an upsert, **all columns need to be passed**.
 
 **How it works**
 
-1. Postgres tries to insert a row (hence all the columns need to be present) 
+1. Postgres tries to insert a row (hence all the columns need to be present)
 
 2. If this fails because of some constraint, it updates the specified columns
 
@@ -103,6 +103,53 @@ the columns specified in ``update_columns``:
     }
 
 The ``published_on`` column is left unchanged as it wasn't present in ``update_columns``.
+
+Update selected columns on conflict using a filter
+--------------------------------------------------
+Insert a new object in the ``article`` table or, if the primary key constraint ``article_pkey`` is violated, update
+the columns specified in ``update_columns`` only if provided ``where`` condition is met:
+
+
+.. graphiql::
+  :view_only:
+  :query:
+    mutation upsert_article {
+      insert_article (
+        objects: [
+          {
+            id: 2,
+            published_on: "2018-10-12"
+          }
+        ],
+        on_conflict: {
+          constraint: article_pkey,
+          update_columns: [published_on],
+          where: {
+            published_on: {_lt: "2018-10-12"}
+          }
+        }
+      ) {
+        returning {
+          id
+          published_on
+        }
+      }
+    }
+  :response:
+    {
+      "data": {
+        "insert_article": {
+          "returning": [
+            {
+              "id": 2,
+              "published_on": "2018-10-12"
+            }
+          ]
+        }
+      }
+    }
+
+The ``published_on`` column is updated only if the new value is greater than old value.
 
 Ignore request on conflict
 --------------------------

--- a/docs/graphql/manual/mutations/upsert.rst
+++ b/docs/graphql/manual/mutations/upsert.rst
@@ -106,8 +106,8 @@ The ``published_on`` column is left unchanged as it wasn't present in ``update_c
 
 Update selected columns on conflict using a filter
 --------------------------------------------------
-Insert a new object in the ``article`` table or, if the primary key constraint ``article_pkey`` is violated, update
-the columns specified in ``update_columns`` only if provided ``where`` condition is met:
+Insert a new object in the ``article`` table, or if the primary key constraint ``article_pkey`` is violated, update
+the columns specified in ``update_columns`` only if provided the ``where`` condition is met:
 
 
 .. graphiql::
@@ -149,7 +149,7 @@ the columns specified in ``update_columns`` only if provided ``where`` condition
       }
     }
 
-The ``published_on`` column is updated only if the new value is greater than old value.
+The ``published_on`` column is updated only if the new value is greater than the old value.
 
 Ignore request on conflict
 --------------------------

--- a/server/src-lib/Hasura/GraphQL/Schema/Mutation/Insert.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema/Mutation/Insert.hs
@@ -10,6 +10,7 @@ import qualified Data.HashMap.Strict                   as Map
 import qualified Language.GraphQL.Draft.Syntax         as G
 
 import           Hasura.GraphQL.Resolve.Types
+import           Hasura.GraphQL.Schema.BoolExp
 import           Hasura.GraphQL.Schema.Common
 import           Hasura.GraphQL.Schema.Mutation.Common
 import           Hasura.GraphQL.Validate.Types
@@ -124,6 +125,7 @@ mkInsInp tn insCols relInfoMap =
 input table_on_conflict {
   constraint: table_constraint!
   update_columns: [table_column!]
+  where: table_bool_exp
 }
 
 -}
@@ -131,7 +133,7 @@ input table_on_conflict {
 mkOnConflictInp :: QualifiedTable -> InpObjTyInfo
 mkOnConflictInp tn =
   mkHsraInpTyInfo (Just desc) (mkOnConflictInpTy tn) $ fromInpValL
-  [constraintInpVal, updateColumnsInpVal]
+  [constraintInpVal, updateColumnsInpVal, whereInpVal]
   where
     desc = G.Description $
       "on conflict condition type for table " <>> tn
@@ -141,6 +143,9 @@ mkOnConflictInp tn =
 
     updateColumnsInpVal = InpValInfo Nothing (G.Name "update_columns") Nothing $
       G.toGT $ G.toNT $ G.toLT $ G.toNT $ mkUpdColumnInpTy tn
+
+    whereInpVal = InpValInfo Nothing (G.Name "where") Nothing $
+                  G.toGT $ mkBoolExpTy tn
 {-
 
 insert_table(

--- a/server/tests-py/queries/graphql_mutation/insert/onconflict/order_on_conflict_where.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/onconflict/order_on_conflict_where.yaml
@@ -1,0 +1,47 @@
+- description: Upsert into orders only if new value is greater than old value
+  url: /v1/graphql
+  status: 200
+  response:
+    data:
+      insert_orders:
+        affected_rows: 0
+  query:
+    variables:
+      placed: '2017-08-18 14:22:11.802755+02'
+    query: |
+      mutation ($placed: timestamptz) {
+        insert_orders(
+          objects: [{id: 1, placed: $placed}]
+          on_conflict: {
+            constraint:orders_pkey
+            update_columns: [placed]
+            where: {placed: {_lt: $placed}}
+          }
+        ){
+          affected_rows
+        }
+      }
+
+- description: Upsert into orders only if new value is greater than old value
+  url: /v1/graphql
+  status: 200
+  response:
+    data:
+      insert_orders:
+        affected_rows: 1
+  query:
+    variables:
+      placed: '2017-08-20 14:22:11.802755+02'
+    query: |
+      mutation ($placed: timestamptz) {
+        insert_orders(
+          objects: [{id: 1, placed: $placed}]
+          on_conflict: {
+            constraint:orders_pkey
+            update_columns: [placed]
+            where: {placed: {_lt: $placed}}
+          }
+        ){
+          affected_rows
+        }
+      }

--- a/server/tests-py/queries/graphql_mutation/insert/onconflict/values_setup.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/onconflict/values_setup.yaml
@@ -21,3 +21,9 @@ args:
     - content: Sample article content
       title: Article 3
 
+#Insert into orders
+- type: insert
+  args:
+    table: orders
+    objects:
+    - placed: '2017-08-19 14:22:11.802755+02'

--- a/server/tests-py/queries/graphql_mutation/insert/permissions/resident_on_conflict_where.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/permissions/resident_on_conflict_where.yaml
@@ -1,0 +1,36 @@
+description: Upsert into resident table only if age is greater
+url: /v1/graphql
+status: 200
+response:
+  data:
+    insert_resident:
+      affected_rows: 1
+      returning:
+      - id: 6
+        age: 23
+query:
+  variables:
+    age: 23
+  query: |
+    mutation ($age:Int){
+      insert_resident(
+        objects: [
+          {
+            id: 6
+            age: $age
+            name: "Resident 6"
+          }
+        ]
+        on_conflict:{
+          constraint: resident_pkey
+          update_columns: [age]
+          where: {age: {_lt: $age}}
+        }
+      ){
+        affected_rows
+        returning{
+          id
+          age
+        }
+      }
+    }

--- a/server/tests-py/test_graphql_mutations.py
+++ b/server/tests-py/test_graphql_mutations.py
@@ -58,6 +58,9 @@ class TestGraphqlInsertOnConflict(DefaultTestMutations):
     def test_err_unexpected_constraint(self, hge_ctx, transport):
         check_query_f(hge_ctx, self.dir() + "/article_unexpected_on_conflict_constraint_error.yaml")
 
+    def test_order_on_conflict_where(self, hge_ctx, transport):
+        check_query_f(hge_ctx, self.dir() + '/order_on_conflict_where.yaml')
+
     @classmethod
     def dir(cls):
         return "queries/graphql_mutation/insert/onconflict"
@@ -119,6 +122,9 @@ class TestGraphqlInsertPermission(DefaultTestMutations):
 
     def test_resident_5_modifies_resident_6_upsert(self, hge_ctx, transport):
         check_query_f(hge_ctx, self.dir() + "/resident_5_modifies_resident_6_upsert.yaml")
+
+    def test_resident_on_conflict_where(self, hge_ctx, transport):
+        check_query_f(hge_ctx, self.dir() + "/resident_on_conflict_where.yaml")
 
     def test_blog_on_conflict_update_preset(self, hge_ctx, transport):
         check_query_f(hge_ctx, self.dir() + "/blog_on_conflict_update_preset.yaml")


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->


### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

Support `where` clause in `on_conflict` input object. It is optional. This `where` condition applies to old data.

For more details, refer to issue https://github.com/hasura/graphql-engine/issues/2795

### Affected components 
<!-- Remove non-affected components from the list -->

- Server
- Docs
- Tests

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
closes #2795 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

- Generate nullable `where` field in `on_conflict` input object
```graphql
    on_conflict: {
      constraint: table_constraint!
      update_columns: [table_update_column!]!
      where: table_bool_exp
    }
```
- Resolve the `where` field using text encoding of input values.
- Join the obtained boolean expression from `where` with update filter using `AND` operator

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Follow any test case added in this PR