### PR TITLE
add raw query field for error http log (close #2963)

### DIFF
--- a/server/src-lib/Hasura/Server/App.hs
+++ b/server/src-lib/Hasura/Server/App.hs
@@ -226,7 +226,7 @@ mkSpockAction qErrEncoder qErrModifier serverCtx apiHandler = do
   let headers = requestHeaders req
       authMode = scAuthMode serverCtx
       manager = scManager serverCtx
-      -- convert ByteString to Maybe Value for logging
+      -- convert ByteString to Text for logging
       reqTxt = bsToTxt $ BL.toStrict reqBody
 
   requestId <- getRequestId headers

--- a/server/src-lib/Hasura/Server/App.hs
+++ b/server/src-lib/Hasura/Server/App.hs
@@ -19,7 +19,6 @@ import           System.Exit                            (exitFailure)
 import           System.FilePath                        (joinPath, takeFileName)
 import           Web.Spock.Core
 
-import qualified Data.ByteString.Char8                  as BS
 import qualified Data.ByteString.Lazy                   as BL
 import qualified Data.HashMap.Strict                    as M
 import qualified Data.HashSet                           as S

--- a/server/src-lib/Hasura/Server/Logging.hs
+++ b/server/src-lib/Hasura/Server/Logging.hs
@@ -146,7 +146,7 @@ data OperationLog
   , olResponseSize       :: !(Maybe Int64)
   , olQueryExecutionTime :: !(Maybe Double)
   , olQuery              :: !(Maybe Value)
-  , olRawQuery :: !(Maybe Value)
+  , olRawQuery           :: !(Maybe Value)
   , olError              :: !(Maybe Value)
   } deriving (Show, Eq)
 $(deriveToJSON (aesonDrop 2 snakeCase) ''OperationLog)
@@ -234,8 +234,8 @@ mkHttpErrorLog userInfoM reqId req err query mTimeT compressTypeM =
     respTime = computeTimeDiff mTimeT
     query' = query >>= \q -> case q of
       Object _ -> Just q
-      Array _ -> Just q
-      _ -> Nothing
+      Array _  -> Just q
+      _        -> Nothing
     rawQuery = maybe query (const Nothing) query'
 
 computeTimeDiff :: Maybe (UTCTime, UTCTime) -> Maybe Double

--- a/server/src-lib/Hasura/Server/Logging.hs
+++ b/server/src-lib/Hasura/Server/Logging.hs
@@ -207,7 +207,7 @@ mkHttpErrorLog
   -> RequestId
   -> Wai.Request
   -> QErr
-  -> Either Text Value
+  -> Either BL.ByteString Value
   -> Maybe (UTCTime, UTCTime)
   -> Maybe CompressionType
   -> HttpLog
@@ -226,7 +226,7 @@ mkHttpErrorLog userInfoM reqId req err query mTimeT compressTypeM =
            , olResponseSize       = Just $ BL.length $ encode err
            , olQueryExecutionTime = computeTimeDiff mTimeT
            , olQuery              = either (const Nothing) Just query
-           , olRawQuery           = either Just (const Nothing) query
+           , olRawQuery           = either (Just . bsToTxt . BL.toStrict) (const Nothing) query
            , olError              = Just err
            }
   in HttpLog L.LevelError $ HttpAccessLog http op

--- a/server/stack.yaml.lock
+++ b/server/stack.yaml.lock
@@ -21,7 +21,7 @@ packages:
 - completed:
     cabal-file:
       size: 3364
-      sha256: 09bad175e8ccb1fec5ddbc94d95d18b4206ac4481cf3749e42ffbaac90bc4a37
+      sha256: 80e8d405c6c57f8e450e55f5c43b7f8d9135b8b36c1ae0424afd058f4eb596b3
     name: graphql-parser
     version: 0.1.0.0
     git: https://github.com/hasura/graphql-parser-hs.git
@@ -35,7 +35,7 @@ packages:
 - completed:
     cabal-file:
       size: 1253
-      sha256: d0356b65cbe17a2fecf9334aa133de238161ef9c22af015d67ab622e08eb8ed1
+      sha256: d878a89d953cea6e914073c0eb9e21280369042a0054cb81e0b9fddf215231a5
     name: ci-info
     version: 0.1.0.0
     git: https://github.com/hasura/ci-info-hs.git
@@ -103,10 +103,10 @@ packages:
   original:
     hackage: monad-validate-1.2.0.0
 - completed:
-    hackage: brotli-0.0.0.0@sha256:0a8232f028dbc6a1f9db291ef996a5abe74aa00c7c3dc00a741c41f3da75a4dc,2873
+    hackage: brotli-0.0.0.0@sha256:448061ceabdcaa752bbaf208f255bbb7e90bbcf8ea8a913d26ffa7887636823b,2887
     pantry-tree:
       size: 407
-      sha256: f4c2e742f10ca010554aeb0037294f118be4f35228acca98c0df97e1093bca33
+      sha256: 5ad2a6b25c8145f58c43b10f1b60a1e1b5bf57f0e33e4a203f9671b361fb03c0
   original:
     hackage: brotli-0.0.0.0
 snapshots:

--- a/server/stack.yaml.lock
+++ b/server/stack.yaml.lock
@@ -21,7 +21,7 @@ packages:
 - completed:
     cabal-file:
       size: 3364
-      sha256: 80e8d405c6c57f8e450e55f5c43b7f8d9135b8b36c1ae0424afd058f4eb596b3
+      sha256: 09bad175e8ccb1fec5ddbc94d95d18b4206ac4481cf3749e42ffbaac90bc4a37
     name: graphql-parser
     version: 0.1.0.0
     git: https://github.com/hasura/graphql-parser-hs.git
@@ -35,7 +35,7 @@ packages:
 - completed:
     cabal-file:
       size: 1253
-      sha256: d878a89d953cea6e914073c0eb9e21280369042a0054cb81e0b9fddf215231a5
+      sha256: d0356b65cbe17a2fecf9334aa133de238161ef9c22af015d67ab622e08eb8ed1
     name: ci-info
     version: 0.1.0.0
     git: https://github.com/hasura/ci-info-hs.git
@@ -103,10 +103,10 @@ packages:
   original:
     hackage: monad-validate-1.2.0.0
 - completed:
-    hackage: brotli-0.0.0.0@sha256:448061ceabdcaa752bbaf208f255bbb7e90bbcf8ea8a913d26ffa7887636823b,2887
+    hackage: brotli-0.0.0.0@sha256:0a8232f028dbc6a1f9db291ef996a5abe74aa00c7c3dc00a741c41f3da75a4dc,2873
     pantry-tree:
       size: 407
-      sha256: 5ad2a6b25c8145f58c43b10f1b60a1e1b5bf57f0e33e4a203f9671b361fb03c0
+      sha256: f4c2e742f10ca010554aeb0037294f118be4f35228acca98c0df97e1093bca33
   original:
     hackage: brotli-0.0.0.0
 snapshots:

--- a/server/tests-py/test_logging.py
+++ b/server/tests-py/test_logging.py
@@ -178,7 +178,7 @@ class TestLogging():
         print(http_logs[0])
         assert 'error' in http_logs[0]['detail']['operation']
         assert http_logs[0]['detail']['operation']['error']['code'] == 'access-denied'
-        assert http_logs[0]['detail']['operation']['query'] is None
+        assert http_logs[0]['detail']['operation'].get('query') is None
         assert http_logs[0]['detail']['operation']['raw_query'] is not None
 
     def test_http_unthorized_metadata(self, hge_ctx):
@@ -192,5 +192,5 @@ class TestLogging():
         print(http_logs[0])
         assert 'error' in http_logs[0]['detail']['operation']
         assert http_logs[0]['detail']['operation']['error']['code'] == 'access-denied'
-        assert http_logs[0]['detail']['operation']['query'] is None
+        assert http_logs[0]['detail']['operation'].get('query') is None
         assert http_logs[0]['detail']['operation']['raw_query'] is not None

--- a/server/tests-py/test_logging.py
+++ b/server/tests-py/test_logging.py
@@ -39,6 +39,32 @@ class TestLogging():
         resp = hge_ctx.http.post(hge_ctx.hge_url + '/v1/graphql', json=q,
                                  headers=headers)
         assert resp.status_code == 200 and 'errors' in resp.json()
+        
+        # make an unthorized query where admin secret/access token is empty
+        q = {'query': 'query { hello {code name} }'}
+        headers = {'x-request-id': 'unauthorized-query-test'}
+        resp = hge_ctx.http.post(hge_ctx.hge_url + '/v1/graphql', json=q,
+                                 headers=headers)
+        assert resp.status_code == 200 and 'errors' in resp.json()
+
+        # make an unthorized metadata request where admin secret/access token is empty
+        q = {
+        'query': {
+            'type': 'select',
+            'args': {
+                    "table": {
+                        "name": "hdb_function",
+                        "schema": "hdb_catalog"
+                    },
+                    "columns": ["function_name", "function_schema", "is_system_defined"],
+                    "where": { "function_schema": "public" }
+                }
+            }
+        }
+        headers = {'x-request-id': 'unauthorized-metadata-test'}
+        resp = hge_ctx.http.post(hge_ctx.hge_url + '/v1/query', json=q,
+                                 headers=headers)
+        assert resp.status_code == 401 and 'error' in resp.json()
 
         # gather and parse the logs now
         self.logs = self._parse_logs(hge_ctx)
@@ -140,3 +166,31 @@ class TestLogging():
         print(http_logs[0])
         assert 'error' in http_logs[0]['detail']['operation']
         assert http_logs[0]['detail']['operation']['error']['code'] == 'parse-failed'
+
+    def test_http_unthorized_query(self, hge_ctx):
+        def _get_failed_logs(x):
+            return x['type'] == 'http-log' and \
+                x['detail']['operation']['request_id'] == 'unauthorized-query-test'
+
+        http_logs = list(filter(_get_failed_logs, self.logs))
+        print('unauthorized failed logs', http_logs)
+        assert len(http_logs) > 0
+        print(http_logs[0])
+        assert 'error' in http_logs[0]['detail']['operation']
+        assert http_logs[0]['detail']['operation']['error']['code'] == 'access-denied'
+        assert http_logs[0]['detail']['operation']['query'] is None
+        assert http_logs[0]['detail']['operation']['raw_query'] is not None
+
+    def test_http_unthorized_metadata(self, hge_ctx):
+        def _get_failed_logs(x):
+            return x['type'] == 'http-log' and \
+                x['detail']['operation']['request_id'] == 'unauthorized-metadata-test'
+
+        http_logs = list(filter(_get_failed_logs, self.logs))
+        print('unauthorized failed logs', http_logs)
+        assert len(http_logs) > 0
+        print(http_logs[0])
+        assert 'error' in http_logs[0]['detail']['operation']
+        assert http_logs[0]['detail']['operation']['error']['code'] == 'access-denied'
+        assert http_logs[0]['detail']['operation']['query'] is None
+        assert http_logs[0]['detail']['operation']['raw_query'] is not None


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
For errors like invalid-jwt etc, the http-log contains detail.operation.query as a string, instead of the parsed JSON. This is causing trouble in analysing logs.

### Affected components 
<!-- Remove non-affected components from the list -->

- Server
- Tests

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#2963 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
We can parse JSON query data. However, according to @lexi-lambda, reading the entire payload on every request makes us more vulnerable to denial-of-service attacks, and parsing the whole thing makes it even worse (consider: bad client sends us a several GB payload, we reject their auth, but we still try to decode their whole JSON document into memory).

Therefore, there is an option that add `raw_query` field for raw query string

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
- Do some unauthorized (empty x-hasura-admin-secret) request
- Or run automation test

### Limitations, known bugs & workarounds
None
