### PR TITLE
update github social icon width (close #3024)

### DIFF
--- a/docs/_theme/djangodocs/layout.html
+++ b/docs/_theme/djangodocs/layout.html
@@ -67,7 +67,7 @@
                   <div class="inline-block header_links">
                     <div class="social_icons_wrapper">
                       <div class="social_icons">
-                        <iframe src="https://ghbtns.com/github-btn.html?user=hasura&repo=graphql-engine&type=star&count=true" frameBorder="0" scrolling="0" width="95px" height="25px"></iframe>
+                        <iframe src="https://ghbtns.com/github-btn.html?user=hasura&repo=graphql-engine&type=star&count=true" frameBorder="0" scrolling="0" width="100px" height="25px"></iframe>
                       </div>
                       <div class="social_icons">
                         <a href="https://twitter.com/hasurahq/" target="_blank">


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

The github social icon in the header is not wide enough and the star count is dropping to a new line where it is not completely visible.

### Affected components 
<!-- Remove non-affected components from the list -->

- Docs

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#3024 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
This pr updates de width of the iframe to the minimum required to show the github widget in a single row (i.e. 100px).

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
You can quickly inspect the github social icon element in a browser and preview/test the change (changing the iframe width to 100px).

Should look like this:
<img width="222" alt="Screen Shot 2019-10-04 at 9 00 39 PM" src="https://user-images.githubusercontent.com/2272928/66248359-82f04c00-e6eb-11e9-9e20-892c572e38ad.png">

Instead of this:
<img width="216" alt="Screen Shot 2019-10-04 at 9 00 49 PM" src="https://user-images.githubusercontent.com/2272928/66248365-8e437780-e6eb-11e9-824d-3b691ac537bb.png">


### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
Was only tested on Chrome 77 and Firefox 69.

<!-- Feel free to delete these comment lines -->
