### PR TITLE
fix github stars icon in docs (fix #3024)

### DIFF
--- a/docs/_ext/djangodocs.py
+++ b/docs/_ext/djangodocs.py
@@ -44,7 +44,7 @@ def setup(app):
         rolename="lookup",
         indextemplate="pair: %s; field lookup type",
     )
-    app.add_description_unit(
+    app.add_object_type(
         directivename="django-admin",
         rolename="djadmin",
         indextemplate="pair: %s; django-admin command",

--- a/docs/_ext/global_tabs.py
+++ b/docs/_ext/global_tabs.py
@@ -1,7 +1,7 @@
 import fett
 from docutils import statemachine
 from docutils.utils.error_reporting import ErrorString
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 import yaml
 
 # List of tabs ( ID, Display Name)

--- a/docs/_ext/graphiql.py
+++ b/docs/_ext/graphiql.py
@@ -1,7 +1,7 @@
 import fett
 from docutils import statemachine
 from docutils.utils.error_reporting import ErrorString
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 
 
 class GraphiQLDirective(Directive):

--- a/docs/_theme/djangodocs/layout.html
+++ b/docs/_theme/djangodocs/layout.html
@@ -67,7 +67,7 @@
                   <div class="inline-block header_links">
                     <div class="social_icons_wrapper">
                       <div class="social_icons">
-                        <iframe src="https://ghbtns.com/github-btn.html?user=hasura&repo=graphql-engine&type=star&count=true" frameBorder="0" scrolling="0" width="95px" height="25px"></iframe>
+                        <iframe src="https://ghbtns.com/github-btn.html?user=hasura&repo=graphql-engine&type=star&count=true" frameBorder="0" scrolling="0" width="120px" height="25px"></iframe>
                       </div>
                       <div class="social_icons">
                         <a href="https://twitter.com/hasurahq/" target="_blank">


### PR DESCRIPTION
### Description

Extend the Github stars icon to properly display. Also resolved deprecated sphinx errors while building the docs (can be reverted if wanted).

### Affected components 

- Docs

### Related Issues

#3024

### Solution and Design

Icon was not properly displaying. Star number was below the icon. By extending the icon, the number was properly displayed next to the item.

### Steps to test and verify

Ran `make livehtml` to build and debug the HTML files. Pip packages needed to be installed, and resolved some deprecation errors as well with the sphinx package.

### Limitations, known bugs & workarounds

A few sphinx items were changed based on deprecations. These items can be reverted, depending on the production build environment.
