### PR TITLE
Add blogpost on modelling teams to docs

### DIFF
--- a/docs/graphql/manual/guides/sample-apps/index.rst
+++ b/docs/graphql/manual/guides/sample-apps/index.rst
@@ -16,6 +16,7 @@ Blogposts
 - `Build a Login app using React-native and Hasura without Redux <https://codeburst.io/making-a-login-app-using-react-native-and-hasura-without-redux-bb31d102038d>`__
 - `Build file upload and download for your Hasura app with S3 <https://blog.hasura.io/building-file-upload-downloads-for-your-hasura-app/>`__
 - `Public GraphQL queries with Hasura (unauthenticated users) <https://dev.to/mikewheaton/public-graphql-queries-with-hasura-2n06>`__
+- `Modelling teams and user security with Hasura <https://dev.to/lineup-ninja/modelling-teams-and-user-security-with-hasura-204i>`__
 
 Repositories
 ------------


### PR DESCRIPTION
### Description
Feedback from @elgordino was that people often ask how to model user and teams in regard to security. He wrote a blogpost about this. Adding a link in the docs.

### Affected components 
- Docs

