### PR TITLE
Fix two minor enum table reference bugs (fix #2820 and #3010)

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Schema.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema.hs
@@ -114,15 +114,14 @@ isAggFld = flip elem (numAggOps <> compAggOps)
 
 mkGCtxRole'
   :: QualifiedTable
-  -- Postgres description
   -> Maybe PGDescription
-  -- insert permission
+  -- ^ Postgres description
   -> Maybe ([PGColumnInfo], RelationInfoMap)
-  -- select permission
+  -- ^ insert permission
   -> Maybe (Bool, [SelField])
-  -- update cols
+  -- ^ select permission
   -> Maybe [PGColumnInfo]
-  -- delete cols
+  -- ^ update cols
   -> Maybe ()
   -- ^ delete cols
   -> [PGColumnInfo]
@@ -132,12 +131,8 @@ mkGCtxRole'
   -> Maybe ViewInfo
   -> [FunctionInfo]
   -- ^ all functions
-  -> Maybe EnumValues
-  -- ^ present iff this table is an enum table (see "Hasura.RQL.Schema.Enum")
   -> TyAgg
-mkGCtxRole' tn descM insPermM selPermM updColsM
-            delPermM pkeyCols constraints viM funcs enumValuesM =
-
+mkGCtxRole' tn descM insPermM selPermM updColsM delPermM pkeyCols constraints viM funcs =
   TyAgg (mkTyInfoMap allTypes) fieldMap scalars ordByCtx
   where
 
@@ -154,7 +149,7 @@ mkGCtxRole' tn descM insPermM selPermM updColsM
 
     allTypes = relInsInpObjTys <> onConflictTypes <> jsonOpTys
                <> queryTypes <> aggQueryTypes <> mutationTypes
-               <> funcInpArgTys
+               <> funcInpArgTys <> referencedEnumTypes
 
     queryTypes = catMaybes
       [ TIInpObj <$> boolExpInpObjM
@@ -169,7 +164,6 @@ mkGCtxRole' tn descM insPermM selPermM updColsM
       , TIInpObj <$> mutHelper viIsUpdatable updIncInpObjM
       , TIObj <$> mutRespObjM
       , TIEnum <$> selColInpTyM
-      , TIEnum <$> tableEnumTypeM
       ]
 
     mutHelper :: (ViewInfo -> Bool) -> Maybe a -> Maybe a
@@ -289,9 +283,19 @@ mkGCtxRole' tn descM insPermM selPermM updColsM
       Just (a, b) -> (Just a, Just b)
       Nothing     -> (Nothing, Nothing)
 
-    tableEnumTypeM = enumValuesM <&> \enumValues ->
-      mkHsraEnumTyInfo Nothing (mkTableEnumType tn) $
-        EnumValuesReference (EnumReference tn enumValues)
+    -- the types for all enums that are /referenced/ by this table (not /defined/ by this table;
+    -- there isn’t actually any need to generate a GraphQL enum type for an enum table if it’s
+    -- never referenced anywhere else)
+    referencedEnumTypes =
+      let allColumnInfos =
+               (selPermM ^.. _Just._2.traverse._Left)
+            <> (insPermM ^. _Just._1)
+            <> (updColsM ^. _Just)
+          allEnumReferences = allColumnInfos ^.. traverse.to pgiType._PGColumnEnumReference
+      in flip map allEnumReferences $ \enumReference@(EnumReference referencedTableName _) ->
+           let typeName = mkTableEnumType referencedTableName
+           in TIEnum $ mkHsraEnumTyInfo Nothing typeName (EnumValuesReference enumReference)
+
 
 getRootFldsRole'
   :: QualifiedTable
@@ -533,13 +537,11 @@ mkGCtxRole
   -> [ConstraintName]
   -> [FunctionInfo]
   -> Maybe ViewInfo
-  -> Maybe EnumValues
   -> TableConfig
   -> RoleName
   -> RolePermInfo
   -> m (TyAgg, RootFields, InsCtxMap)
-mkGCtxRole tableCache tn descM fields pColInfos constraints funcs viM
-           enumValuesM tabConfigM role permInfo = do
+mkGCtxRole tableCache tn descM fields pColInfos constraints funcs viM tabConfigM role permInfo = do
   selPermM <- mapM (getSelPerm tableCache fields role) $ _permSel permInfo
   tabInsInfoM <- forM (_permIns permInfo) $ \ipi -> do
     ctx <- mkInsCtx role tableCache fields ipi $ _permUpd permInfo
@@ -549,7 +551,7 @@ mkGCtxRole tableCache tn descM fields pColInfos constraints funcs viM
       insCtxM = fst <$> tabInsInfoM
       updColsM = filterColFlds . upiCols <$> _permUpd permInfo
       tyAgg = mkGCtxRole' tn descM insPermM selPermM updColsM
-              (void $ _permDel permInfo) pColInfos constraints viM funcs enumValuesM
+              (void $ _permDel permInfo) pColInfos constraints viM funcs
       rootFlds = getRootFldsRole tn pColInfos constraints fields funcs
                  viM permInfo tabConfigM
       insCtxMap = maybe Map.empty (Map.singleton tn) insCtxM
@@ -597,17 +599,17 @@ mkGCtxMapTable
 mkGCtxMapTable tableCache funcCache tabInfo = do
   m <- flip Map.traverseWithKey rolePerms $
        mkGCtxRole tableCache tn descM fields pkeyColInfos validConstraints
-                  tabFuncs viewInfo enumValues customConfig
+                  tabFuncs viewInfo customConfig
   adminInsCtx <- mkAdminInsCtx tn tableCache fields
   adminSelFlds <- mkAdminSelFlds fields tableCache
   let adminCtx = mkGCtxRole' tn descM (Just (cols, icRelations adminInsCtx))
                  (Just (True, adminSelFlds)) (Just cols) (Just ())
-                 pkeyColInfos validConstraints viewInfo tabFuncs enumValues
+                 pkeyColInfos validConstraints viewInfo tabFuncs
       adminInsCtxMap = Map.singleton tn adminInsCtx
   return $ Map.insert adminRole (adminCtx, adminRootFlds, adminInsCtxMap) m
   where
     TableInfo tn descM _ fields rolePerms constraints
-              pkeyCols viewInfo _ enumValues customConfig = tabInfo
+              pkeyCols viewInfo _ _ customConfig = tabInfo
     validConstraints = mkValidConstraints constraints
     cols = getValidCols fields
     colInfos = getCols fields
@@ -702,7 +704,6 @@ instance Semigroup TyAgg where
 
 instance Monoid TyAgg where
   mempty = TyAgg Map.empty Map.empty Set.empty Map.empty
-  mappend = (<>)
 
 -- | A role-specific mapping from root field names to allowed operations.
 data RootFields
@@ -717,7 +718,6 @@ instance Semigroup RootFields where
 
 instance Monoid RootFields where
   mempty = RootFields Map.empty Map.empty
-  mappend  = (<>)
 
 mkGCtx :: TyAgg -> RootFields -> InsCtxMap -> GCtx
 mkGCtx tyAgg (RootFields queryFields mutationFields) insCtxMap =

--- a/server/tests-py/queries/graphql_mutation/enums/insert_nullable_enum_field.yaml
+++ b/server/tests-py/queries/graphql_mutation/enums/insert_nullable_enum_field.yaml
@@ -1,0 +1,36 @@
+description: Test inserting records with null enum values
+url: /v1/graphql
+status: 200
+response:
+  data:
+    insert_posts:
+      returning:
+      - title: Post 1
+        custom_color: blue
+      - title: Post 2
+        custom_color: null
+      - title: Post 3
+        custom_color: red
+      - title: Post 4
+        custom_color: null
+      - title: Post 5
+        custom_color: null
+query:
+  query: |
+    mutation ($post_3_color: colors_enum, $post_4_color: colors_enum, $post_5_color: colors_enum) {
+      insert_posts(objects: [
+        { title: "Post 1", custom_color: blue },
+        { title: "Post 2" },
+        { title: "Post 3", custom_color: $post_3_color },
+        { title: "Post 4", custom_color: $post_4_color },
+        { title: "Post 5", custom_color: $post_5_color }
+      ]) {
+        returning {
+          title
+          custom_color
+        }
+      }
+    }
+  variables:
+    post_3_color: red
+    post_5_color: null

--- a/server/tests-py/queries/graphql_mutation/enums/schema_setup.yaml
+++ b/server/tests-py/queries/graphql_mutation/enums/schema_setup.yaml
@@ -20,9 +20,16 @@ args:
         , name text NOT NULL
         , favorite_color text NOT NULL REFERENCES colors );
 
+      CREATE TABLE posts
+        ( id serial PRIMARY KEY
+        , title text NOT NULL
+        , custom_color text REFERENCES colors );
+
 - type: track_table
   args:
     table: colors
     is_enum: true
 - type: track_table
   args: users
+- type: track_table
+  args: posts

--- a/server/tests-py/queries/graphql_mutation/enums/schema_teardown.yaml
+++ b/server/tests-py/queries/graphql_mutation/enums/schema_teardown.yaml
@@ -3,6 +3,7 @@ args:
 - type: run_sql
   args:
     sql: |
+      DROP TABLE posts;
       DROP TABLE users;
       DROP TABLE colors;
     cascade: true

--- a/server/tests-py/queries/graphql_query/enums/select_where_enum_eq_without_enum_table_visibility.yaml
+++ b/server/tests-py/queries/graphql_query/enums/select_where_enum_eq_without_enum_table_visibility.yaml
@@ -1,0 +1,64 @@
+- description: >
+    Test that the enum table is not visible under a restricted role, but the generated enum type
+    still is
+  url: /v1/graphql
+  headers:
+    X-Hasura-Role: anonymous
+  query:
+    query: |
+      {
+        table: __type(name: "colors") {
+          name
+          kind
+        }
+        enum: __type(name: "colors_enum") {
+          name
+          kind
+          enumValues {
+            name
+            description
+          }
+        }
+      }
+  status: 200
+  response:
+    data:
+      table: null
+      enum:
+        name: colors_enum
+        kind: ENUM
+        enumValues:
+        - name: blue
+          description: '#0000FF'
+        - name: green
+          description: '#00FF00'
+        - name: orange
+          description: '#FFFF00'
+        - name: purple
+          description: '#FF00FF'
+        - name: red
+          description: '#FF0000'
+        - name: yellow
+          description: '#00FFFF'
+
+- description: >
+    Test querying a table that references an enum table and filtering on enum equality works even if
+    the user performing the query does not have access to query the enum table itself
+  url: /v1/graphql
+  headers:
+    X-Hasura-Role: anonymous
+  query:
+    query: |
+      {
+        like_red:   users(where: { favorite_color: { _eq: red   }}) { name }
+        like_blue:  users(where: { favorite_color: { _eq: blue  }}) { name }
+        like_green: users(where: { favorite_color: { _eq: green }}) { name }
+      }
+  status: 200
+  response:
+    data:
+      like_red:
+      - name: Alyssa
+      like_blue:
+      - name: Ben
+      like_green: []

--- a/server/tests-py/queries/graphql_query/enums/setup.yaml
+++ b/server/tests-py/queries/graphql_query/enums/setup.yaml
@@ -29,3 +29,12 @@ args:
     is_enum: true
 - type: track_table
   args: users
+
+# Anonymous users can query users, but not colors
+- type: create_select_permission
+  args:
+    table: users
+    role: anonymous
+    permission:
+      columns: [id, name, favorite_color]
+      filter: {}

--- a/server/tests-py/queries/v1/insert/basic/insert_nullable_enum_field.yaml
+++ b/server/tests-py/queries/v1/insert/basic/insert_nullable_enum_field.yaml
@@ -1,0 +1,22 @@
+url: /v1/query
+status: 200
+response:
+  affected_rows: 3
+  returning:
+  - title: Post 1
+    custom_color: blue
+  - title: Post 2
+    custom_color: null
+  - title: Post 3
+    custom_color: null
+query:
+  type: insert
+  args:
+    table: posts
+    objects:
+    - title: Post 1
+      custom_color: blue
+    - title: Post 2
+    - title: Post 3
+      custom_color: null
+    returning: [title, custom_color]

--- a/server/tests-py/queries/v1/insert/basic/schema_setup.yaml
+++ b/server/tests-py/queries/v1/insert/basic/schema_setup.yaml
@@ -65,6 +65,32 @@ args:
         table: article
         column: author_id
 
+# Enum table
+- type: run_sql
+  args:
+    sql: |
+      CREATE TABLE colors
+        ( value text PRIMARY KEY
+        , comment text );
+      INSERT INTO colors (value, comment) VALUES
+        ('red',    '#FF0000'),
+        ('green',  '#00FF00'),
+        ('blue',   '#0000FF'),
+        ('orange', '#FFFF00'),
+        ('yellow', '#00FFFF'),
+        ('purple', '#FF00FF');
+
+      CREATE TABLE posts
+        ( id serial PRIMARY KEY
+        , title text NOT NULL
+        , custom_color text REFERENCES colors );
+- type: track_table
+  args:
+    table: colors
+    is_enum: true
+- type: track_table
+  args: posts
+
 #Set timezone
 - type: run_sql
   args:

--- a/server/tests-py/queries/v1/insert/basic/schema_teardown.yaml
+++ b/server/tests-py/queries/v1/insert/basic/schema_teardown.yaml
@@ -4,6 +4,8 @@ args:
 - type: run_sql
   args:
     sql: |
+      drop table posts;
+      drop table colors;
       drop table article;
       drop table author;
       drop table orders;

--- a/server/tests-py/test_graphql_mutations.py
+++ b/server/tests-py/test_graphql_mutations.py
@@ -436,6 +436,9 @@ class TestGraphQLMutateEnums(DefaultTestMutations):
     def test_insert_enum_field(self, hge_ctx, transport):
         check_query_f(hge_ctx, self.dir() + '/insert_enum_field.yaml', transport)
 
+    def test_insert_enum_field(self, hge_ctx, transport):
+        check_query_f(hge_ctx, self.dir() + '/insert_nullable_enum_field.yaml', transport)
+
     def test_insert_enum_field_bad_value(self, hge_ctx, transport):
         check_query_f(hge_ctx, self.dir() + '/insert_enum_field_bad_value.yaml', transport)
 

--- a/server/tests-py/test_graphql_queries.py
+++ b/server/tests-py/test_graphql_queries.py
@@ -501,3 +501,6 @@ class TestGraphQLQueryEnums(DefaultTestSelectQueries):
 
     def test_select_where_enum_eq_variable_bad_value(self, hge_ctx, transport):
         check_query_f(hge_ctx, self.dir() + '/select_where_enum_eq_variable_bad_value.yaml', transport)
+
+    def test_select_where_enum_eq_without_enum_table_visibility(self, hge_ctx, transport):
+        check_query_f(hge_ctx, self.dir() + '/select_where_enum_eq_without_enum_table_visibility.yaml', transport)

--- a/server/tests-py/test_v1_queries.py
+++ b/server/tests-py/test_v1_queries.py
@@ -276,6 +276,9 @@ class TestV1InsertBasic(DefaultTestMutations):
     def test_insert_null_col_value(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + "/order_col_shipped_null.yaml")
 
+    def test_insert_nullable_enum_field(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + "/insert_nullable_enum_field.yaml")
+
     @classmethod
     def dir(cls):
         return "queries/v1/insert/basic"


### PR DESCRIPTION
### Description

As reported in #2820 and #3010, the initial implementation of enum table references missed a few edge cases, specifically:

  - We failed to generate an enum type in the GraphQL schema if the enum table itself wasn’t visible, even if other tables that referenced it were.

  - RQL queries with null values for nullable enum columns were incorrectly rejected, which caused issues when trying to insert rows via the console.

This PR fixes both those bugs.

### Affected components 
- Server

### Related Issues
#2820
#3010

### Solution and Design
TODO

### Steps to test and verify
The appropriate test cases have been added; no manual testing is necessary.

### Limitations, known bugs & workarounds
none