### PR TITLE
enabled up down arrows in dropdown+textbox inputs

### DIFF
--- a/console/src/components/Common/DropdownButton/DropdownButton.js
+++ b/console/src/components/Common/DropdownButton/DropdownButton.js
@@ -6,6 +6,29 @@ import DropdownButton from 'react-bootstrap/lib/DropdownButton';
 import MenuItem from 'react-bootstrap/lib/MenuItem';
 
 class DropButton extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.state = {
+      cursor: 0,
+    };
+  }
+
+  handleKeyDown(e) {
+    const { cursor } = this.state;
+    const { dropdownOptions } = this.props;
+    // arrow up/down button should select next/previous list element
+    if (e.keyCode === 38 && cursor > 0) {
+      this.setState(prevState => ({
+        cursor: prevState.cursor - 1,
+      }));
+    } else if (e.keyCode === 40 && cursor < dropdownOptions.length - 1) {
+      this.setState(prevState => ({
+        cursor: prevState.cursor + 1,
+      }));
+    }
+  }
+
   render() {
     const {
       title,
@@ -23,8 +46,11 @@ class DropButton extends React.Component {
       id,
       testId,
     } = this.props;
+
+    const { cursor } = this.state;
+
     return (
-      <InputGroup className={bsClass}>
+      <InputGroup className={bsClass} onKeyDown={this.handleKeyDown}>
         <DropdownButton
           title={value || title}
           componentClass={InputGroup.Button}
@@ -40,6 +66,7 @@ class DropButton extends React.Component {
               eventKey={i + 1}
               key={i}
               data-test={testId + '-' + 'dropdown-item' + '-' + (i + 1)}
+              className={cursor === i ? 'active' : null}
             >
               {d.display_text}
             </MenuItem>


### PR DESCRIPTION
Fixed https://github.com/hasura/graphql-engine/issues/1210

### Description
Enabled the up and down arrows in dropdown + textbox inputs. Added class 'active' based on the up and down arrow.  

### Affected components 
- Console

### Solution and Design
Created an event handler and based on the up and down key, changing the position of the cursor.

### Limitations, known bugs & workarounds
We need to use active class because of the default behavior and there is no way we can stop the default behavior.
