### PR TITLE
fix console row edit behaviour

### DIFF
--- a/console/src/components/Services/Data/TableBrowseRows/EditActions.js
+++ b/console/src/components/Services/Data/TableBrowseRows/EditActions.js
@@ -6,6 +6,12 @@ import {
   showSuccessNotification,
 } from '../../Common/Notification';
 import dataHeaders from '../Common/Headers';
+import {
+  findTable,
+  generateTableDef,
+  getColumnType,
+  getTableColumn,
+} from '../../../Common/utils/pgUtils';
 
 const E_SET_EDITITEM = 'EditItem/E_SET_EDITITEM';
 const E_ONGOING_REQ = 'EditItem/E_ONGOING_REQ';
@@ -20,59 +26,75 @@ const modalClose = () => ({ type: MODAL_CLOSE });
 /* ****************** edit action creators ************ */
 const editItem = (tableName, colValues) => {
   return (dispatch, getState) => {
-    /* Type all the values correctly */
-    const insertObject = {};
     const state = getState();
-    const { currentSchema } = state.tables;
-    const columns = state.tables.allSchemas.find(
-      t => t.table_name === tableName && t.table_schema === currentSchema
-    ).columns;
-    let error = false;
+
+    /* Type all the values correctly */
+    const { currentSchema, allSchemas } = state.tables;
+
+    const tableDef = generateTableDef(tableName, currentSchema);
+
+    const table = findTable(allSchemas, tableDef);
+
+    const _setObject = {};
+    const _defaultArray = [];
+
     let errorMessage = '';
+
+    if (!Object.keys(colValues).length) {
+      errorMessage = 'No fields modified';
+    }
+
     Object.keys(colValues).map(colName => {
-      const colSchema = columns.find(x => x.column_name === colName);
-      const colType = colSchema.data_type;
-      if (Integers.indexOf(colSchema.data_type) > 0) {
-        insertObject[colName] = parseInt(colValues[colName], 10);
-      } else if (Reals.indexOf(colSchema.data_type) > 0) {
-        insertObject[colName] = parseFloat(colValues[colName], 10);
-      } else if (colSchema.data_type === 'boolean') {
-        if (colValues[colName] === 'true') {
-          insertObject[colName] = true;
-        } else if (colValues[colName] === 'false') {
-          insertObject[colName] = false;
-        } else {
-          insertObject[colName] = null;
-        }
-      } else if (colType === 'json' || colType === 'jsonb') {
-        try {
-          const val = JSON.parse(colValues[colName]);
-          insertObject[colName] = val;
-        } catch (e) {
-          errorMessage =
-            colName +
-            ' :: could not read ' +
-            colValues[colName] +
-            ' as a valid JSON object/array';
-          error = true;
-        }
+      const colValue = colValues[colName];
+
+      const column = getTableColumn(table, colName);
+      const colType = getColumnType(column);
+
+      if (colValue && colValue.default === true) {
+        _defaultArray.push(colName);
       } else {
-        insertObject[colName] = colValues[colName];
+        if (Integers.indexOf(colType) > 0) {
+          _setObject[colName] = parseInt(colValue, 10);
+        } else if (Reals.indexOf(colType) > 0) {
+          _setObject[colName] = parseFloat(colValue);
+        } else if (colType === 'boolean') {
+          if (colValue === 'true') {
+            _setObject[colName] = true;
+          } else if (colValue === 'false') {
+            _setObject[colName] = false;
+          } else {
+            _setObject[colName] = null;
+          }
+        } else if (colType === 'json' || colType === 'jsonb') {
+          try {
+            _setObject[colName] = JSON.parse(colValue);
+          } catch (e) {
+            errorMessage =
+              colName +
+              ' :: could not read ' +
+              colValue +
+              ' as a valid JSON object/array';
+          }
+        } else {
+          _setObject[colName] = colValue;
+        }
       }
     });
-    if (error) {
+
+    if (errorMessage) {
       dispatch(showErrorNotification('Edit failed!', errorMessage));
       return dispatch({
         type: E_REQUEST_ERROR,
-        error: { message: 'Not valid JSON' },
+        error: { message: errorMessage },
       });
     }
 
     const reqBody = {
       type: 'update',
       args: {
-        table: { name: tableName, schema: getState().tables.currentSchema },
-        $set: insertObject,
+        table: tableDef,
+        $set: _setObject,
+        $default: _defaultArray,
         where: state.tables.update.pkClause,
       },
     };
@@ -83,6 +105,7 @@ const editItem = (tableName, colValues) => {
       body: JSON.stringify(reqBody),
     };
     const url = Endpoints.query;
+
     return dispatch(
       requestAction(url, options, E_REQUEST_SUCCESS, E_REQUEST_ERROR)
     ).then(

--- a/console/src/components/Services/Data/TableBrowseRows/EditItem.js
+++ b/console/src/components/Services/Data/TableBrowseRows/EditItem.js
@@ -13,7 +13,6 @@ import { replace } from 'react-router-redux';
 import globals from '../../../../Globals';
 import { E_ONGOING_REQ, editItem } from './EditActions';
 import { findTable, generateTableDef } from '../../../Common/utils/pgUtils';
-import { showErrorNotification } from '../../Common/Notification';
 
 class EditItem extends Component {
   constructor() {
@@ -228,7 +227,7 @@ class EditItem extends Component {
           inputValues[colName] = null;
         } else if (refs[colName].defaultNode.checked) {
           // default
-          return;
+          inputValues[colName] = { default: true };
         } else if (refs[colName].valueNode.checked) {
           inputValues[colName] =
             refs[colName].valueInput.props !== undefined
@@ -237,13 +236,9 @@ class EditItem extends Component {
         }
       });
 
-      if (Object.keys(inputValues).length) {
-        dispatch({ type: E_ONGOING_REQ });
+      dispatch({ type: E_ONGOING_REQ });
 
-        dispatch(editItem(tableName, inputValues));
-      } else {
-        dispatch(showErrorNotification('Edit failed!', 'No fields updated'));
-      }
+      dispatch(editItem(tableName, inputValues));
     };
 
     return (

--- a/console/src/components/Services/Data/TableBrowseRows/EditItem.js
+++ b/console/src/components/Services/Data/TableBrowseRows/EditItem.js
@@ -13,6 +13,7 @@ import { replace } from 'react-router-redux';
 import globals from '../../../../Globals';
 import { E_ONGOING_REQ, editItem } from './EditActions';
 import { findTable, generateTableDef } from '../../../Common/utils/pgUtils';
+import { showErrorNotification } from '../../Common/Notification';
 
 class EditItem extends Component {
   constructor() {
@@ -65,8 +66,13 @@ class EditItem extends Component {
 
       const prevValue = oldItem[colName];
 
-      refs[colName] = { valueNode: null, nullNode: null, defaultNode: null };
-      const inputRef = node => (refs[colName].valueNode = node);
+      refs[colName] = {
+        valueNode: null,
+        valueInput: null,
+        nullNode: null,
+        defaultNode: null,
+      };
+      const inputRef = node => (refs[colName].valueInput = node);
 
       const clicker = e => {
         e.target
@@ -149,7 +155,14 @@ class EditItem extends Component {
             {colName}
           </label>
           <label className={styles.radioLabel + ' radio-inline'}>
-            <input type="radio" name={colName + '-value'} value="option1" />
+            <input
+              type="radio"
+              ref={node => {
+                refs[colName].valueNode = node;
+              }}
+              name={colName + '-value'}
+              value="option1"
+            />
             {typedInput}
           </label>
           <label className={styles.radioLabel + ' radio-inline'}>
@@ -205,6 +218,34 @@ class EditItem extends Component {
       );
     }
 
+    const handleSaveClick = e => {
+      e.preventDefault();
+
+      const inputValues = {};
+      Object.keys(refs).map(colName => {
+        if (refs[colName].nullNode.checked) {
+          // null
+          inputValues[colName] = null;
+        } else if (refs[colName].defaultNode.checked) {
+          // default
+          return;
+        } else if (refs[colName].valueNode.checked) {
+          inputValues[colName] =
+            refs[colName].valueInput.props !== undefined
+              ? refs[colName].valueInput.props.value
+              : refs[colName].valueInput.value;
+        }
+      });
+
+      if (Object.keys(inputValues).length) {
+        dispatch({ type: E_ONGOING_REQ });
+
+        dispatch(editItem(tableName, inputValues));
+      } else {
+        dispatch(showErrorNotification('Edit failed!', 'No fields updated'));
+      }
+    };
+
     return (
       <div className={styles.container + ' container-fluid'}>
         <TableHeader
@@ -223,26 +264,7 @@ class EditItem extends Component {
                 type="submit"
                 color="yellow"
                 size="sm"
-                onClick={e => {
-                  e.preventDefault();
-                  dispatch({ type: E_ONGOING_REQ });
-                  const inputValues = {};
-                  Object.keys(refs).map(colName => {
-                    if (refs[colName].nullNode.checked) {
-                      // null
-                      inputValues[colName] = null;
-                    } else if (refs[colName].defaultNode.checked) {
-                      // default
-                      return;
-                    } else {
-                      inputValues[colName] =
-                        refs[colName].valueNode.props !== undefined
-                          ? refs[colName].valueNode.props.value
-                          : refs[colName].valueNode.value;
-                    }
-                  });
-                  dispatch(editItem(tableName, inputValues));
-                }}
+                onClick={handleSaveClick}
                 data-test="edit-save-button"
               >
                 {buttonText}


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Currently during row edits the console attempts to set all column values even if the column isn't modified which causes issues such as data format changes as reported in the related issue.

This PR ensures only columns which have been manually edited will be updated.

Also handling setting values to default during edit

### Affected components 
<!-- Remove non-affected components from the list -->

- Console

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#3121

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

Check if the value radio button is checked before setting column value to be updated

Set column value to `{default: true}` if default value selected and use it to generate the $default array 

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
