### PR TITLE
Track variable uses within query validation for caching (fix #3097)

### DIFF
--- a/.circleci/test-server.sh
+++ b/.circleci/test-server.sh
@@ -414,6 +414,15 @@ pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" -
 
 kill_hge_servers
 
+echo -e "\n$(time_elapsed): <########## TEST GRAPHQL-ENGINE QUERY CACHING #####################################>\n"
+TEST_TYPE="query-caching"
+
+# use only one capability to disable cache striping
+run_hge_with_args +RTS -N1 -RTS serve
+wait_for_port 8080
+pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" test_graphql_queries.py::TestGraphQLQueryCaching
+kill_hge_servers
+
 # verbose logging tests
 echo -e "\n$(time_elapsed): <########## TEST GRAPHQL-ENGINE WITH QUERY LOG ########>\n"
 TEST_TYPE="query-logs"

--- a/server/src-lib/Hasura/GraphQL/Explain.hs
+++ b/server/src-lib/Hasura/GraphQL/Explain.hs
@@ -12,7 +12,8 @@ import qualified Language.GraphQL.Draft.Syntax          as G
 
 import           Hasura.EncJSON
 import           Hasura.GraphQL.Context
-import           Hasura.GraphQL.Resolve.Types
+import           Hasura.GraphQL.Validate.Types          (evalReusabilityT,
+                                                         runReusabilityT)
 import           Hasura.Prelude
 import           Hasura.RQL.DML.Internal
 import           Hasura.RQL.Types
@@ -90,7 +91,7 @@ explainField userInfo gCtx sqlGenCtx fld =
     _            -> do
       unresolvedAST <-
         runExplain (queryCtxMap, userInfo, fldMap, orderByCtx, sqlGenCtx) $
-          evalResolveT $ RS.queryFldToPGAST fld
+          evalReusabilityT $ RS.queryFldToPGAST fld
       resolvedAST <- RS.traverseQueryRootFldAST (resolveVal userInfo)
                      unresolvedAST
       let txtSQL = Q.getQueryText $ RS.toPGQuery resolvedAST
@@ -114,7 +115,8 @@ explainGQLQuery
   -> GQLExplain
   -> m EncJSON
 explainGQLQuery pgExecCtx sc sqlGenCtx enableAL (GQLExplain query userVarsRaw) = do
-  execPlan <- E.getExecPlanPartial userInfo sc enableAL query
+  (execPlan, queryReusability) <- runReusabilityT $
+    E.getExecPlanPartial userInfo sc enableAL query
   (gCtx, rootSelSet) <- case execPlan of
     E.GExPHasura (gCtx, rootSelSet) ->
       return (gCtx, rootSelSet)
@@ -126,7 +128,7 @@ explainGQLQuery pgExecCtx sc sqlGenCtx enableAL (GQLExplain query userVarsRaw) =
     GV.RMutation _ ->
       throw400 InvalidParams "only queries can be explained"
     GV.RSubscription rootField -> do
-      (plan, _) <- E.getSubsOp pgExecCtx gCtx sqlGenCtx userInfo rootField
+      (plan, _) <- E.getSubsOp pgExecCtx gCtx sqlGenCtx userInfo queryReusability rootField
       runInTx $ encJFromJValue <$> E.explainLiveQueryPlan plan
   where
     usrVars = mkUserVars $ maybe [] Map.toList userVarsRaw

--- a/server/src-lib/Hasura/GraphQL/Resolve.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve.hs
@@ -42,7 +42,7 @@ validateHdrs userInfo hdrs = do
     throw400 NotFound $ hdr <<> " header is expected but not found"
 
 queryFldToPGAST
-  :: ( MonadResolve m, MonadReader r m, Has FieldMap r
+  :: ( MonadReusability m, MonadError QErr m, MonadReader r m, Has FieldMap r
      , Has OrdByCtx r, Has SQLGenCtx r, Has UserInfo r
      , Has QueryCtxMap r
      )
@@ -69,7 +69,7 @@ queryFldToPGAST fld = do
       RS.convertFuncQueryAgg ctx fld
 
 queryFldToSQL
-  :: ( MonadResolve m, MonadReader r m, Has FieldMap r
+  :: ( MonadReusability m, MonadError QErr m, MonadReader r m, Has FieldMap r
      , Has OrdByCtx r, Has SQLGenCtx r, Has UserInfo r
      , Has QueryCtxMap r
      )
@@ -85,7 +85,8 @@ queryFldToSQL fn fld = do
   return $ RS.toPGQuery resolvedAST
 
 mutFldToTx
-  :: ( MonadResolve m
+  :: ( MonadReusability m
+     , MonadError QErr m
      , MonadReader r m
      , Has UserInfo r
      , Has MutationCtxMap r
@@ -112,7 +113,8 @@ mutFldToTx fld = do
       RM.convertDelete ctx fld
 
 getOpCtx
-  :: ( MonadResolve m
+  :: ( MonadReusability m
+     , MonadError QErr m
      , MonadReader r m
      , Has (OpCtxMap a) r
      )

--- a/server/src-lib/Hasura/GraphQL/Resolve/BoolExp.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/BoolExp.hs
@@ -20,7 +20,7 @@ import qualified Hasura.SQL.DML                    as S
 
 type OpExp = OpExpG UnresolvedVal
 
-parseOpExps :: (MonadResolve m) => PGColumnType -> AnnInpVal -> m [OpExp]
+parseOpExps :: (MonadReusability m, MonadError QErr m) => PGColumnType -> AnnInpVal -> m [OpExp]
 parseOpExps colTy annVal = do
   opExpsM <- flip withObjectM annVal $ \nt objM -> forM objM $ \obj ->
     forM (OMap.toList obj) $ \(k, v) ->
@@ -138,7 +138,7 @@ parseOpExps colTy annVal = do
       mkParameterizablePGValue <$> asPGColumnValue geomminVal
 
 parseCastExpression
-  :: (MonadResolve m)
+  :: (MonadReusability m, MonadError QErr m)
   => AnnInpVal -> m (Maybe (CastExp UnresolvedVal))
 parseCastExpression =
   withObjectM $ \_ objM -> forM objM $ \obj -> do
@@ -149,7 +149,8 @@ parseCastExpression =
     return $ Map.fromList targetExps
 
 parseColExp
-  :: ( MonadResolve m
+  :: ( MonadReusability m
+     , MonadError QErr m
      , MonadReader r m
      , Has FieldMap r
      )
@@ -167,7 +168,8 @@ parseColExp nt n val = do
         fmapAnnBoolExp partialSQLExpToUnresolvedVal permExp
 
 parseBoolExp
-  :: ( MonadResolve m
+  :: ( MonadReusability m
+     , MonadError QErr m
      , MonadReader r m
      , Has FieldMap r
      )

--- a/server/src-lib/Hasura/GraphQL/Resolve/Context.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/Context.hs
@@ -100,7 +100,7 @@ withArg args arg f = prependArgsInPath $ nameAsPath arg $
   getArg args arg >>= f
 
 withArgM
-  :: (MonadResolve m)
+  :: (MonadReusability m, MonadError QErr m)
   => ArgsMap
   -> G.Name
   -> (AnnInpVal -> m a)

--- a/server/src-lib/Hasura/GraphQL/Resolve/Insert.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/Insert.hs
@@ -87,7 +87,7 @@ data AnnInsObj
   } deriving (Show, Eq)
 
 mkAnnInsObj
-  :: (MonadResolve m, Has InsCtxMap r, MonadReader r m, Has FieldMap r)
+  :: (MonadReusability m, MonadError QErr m, Has InsCtxMap r, MonadReader r m, Has FieldMap r)
   => RelationInfoMap
   -> PGColGNameMap
   -> AnnGObject
@@ -98,7 +98,7 @@ mkAnnInsObj relInfoMap allColMap annObj =
     emptyInsObj = AnnInsObj [] [] []
 
 traverseInsObj
-  :: (MonadResolve m, Has InsCtxMap r, MonadReader r m, Has FieldMap r)
+  :: (MonadReusability m, MonadError QErr m, Has InsCtxMap r, MonadReader r m, Has FieldMap r)
   => RelationInfoMap
   -> PGColGNameMap
   -> (G.Name, AnnInpVal)
@@ -161,7 +161,7 @@ traverseInsObj rim allColMap (gName, annVal) defVal@(AnnInsObj cols objRels arrR
             bool withNonEmptyArrData (return defVal) $ null arrDataVals
 
 parseOnConflict
-  :: (MonadResolve m, MonadReader r m, Has FieldMap r)
+  :: (MonadReusability m, MonadError QErr m, MonadReader r m, Has FieldMap r)
   => QualifiedTable
   -> Maybe UpdPermForIns
   -> PGColGNameMap
@@ -495,7 +495,7 @@ prefixErrPath fld =
   withPathK "selectionSet" . fieldAsPath fld . withPathK "args"
 
 convertInsert
-  :: ( MonadResolve m, MonadReader r m, Has FieldMap r
+  :: ( MonadReusability m, MonadError QErr m, MonadReader r m, Has FieldMap r
      , Has OrdByCtx r, Has SQLGenCtx r, Has InsCtxMap r
      )
   => RoleName

--- a/server/src-lib/Hasura/GraphQL/Resolve/Introspect.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/Introspect.hs
@@ -333,7 +333,7 @@ schemaR fld =
     _              -> return J.Null
 
 typeR
-  :: (MonadResolve m, MonadReader r m, Has TypeMap r)
+  :: (MonadReusability m, MonadError QErr m, MonadReader r m, Has TypeMap r)
   => Field -> m J.Value
 typeR fld = do
   name <- asPGColText =<< getArg args "name"

--- a/server/src-lib/Hasura/GraphQL/Resolve/Mutation.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/Mutation.hs
@@ -32,7 +32,7 @@ import           Hasura.SQL.Types
 import           Hasura.SQL.Value
 
 convertMutResp
-  :: ( MonadResolve m, MonadReader r m, Has FieldMap r
+  :: ( MonadReusability m, MonadError QErr m, MonadReader r m, Has FieldMap r
      , Has OrdByCtx r, Has SQLGenCtx r
      )
   => G.NamedType -> SelSet -> m (RR.MutFldsG UnresolvedVal)
@@ -53,7 +53,7 @@ convertMutResp ty selSet =
       UVSQL sqlExp -> pure $ UVSQL sqlExp
 
 convertRowObj
-  :: (MonadResolve m)
+  :: (MonadReusability m, MonadError QErr m)
   => PGColGNameMap
   -> AnnInpVal
   -> m [(PGCol, UnresolvedVal)]
@@ -80,7 +80,7 @@ lhsExpOp op annTy (col, e) =
     annExp = S.SETyAnn e annTy
 
 convObjWithOp
-  :: (MonadResolve m)
+  :: (MonadReusability m, MonadError QErr m)
   => PGColGNameMap -> ApplySQLOp -> AnnInpVal -> m [(PGCol, UnresolvedVal)]
 convObjWithOp colGNameMap opFn val =
   flip withObject val $ \_ obj -> forM (OMap.toList obj) $ \(k, v) -> do
@@ -92,7 +92,7 @@ convObjWithOp colGNameMap opFn val =
   return (pgCol, UVSQL sqlExp)
 
 convDeleteAtPathObj
-  :: (MonadResolve m)
+  :: (MonadReusability m, MonadError QErr m)
   => PGColGNameMap -> AnnInpVal -> m [(PGCol, UnresolvedVal)]
 convDeleteAtPathObj colGNameMap val =
   flip withObject val $ \_ obj -> forM (OMap.toList obj) $ \(k, v) -> do
@@ -105,7 +105,7 @@ convDeleteAtPathObj colGNameMap val =
     return (pgCol, UVSQL sqlExp)
 
 convertUpdateP1
-  :: ( MonadResolve m
+  :: ( MonadReusability m, MonadError QErr m
      , MonadReader r m, Has FieldMap r
      , Has OrdByCtx r, Has SQLGenCtx r
      )
@@ -163,7 +163,7 @@ convertUpdateP1 opCtx fld = do
     args = _fArguments fld
 
 convertUpdate
-  :: ( MonadResolve m
+  :: ( MonadReusability m, MonadError QErr m
      , MonadReader r m, Has FieldMap r
      , Has OrdByCtx r, Has SQLGenCtx r
      )
@@ -184,7 +184,7 @@ convertUpdate opCtx fld = do
   bool whenNonEmptyItems whenEmptyItems $ null $ RU.uqp1SetExps annUpdResolved
 
 convertDelete
-  :: ( MonadResolve m
+  :: ( MonadReusability m, MonadError QErr m
      , MonadReader r m, Has FieldMap r
      , Has OrdByCtx r, Has SQLGenCtx r
      )

--- a/server/src-lib/Hasura/GraphQL/Resolve/Select.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/Select.hs
@@ -47,7 +47,7 @@ jsonPathToColExp t = case parseJSONPath t of
     elToColExp (Index i) = S.SELit $ T.pack (show i)
 
 
-argsToColOp :: (MonadResolve m) => ArgsMap -> m (Maybe RS.ColOp)
+argsToColOp :: (MonadReusability m, MonadError QErr m) => ArgsMap -> m (Maybe RS.ColOp)
 argsToColOp args = maybe (return Nothing) toOp $ Map.lookup "path" args
   where
     toJsonPathExp = fmap (RS.ColOp S.jsonbPathOp) . jsonPathToColExp
@@ -56,7 +56,7 @@ argsToColOp args = maybe (return Nothing) toOp $ Map.lookup "path" args
 type AnnFlds = RS.AnnFldsG UnresolvedVal
 
 fromSelSet
-  :: ( MonadResolve m, MonadReader r m, Has FieldMap r
+  :: ( MonadReusability m, MonadError QErr m, MonadReader r m, Has FieldMap r
      , Has OrdByCtx r, Has SQLGenCtx r
      )
   => G.NamedType -> SelSet -> m AnnFlds
@@ -88,7 +88,7 @@ fromSelSet fldTy flds =
 type TableAggFlds = RS.TableAggFldsG UnresolvedVal
 
 fromAggSelSet
-  :: ( MonadResolve m, MonadReader r m, Has FieldMap r
+  :: ( MonadReusability m, MonadError QErr m, MonadReader r m, Has FieldMap r
      , Has OrdByCtx r, Has SQLGenCtx r
      )
   => PGColGNameMap -> G.NamedType -> SelSet -> m TableAggFlds
@@ -105,7 +105,7 @@ fromAggSelSet colGNameMap fldTy selSet = fmap toFields $
 type TableArgs = RS.TableArgsG UnresolvedVal
 
 parseTableArgs
-  :: ( MonadResolve m, MonadReader r m
+  :: ( MonadReusability m, MonadError QErr m, MonadReader r m
      , Has FieldMap r, Has OrdByCtx r
      )
   => PGColGNameMap -> ArgsMap -> m TableArgs
@@ -137,7 +137,7 @@ parseTableArgs colGNameMap args = do
 type AnnSimpleSelect = RS.AnnSimpleSelG UnresolvedVal
 
 fromField
-  :: ( MonadResolve m, MonadReader r m, Has FieldMap r
+  :: ( MonadReusability m, MonadError QErr m, MonadReader r m, Has FieldMap r
      , Has OrdByCtx r, Has SQLGenCtx r
      )
   => QualifiedTable
@@ -168,7 +168,8 @@ getOrdByItemMap nt = do
     throw500 $ "could not lookup " <> showNamedTy nt
 
 parseOrderBy
-  :: ( MonadResolve m
+  :: ( MonadReusability m
+     , MonadError QErr m
      , MonadReader r m
      , Has OrdByCtx r
      )
@@ -178,7 +179,8 @@ parseOrderBy = fmap concat . withArray f
     f _ = mapM (withObject (getAnnObItems id))
 
 getAnnObItems
-  :: ( MonadResolve m
+  :: ( MonadReusability m
+     , MonadError QErr m
      , MonadReader r m
      , Has OrdByCtx r
      )
@@ -218,7 +220,7 @@ mkOrdByItemG ordTy aobCol nullsOrd =
   OrderByItemG (Just $ OrderType ordTy) aobCol (Just $ NullsOrder nullsOrd)
 
 parseAggOrdBy
-  :: (MonadResolve m)
+  :: (MonadReusability m, MonadError QErr m)
   => PGColGNameMap
   -> (RS.AnnAggOrdBy -> RS.AnnObColG UnresolvedVal)
   -> AnnGObject
@@ -257,7 +259,7 @@ parseOrderByEnum = \case
   G.EnumValue v                   -> throw500 $
     "enum value " <> showName v <> " not found in type order_by"
 
-parseLimit :: (MonadResolve m) => AnnInpVal -> m Int
+parseLimit :: (MonadReusability m, MonadError QErr m) => AnnInpVal -> m Int
 parseLimit v = do
   pgColVal <- openOpaqueValue =<< asPGColumnValue v
   limit <- maybe noIntErr return . pgColValueToInt . pstValue $ _apvValue pgColVal
@@ -271,7 +273,8 @@ type AnnSimpleSel = RS.AnnSimpleSelG UnresolvedVal
 
 type PGColValMap = Map.HashMap G.Name AnnInpVal
 
-pgColValToBoolExp :: (MonadResolve m) => PGColArgMap -> PGColValMap -> m AnnBoolExpUnresolved
+pgColValToBoolExp
+  :: (MonadReusability m, MonadError QErr m) => PGColArgMap -> PGColValMap -> m AnnBoolExpUnresolved
 pgColValToBoolExp colArgMap colValMap = do
   colExps <- forM colVals $ \(name, val) ->
     BoolFld <$> do
@@ -285,7 +288,8 @@ pgColValToBoolExp colArgMap colValMap = do
     colVals = Map.toList colValMap
 
 fromFieldByPKey
-  :: ( MonadResolve m
+  :: ( MonadReusability m
+     , MonadError QErr m
      , MonadReader r m
      , Has FieldMap r
      , Has OrdByCtx r
@@ -307,7 +311,7 @@ fromFieldByPKey tn colArgMap permFilter fld = fieldAsPath fld $ do
     fldTy = _fType fld
 
 convertSelect
-  :: ( MonadResolve m, MonadReader r m, Has FieldMap r
+  :: ( MonadReusability m, MonadError QErr m, MonadReader r m, Has FieldMap r
      , Has OrdByCtx r, Has SQLGenCtx r
      )
   => SelOpCtx -> Field -> m QueryRootFldUnresolved
@@ -318,7 +322,7 @@ convertSelect opCtx fld =
     SelOpCtx qt _ colGNameMap permFilter permLimit = opCtx
 
 convertSelectByPKey
-  :: ( MonadResolve m, MonadReader r m, Has FieldMap r
+  :: ( MonadReusability m, MonadError QErr m, MonadReader r m, Has FieldMap r
      , Has OrdByCtx r, Has SQLGenCtx r
      )
   => SelPkOpCtx -> Field -> m QueryRootFldUnresolved
@@ -329,14 +333,14 @@ convertSelectByPKey opCtx fld =
     SelPkOpCtx qt _ permFilter colArgMap = opCtx
 
 -- agg select related
-parseColumns :: (MonadResolve m) => PGColGNameMap -> AnnInpVal -> m [PGCol]
+parseColumns :: (MonadReusability m, MonadError QErr m) => PGColGNameMap -> AnnInpVal -> m [PGCol]
 parseColumns allColFldMap val =
   flip withArray val $ \_ vals ->
     forM vals $ \v -> do
       (_, G.EnumValue enumVal) <- asEnumVal v
       pgiColumn <$> resolvePGCol allColFldMap enumVal
 
-convertCount :: (MonadResolve m) => PGColGNameMap -> ArgsMap -> m S.CountType
+convertCount :: (MonadReusability m, MonadError QErr m) => PGColGNameMap -> ArgsMap -> m S.CountType
 convertCount colGNameMap args = do
   columnsM <- withArgM args "columns" $ parseColumns colGNameMap
   isDistinct <- or <$> withArgM args "distinct" parseDistinct
@@ -356,7 +360,7 @@ toFields :: [(T.Text, a)] -> RS.Fields a
 toFields = map (first FieldName)
 
 convertColFlds
-  :: MonadError QErr m
+  :: (MonadError QErr m)
   => PGColGNameMap -> G.NamedType -> SelSet -> m RS.ColFlds
 convertColFlds colGNameMap ty selSet = fmap toFields $
   withSelSet selSet $ \fld ->
@@ -365,7 +369,7 @@ convertColFlds colGNameMap ty selSet = fmap toFields $
       n            -> (RS.PCFCol . pgiColumn) <$> resolvePGCol colGNameMap n
 
 convertAggFld
-  :: (MonadResolve m)
+  :: (MonadReusability m, MonadError QErr m)
   => PGColGNameMap -> G.NamedType -> SelSet -> m RS.AggFlds
 convertAggFld colGNameMap ty selSet = fmap toFields $
   withSelSet selSet $ \fld -> do
@@ -385,7 +389,7 @@ convertAggFld colGNameMap ty selSet = fmap toFields $
 type AnnAggSel = RS.AnnAggSelG UnresolvedVal
 
 fromAggField
-  :: ( MonadResolve m, MonadReader r m, Has FieldMap r
+  :: ( MonadReusability m, MonadError QErr m, MonadReader r m, Has FieldMap r
      , Has OrdByCtx r, Has SQLGenCtx r
      )
   => QualifiedTable
@@ -406,7 +410,7 @@ fromAggField tn colGNameMap permFilter permLimit fld = fieldAsPath fld $ do
     args = _fArguments fld
 
 convertAggSelect
-  :: ( MonadResolve m, MonadReader r m, Has FieldMap r
+  :: ( MonadReusability m, MonadError QErr m, MonadReader r m, Has FieldMap r
      , Has OrdByCtx r, Has SQLGenCtx r
      )
   => SelOpCtx -> Field -> m QueryRootFldUnresolved
@@ -418,7 +422,7 @@ convertAggSelect opCtx fld =
     SelOpCtx qt _ colGNameMap permFilter permLimit = opCtx
 
 parseFunctionArgs
-  :: (MonadResolve m)
+  :: (MonadReusability m, MonadError QErr m)
   => FuncArgSeq
   -> AnnInpVal
   -> m (RS.FunctionArgsExpG UnresolvedVal)
@@ -443,7 +447,7 @@ parseFunctionArgs argSeq val = flip withObject val $ \_ obj -> do
                    else pure Nothing
 
 fromFuncQueryField
-  :: (MonadResolve m)
+  :: (MonadReusability m, MonadError QErr m)
   => (Field -> m s)
   -> QualifiedFunction -> FuncArgSeq
   -> Field
@@ -454,7 +458,8 @@ fromFuncQueryField fn qf argSeq fld = fieldAsPath fld $ do
   RS.AnnFnSel qf funcArgs <$> fn fld
 
 convertFuncQuerySimple
-  :: ( MonadResolve m
+  :: ( MonadReusability m
+     , MonadError QErr m
      , MonadReader r m
      , Has FieldMap r
      , Has OrdByCtx r
@@ -468,7 +473,8 @@ convertFuncQuerySimple funcOpCtx fld =
     FuncQOpCtx qt _ colGNameMap permFilter permLimit qf argSeq = funcOpCtx
 
 convertFuncQueryAgg
-  :: ( MonadResolve m
+  :: ( MonadReusability m
+     , MonadError QErr m
      , MonadReader r m
      , Has FieldMap r
      , Has OrdByCtx r

--- a/server/src-lib/Hasura/GraphQL/Validate.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate.hs
@@ -148,7 +148,8 @@ data RootSelSet
   | RSubscription !Field
   deriving (Show, Eq)
 
-validateGQ :: (MonadError QErr m, MonadReader GCtx m) => QueryParts -> m RootSelSet
+validateGQ
+  :: (MonadError QErr m, MonadReader GCtx m, MonadReusability m) => QueryParts -> m RootSelSet
 validateGQ (QueryParts opDef opRoot fragDefsL varValsM) = do
   ctx <- ask
 

--- a/server/src-lib/Hasura/GraphQL/Validate/Field.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate/Field.hs
@@ -111,12 +111,13 @@ data FieldGroup
 
 withDirectives
   :: ( MonadReader ValidationCtx m
-     , MonadError QErr m)
+     , MonadError QErr m
+     , MonadReusability m
+     )
   => [G.Directive]
   -> m a
   -> m (Maybe a)
 withDirectives dirs act = do
-
   dirDefs <- onLeft (mkMapWith G._dName dirs) $ \dups ->
     throwVE $ "the following directives are used more than once: " <>
     showNames dups
@@ -140,13 +141,16 @@ withDirectives dirs act = do
     getIfArg m = do
       val <- onNothing (Map.lookup "if" m) $ throw500
               "missing if argument in the directive"
+      when (isJust $ _aivVariable val) markNotReusable
       case _aivValue val of
         AGScalar _ (Just (PGValBoolean v)) -> return v
         _ -> throw500 "did not find boolean scalar for if argument"
 
 denormSel
   :: ( MonadReader ValidationCtx m
-     , MonadError QErr m)
+     , MonadError QErr m
+     , MonadReusability m
+     )
   => [G.Name] -- visited fragments
   -> ObjTyInfo -- parent type info
   -> G.Selection
@@ -166,7 +170,8 @@ denormSel visFrags parObjTyInfo sel = case sel of
 
 processArgs
   :: ( MonadReader ValidationCtx m
-     , MonadError QErr m)
+     , MonadError QErr m
+     )
   => ParamMap
   -> [G.Argument]
   -> m ArgsMap
@@ -197,7 +202,9 @@ processArgs fldParams argsL = do
 
 denormFld
   :: ( MonadReader ValidationCtx m
-     , MonadError QErr m)
+     , MonadError QErr m
+     , MonadReusability m
+     )
   => [G.Name] -- visited fragments
   -> ObjFldInfo
   -> G.Field
@@ -237,7 +244,9 @@ denormFld visFrags fldInfo (G.Field aliasM name args dirs selSet) = do
 
 denormInlnFrag
   :: ( MonadReader ValidationCtx m
-     , MonadError QErr m)
+     , MonadError QErr m
+     , MonadReusability m
+     )
   => [G.Name] -- visited fragments
   -> ObjTyInfo -- type information of the field
   -> G.InlineFragment
@@ -255,7 +264,9 @@ denormInlnFrag visFrags fldTyInfo inlnFrag = do
 
 denormSelSet
   :: ( MonadReader ValidationCtx m
-     , MonadError QErr m)
+     , MonadError QErr m
+     , MonadReusability m
+     )
   => [G.Name] -- visited fragments
   -> ObjTyInfo
   -> G.SelectionSet
@@ -271,7 +282,9 @@ denormSelSet visFrags fldTyInfo selSet =
 
 mergeFields
   :: ( MonadReader ValidationCtx m
-     , MonadError QErr m)
+     , MonadError QErr m
+     , MonadReusability m
+     )
   => Seq.Seq Field
   -> m (Seq.Seq Field)
 mergeFields flds =
@@ -301,7 +314,9 @@ mergeFields flds =
 
 denormFrag
   :: ( MonadReader ValidationCtx m
-     , MonadError QErr m)
+     , MonadError QErr m
+     , MonadReusability m
+     )
   => [G.Name] -- visited fragments
   -> G.NamedType -- parent type
   -> G.FragmentSpread

--- a/server/src-lib/Hasura/GraphQL/Validate/Types.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate/Types.hs
@@ -62,6 +62,16 @@ module Hasura.GraphQL.Validate.Types
 
   , ReusableVariableTypes(..)
   , ReusableVariableValues
+
+  , QueryReusability(..)
+  , _Reusable
+  , _NotReusable
+  , MonadReusability(..)
+  , ReusabilityT
+  , runReusabilityT
+  , runReusabilityTWith
+  , evalReusabilityT
+
   , module Hasura.GraphQL.Utils
   ) where
 
@@ -77,6 +87,8 @@ import qualified Data.Text                     as T
 import qualified Language.GraphQL.Draft.Syntax as G
 import qualified Language.GraphQL.Draft.TH     as G
 import qualified Language.Haskell.TH.Syntax    as TH
+
+import           Control.Lens                  (makePrisms)
 
 import qualified Hasura.RQL.Types.Column       as RQL
 
@@ -750,8 +762,64 @@ stripTypenames = map filterExecDef
       _                  -> Just s
 
 -- | Used by 'Hasura.GraphQL.Validate.validateVariablesForReuse' to parse new sets of variables for
--- reusable query plans; see also 'Hasura.GraphQL.Resolve.Types.QueryReusability'.
+-- reusable query plans; see also 'QueryReusability'.
 newtype ReusableVariableTypes
   = ReusableVariableTypes { unReusableVarTypes :: Map.HashMap G.Variable RQL.PGColumnType }
   deriving (Show, Eq, Semigroup, Monoid, J.ToJSON)
 type ReusableVariableValues = Map.HashMap G.Variable (WithScalarType PGScalarValue)
+
+-- | Tracks whether or not a query is /reusable/. Reusable queries are nice, since we can cache
+-- their resolved ASTs and avoid re-resolving them if we receive an identical query. However, we
+-- can’t always safely reuse queries if they have variables, since some variable values can affect
+-- the generated SQL. For example, consider the following query:
+--
+-- > query users_where($condition: users_bool_exp!) {
+-- >   users(where: $condition) {
+-- >     id
+-- >   }
+-- > }
+--
+-- Different values for @$condition@ will produce completely different queries, so we can’t reuse
+-- its plan (unless the variable values were also all identical, of course, but we don’t bother
+-- caching those).
+--
+-- If a query does turn out to be reusable, we build up a 'ReusableVariableTypes' value that maps
+-- variable names to their types so that we can use a fast path for validating new sets of
+-- variables (namely 'Hasura.GraphQL.Validate.validateVariablesForReuse').
+data QueryReusability
+  = Reusable !ReusableVariableTypes
+  | NotReusable
+  deriving (Show, Eq)
+$(makePrisms ''QueryReusability)
+
+instance Semigroup QueryReusability where
+  Reusable a <> Reusable b = Reusable (a <> b)
+  _          <> _          = NotReusable
+instance Monoid QueryReusability where
+  mempty = Reusable mempty
+
+class (Monad m) => MonadReusability m where
+  recordVariableUse :: G.Variable -> RQL.PGColumnType -> m ()
+  markNotReusable :: m ()
+
+instance (MonadReusability m) => MonadReusability (ReaderT r m) where
+  recordVariableUse a b = lift $ recordVariableUse a b
+  markNotReusable = lift markNotReusable
+
+newtype ReusabilityT m a = ReusabilityT { unReusabilityT :: StateT QueryReusability m a }
+  deriving (Functor, Applicative, Monad, MonadError e, MonadReader r)
+
+instance (Monad m) => MonadReusability (ReusabilityT m) where
+  recordVariableUse varName varType = ReusabilityT $
+    modify' (<> Reusable (ReusableVariableTypes $ Map.singleton varName varType))
+  markNotReusable = ReusabilityT $ put NotReusable
+
+runReusabilityT :: ReusabilityT m a -> m (a, QueryReusability)
+runReusabilityT = runReusabilityTWith mempty
+
+-- | Like 'runReusabilityT', but starting from an existing 'QueryReusability' state.
+runReusabilityTWith :: QueryReusability -> ReusabilityT m a -> m (a, QueryReusability)
+runReusabilityTWith initialReusability = flip runStateT initialReusability . unReusabilityT
+
+evalReusabilityT :: (Monad m) => ReusabilityT m a -> m a
+evalReusabilityT = flip evalStateT mempty . unReusabilityT

--- a/server/tests-py/queries/graphql_query/caching/include_directive.yaml
+++ b/server/tests-py/queries/graphql_query/caching/include_directive.yaml
@@ -1,0 +1,32 @@
+- description: Test that include directives are properly cached (#3097)
+  url: /v1/graphql
+  status: 200
+  response:
+    data:
+      users:
+      - name: Alyssa
+      - name: Ben
+  query:
+    query: |
+      query ($flag: Boolean!) {
+        users @include(if: $flag) {
+          name
+        }
+      }
+    variables:
+      flag: true
+
+- description: Test that include directives are properly cached (#3097)
+  url: /v1/graphql
+  status: 200
+  response:
+    data: {}
+  query:
+    query: |
+      query ($flag: Boolean!) {
+        users @include(if: $flag) {
+          name
+        }
+      }
+    variables:
+      flag: false

--- a/server/tests-py/queries/graphql_query/caching/setup.yaml
+++ b/server/tests-py/queries/graphql_query/caching/setup.yaml
@@ -1,0 +1,9 @@
+type: bulk
+args:
+- type: run_sql
+  args:
+    sql: |
+      CREATE TABLE users (id serial PRIMARY KEY, name text NOT NULL);
+      INSERT INTO users (name) VALUES ('Alyssa'), ('Ben');
+- type: track_table
+  args: users

--- a/server/tests-py/queries/graphql_query/caching/teardown.yaml
+++ b/server/tests-py/queries/graphql_query/caching/teardown.yaml
@@ -1,0 +1,5 @@
+type: run_sql
+args:
+  sql: |
+    DROP TABLE users;
+  cascade: true

--- a/server/tests-py/test_graphql_queries.py
+++ b/server/tests-py/test_graphql_queries.py
@@ -504,3 +504,12 @@ class TestGraphQLQueryEnums(DefaultTestSelectQueries):
 
     def test_select_where_enum_eq_without_enum_table_visibility(self, hge_ctx, transport):
         check_query_f(hge_ctx, self.dir() + '/select_where_enum_eq_without_enum_table_visibility.yaml', transport)
+
+@pytest.mark.parametrize('transport', ['http', 'websocket'])
+class TestGraphQLQueryCaching(DefaultTestSelectQueries):
+    @classmethod
+    def dir(cls):
+        return 'queries/graphql_query/caching'
+
+    def test_include_directive(self, hge_ctx, transport):
+        check_query_f(hge_ctx, self.dir() + '/include_directive.yaml', transport)


### PR DESCRIPTION
### Description

This fixes a severe bug in query caching that arises from uses of `@include` or `@skip` directives, as described in #3097; see that issue for the details.

### Affected components 
- Server

### Related Issues
#3097

### Solution and Design
This fix is a little ugly—it manually plumbs the reusability information between the output of Validate and the input of Resolve—but it’s the only simple solution without a significant refactoring that restructures the relationship between Validate and Resolve. The ugliness should go away if we implement something like #2801.

### Steps to test and verify
This adds an automated test that disables cache striping in CI to ensure it will be deterministically triggered.

### Limitations, known bugs & workarounds
None.
