### PR TITLE
cli-migrations: enable metadata api while applying migrations

### DIFF
--- a/scripts/cli-migrations/docker-entrypoint.sh
+++ b/scripts/cli-migrations/docker-entrypoint.sh
@@ -11,7 +11,7 @@ log() {
 DEFAULT_MIGRATIONS_DIR="/hasura-migrations"
 TEMP_MIGRATIONS_DIR="/tmp/hasura-migrations"
 
-# check server port and ser default as 8080
+# check server port and set default as 8080
 if [ -z ${HASURA_GRAPHQL_SERVER_PORT+x} ]; then
     log "port env var is not set, defaulting to 8080"
     HASURA_GRAPHQL_SERVER_PORT=8080
@@ -35,8 +35,8 @@ wait_for_port() {
 
 log "starting graphql engine temporarily on port $HASURA_GRAPHQL_SERVER_PORT"
 
-# start graphql engine
-graphql-engine serve &
+# start graphql engine with metadata api enabled
+graphql-engine serve --enabled-apis="metadata" &
 # store the pid to kill it later
 PID=$!
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
If metadata APIs are disabled (as per our production checklist), the `cli-migrations` image will fail to apply migrations.

This change will over-ride the `enabled-apis` setting to force metadata api to be enabled in the intermediate server for applying migrations