### PR TITLE
[RFC] Build server in CI with optimizations, even in pull requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,8 +174,8 @@ jobs:
             echo "Branch starts with dev or release, or tagged commit starts with v. Optimized build"
             make ci-binary
           else
-            echo "Non-release branch, non-optimized build with coverage"
-            BUILD_FLAGS="--fast --coverage" make ci-binary
+            echo "Non-release branch, build with coverage"
+            BUILD_FLAGS="--coverage" make ci-binary
           fi
     - run:
         name: Build the docker image


### PR DESCRIPTION
This PR modifies the CI configuration to always build `graphql-engine` with optimizations enabled, even in pull requests. I think we should do this for the following reasons:

  1. Haskell performance without optimizations can be very poor. Doing any performance-related testing against a non-optimized build is not very meaningful, and enabling optimizations could theoretically even make certain tests run faster (even if the compile times are slower).

  2. We push a Docker image with the built server that we encourage users to try, and it’s not good to encourage anyone to ever use non-optimized builds, even if they’re development versions.

  3. If we start doing automated benchmarking in CI, which we plan to, we’ll have to build an optimized version at some point anyway.