### PR TITLE
change pg_dump version to 12 in server makefile

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -7,7 +7,7 @@ nproc    := $(shell nproc)
 # TODO: needs to be replaced with something like yq
 stack_resolver := $(shell awk '/^resolver:/ {print $$2;}' stack.yaml)
 packager_ver := 20190923
-pg_dump_ver := 11
+pg_dump_ver := 12
 project_dir := $(shell pwd)
 build_dir := $(project_dir)/$(shell stack path --dist-dir)/build
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
I missed the pg_dump version in the server makefile in #3102. Tests did not capture this since they're not run the docker image.

Eventhough the run time image had postgres 12, the final docker image that was built had pg_dump 11 since that was the version mentioned in Makefile.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [x] Build System
- [ ] Tests
- [ ] Other (list it)


### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Download `image.tar` from `build_server` artifacts in circle ci. `docker load` it and then build the following dockerfile:
```dockerfile
FROM hasura/graphql-engine:v1.0.0-beta.8

COPY --from=hasura/graphql-engine:pg-12-tests-304abecc /bin/pg_dump /bin/pg_dump

RUN pg_dump --version
```

verify that the version is 12