### PR TITLE
fix: Broken links in README files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,8 +174,8 @@ jobs:
             echo "Branch starts with dev or release, or tagged commit starts with v. Optimized build"
             make ci-binary
           else
-            echo "Non-release branch, non-optimized build with coverage"
-            BUILD_FLAGS="--fast --coverage" make ci-binary
+            echo "Non-release branch, build with coverage"
+            BUILD_FLAGS="--coverage" make ci-binary
           fi
     - run:
         name: Build the docker image

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Transform data in Postgres or run business logic on it to derive another dataset
 ## Demos
 
 Check out all the example applications in the
-[community/examples](community/examples) directory.
+[community/sample-apps](community/sample-apps) directory.
 
 ### Realtime applications
 

--- a/cli/Gopkg.lock
+++ b/cli/Gopkg.lock
@@ -18,6 +18,14 @@
   version = "v0.4.7"
 
 [[projects]]
+  branch = "master"
+  digest = "1:67f5c19d64f788aa79a8e612eefa1cc68dca46c3436c93b84af9c95bd7e1a556"
+  name = "github.com/aryann/difflib"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e206f873d14a916d3d26c40ab667bca123f365a3"
+
+[[projects]]
   digest = "1:889290ee5c1f1888baa7caa2b4cdfa8a6abcfb86dd772fe6470ad7925cc44bff"
   name = "github.com/briandowns/spinner"
   packages = ["."]
@@ -299,6 +307,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:2b32af4d2a529083275afc192d1067d8126b578c7a9613b26600e4df9c735155"
+  name = "github.com/mgutz/ansi"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9520e82c474b0a04dd04f8a40959027271bab992"
+
+[[projects]]
+  branch = "master"
   digest = "1:8eb17c2ec4df79193ae65b621cd1c0c4697db3bc317fe6afdc76d7f2746abd05"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
@@ -535,6 +551,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/Masterminds/semver",
+    "github.com/aryann/difflib",
     "github.com/briandowns/spinner",
     "github.com/docker/docker/api/types",
     "github.com/docker/docker/api/types/container",
@@ -553,6 +570,7 @@
     "github.com/lib/pq",
     "github.com/manifoldco/promptui",
     "github.com/mattn/go-colorable",
+    "github.com/mgutz/ansi",
     "github.com/mitchellh/go-homedir",
     "github.com/oliveagle/jsonpath",
     "github.com/parnurzeal/gorequest",
@@ -562,6 +580,7 @@
     "github.com/skratchdot/open-golang/open",
     "github.com/spf13/cobra",
     "github.com/spf13/cobra/doc",
+    "github.com/spf13/pflag",
     "github.com/spf13/viper",
     "github.com/stretchr/testify/assert",
   ]

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -396,3 +396,23 @@ func (ec *ExecutionContext) GetMetadataFilePath(format string) (string, error) {
 	}
 	return "", errors.New("unsupported file type")
 }
+
+// GetExistingMetadataFile returns the path to the default metadata file that
+// also exists, json or yaml
+func (ec *ExecutionContext) GetExistingMetadataFile() (string, error) {
+	filename := ""
+	for _, format := range []string{"yaml", "json"} {
+		f, err := ec.GetMetadataFilePath(format)
+		if err != nil {
+			return "", errors.Wrap(err, "cannot get metadata file")
+		}
+
+		filename = f
+		if _, err := os.Stat(filename); os.IsNotExist(err) {
+			continue
+		}
+		break
+	}
+
+	return filename, nil
+}

--- a/cli/commands/metadata.go
+++ b/cli/commands/metadata.go
@@ -19,6 +19,7 @@ func NewMetadataCmd(ec *cli.ExecutionContext) *cobra.Command {
 		SilenceUsage: true,
 	}
 	metadataCmd.AddCommand(
+		newMetadataDiffCmd(ec),
 		newMetadataExportCmd(ec),
 		newMetadataClearCmd(ec),
 		newMetadataReloadCmd(ec),

--- a/cli/commands/metadata_diff.go
+++ b/cli/commands/metadata_diff.go
@@ -1,0 +1,151 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/aryann/difflib"
+	"github.com/ghodss/yaml"
+	"github.com/hasura/graphql-engine/cli"
+	"github.com/mgutz/ansi"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type metadataDiffOptions struct {
+	EC     *cli.ExecutionContext
+	output io.Writer
+
+	// two metadata to diff, 2nd is server if it's empty
+	metadata [2]string
+}
+
+func newMetadataDiffCmd(ec *cli.ExecutionContext) *cobra.Command {
+	v := viper.New()
+	opts := &metadataDiffOptions{
+		EC:     ec,
+		output: os.Stdout,
+	}
+
+	metadataDiffCmd := &cobra.Command{
+		Use:   "diff [file1] [file2]",
+		Short: "(PREVIEW) Show a highlighted diff of Hasura metadata",
+		Long: `(PREVIEW) Show changes between two different sets of Hasura metadata.
+By default, shows changes between exported metadata file and server metadata.`,
+		Example: `  # NOTE: This command is in preview, usage and diff format may change.
+
+  # Show changes between server metadata and the exported metadata file:
+  hasura metadata diff
+
+  # Show changes between server metadata and that in local_metadata.yaml:
+  hasura metadata diff local_metadata.yaml
+
+  # Show changes between metadata from metadata.yaml and metadata_old.yaml:
+  hasura metadata diff metadata.yaml metadata_old.yaml`,
+		Args: cobra.MaximumNArgs(2),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			ec.Viper = v
+			return ec.Validate()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			messageFormat := "Showing diff between %s and %s..."
+			message := ""
+
+			switch len(args) {
+			case 0:
+				// no args, diff exported metadata and metadata on server
+				filename, err := ec.GetExistingMetadataFile()
+				if err != nil {
+					return errors.Wrap(err, "failed getting metadata file")
+				}
+				opts.metadata[0] = filename
+				message = fmt.Sprintf(messageFormat, filename, "the server")
+			case 1:
+				// 1 arg, diff given filename and the metadata on server
+				opts.metadata[0] = args[0]
+				message = fmt.Sprintf(messageFormat, args[0], "the server")
+			case 2:
+				// 2 args, diff given filenames
+				opts.metadata[0] = args[0]
+				opts.metadata[1] = args[1]
+				message = fmt.Sprintf(messageFormat, args[0], args[1])
+			}
+
+			opts.EC.Logger.Info(message)
+			err := opts.run()
+			if err != nil {
+				return errors.Wrap(err, "failed to show metadata diff")
+			}
+			return nil
+		},
+	}
+
+	f := metadataDiffCmd.Flags()
+	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
+	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
+	f.String("access-key", "", "access key for Hasura GraphQL Engine")
+	f.MarkDeprecated("access-key", "use --admin-secret instead")
+
+	// need to create a new viper because https://github.com/spf13/viper/issues/233
+	v.BindPFlag("endpoint", f.Lookup("endpoint"))
+	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
+	v.BindPFlag("access_key", f.Lookup("access-key"))
+
+	return metadataDiffCmd
+}
+
+func (o *metadataDiffOptions) run() error {
+	var oldYaml, newYaml []byte
+	var err error
+	migrateDrv, err := newMigrate(o.EC.MigrationDir, o.EC.ServerConfig.ParsedEndpoint, o.EC.ServerConfig.AdminSecret, o.EC.Logger, o.EC.Version, true)
+	if err != nil {
+		return err
+	}
+
+	if o.metadata[1] == "" {
+		// get metadata from server
+		m, err := migrateDrv.ExportMetadata()
+		if err != nil {
+			return errors.Wrap(err, "cannot fetch metadata from server")
+		}
+
+		newYaml, err = yaml.Marshal(m)
+		if err != nil {
+			return errors.Wrap(err, "cannot convert metadata from server to yaml")
+		}
+	} else {
+		newYaml, err = ioutil.ReadFile(o.metadata[1])
+		if err != nil {
+			return errors.Wrap(err, "cannot read file")
+		}
+	}
+
+	oldYaml, err = ioutil.ReadFile(o.metadata[0])
+	if err != nil {
+		return errors.Wrap(err, "cannot read file")
+	}
+
+	printDiff(string(oldYaml), string(newYaml), o.output)
+	return nil
+}
+
+func printDiff(before, after string, to io.Writer) {
+	diffs := difflib.Diff(strings.Split(before, "\n"), strings.Split(after, "\n"))
+
+	for _, diff := range diffs {
+		text := diff.Payload
+
+		switch diff.Delta {
+		case difflib.RightOnly:
+			fmt.Fprintf(to, "%s\n", ansi.Color(text, "green"))
+		case difflib.LeftOnly:
+			fmt.Fprintf(to, "%s\n", ansi.Color(text, "red"))
+		case difflib.Common:
+			fmt.Fprintf(to, "%s\n", text)
+		}
+	}
+}

--- a/cli/commands/metadata_diff_test.go
+++ b/cli/commands/metadata_diff_test.go
@@ -1,0 +1,125 @@
+package commands
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/hasura/graphql-engine/cli"
+	"github.com/hasura/graphql-engine/cli/version"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+var testMetadata1 = `allowlist: []
+functions: []
+query_collections: []
+remote_schemas: []
+tables:
+- array_relationships: []
+  delete_permissions: []
+  event_triggers: []
+  insert_permissions: []
+  is_enum: false
+  object_relationships: []
+  select_permissions: []
+  table: test
+  update_permissions: []
+`
+
+var testMetadata2 = `allowlist: []
+functions: []
+query_collections: []
+remote_schemas: []
+tables:
+- array_relationships: []
+  configuration:
+    custom_column_names: {}
+    custom_root_fields:
+      delete: null
+      insert: null
+      select: null
+      select_aggregate: null
+      select_by_pk: null
+      update: null
+  delete_permissions: []
+  event_triggers: []
+  insert_permissions: []
+  is_enum: false
+  object_relationships: []
+  select_permissions: []
+  table: test
+  update_permissions: []
+`
+
+func TestMetadataDiffCmd(t *testing.T) {
+	endpointURL, err := url.Parse(os.Getenv("HASURA_GRAPHQL_TEST_ENDPOINT"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create migration Dir
+	migrationsDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(migrationsDir)
+
+	metadataFile := filepath.Join(migrationsDir, "metadata.yaml")
+	testMetadataFile1 := filepath.Join(migrationsDir, "testmetadata1.yaml")
+	testMetadataFile2 := filepath.Join(migrationsDir, "testmetadata2.yaml")
+
+	mustWriteFile(t, "", metadataFile, testMetadata1)
+	mustWriteFile(t, "", testMetadataFile1, testMetadata1)
+	mustWriteFile(t, "", testMetadataFile2, testMetadata2)
+
+	logger, _ := test.NewNullLogger()
+	outputFile := new(bytes.Buffer)
+	opts := &metadataDiffOptions{
+		EC: &cli.ExecutionContext{
+			Logger:       logger,
+			Spinner:      spinner.New(spinner.CharSets[7], 100*time.Millisecond),
+			MetadataFile: []string{metadataFile},
+			ServerConfig: &cli.ServerConfig{
+				Endpoint:       endpointURL.String(),
+				AdminSecret:    os.Getenv("HASURA_GRAPHQL_TEST_ADMIN_SECRET"),
+				ParsedEndpoint: endpointURL,
+			},
+		},
+		output: outputFile,
+	}
+
+	opts.EC.Version = version.New()
+	v, err := version.FetchServerVersion(opts.EC.ServerConfig.Endpoint)
+	if err != nil {
+		t.Fatalf("getting server version failed: %v", err)
+	}
+	opts.EC.Version.SetServerVersion(v)
+
+	// Run without args
+	opts.metadata[0] = metadataFile
+	err = opts.run()
+	if err != nil {
+		t.Fatalf("failed diffing metadata: %v", err)
+	}
+
+	// Run with one arg
+	opts.metadata = [2]string{testMetadataFile1, ""}
+
+	err = opts.run()
+	if err != nil {
+		t.Fatalf("failed diffing metadata: %v", err)
+	}
+
+	// Run with two args
+	opts.metadata = [2]string{testMetadataFile1, testMetadataFile2}
+
+	err = opts.run()
+	if err != nil {
+		t.Fatalf("failed diffing metadata: %v", err)
+	}
+}

--- a/console/Makefile
+++ b/console/Makefile
@@ -1,6 +1,6 @@
 export PATH := node_modules/.bin:$(PATH)
 DIST_PATH ?= ./static/dist
-BUCKET_NAME ?= hasura-graphql-engine
+BUCKET_NAME ?= graphql-engine-cdn.hasura.io
 VERSION ?= $(shell ../scripts/get-version.sh)
 
 all: deps build gzip-assets gcloud-cp-stable gcloud-set-metadata

--- a/docs/graphql/manual/auth/authentication/index.rst
+++ b/docs/graphql/manual/auth/authentication/index.rst
@@ -16,27 +16,41 @@ Your authentication service is required to pass a user's **role** information in
 variables like ``X-Hasura-Role``, etc. More often than not, you'll also need to pass user information
 for your access control use cases, like ``X-Hasura-User-Id``, to build permission rules.
 
+You can also configure Hasura to allow access to unauthenticated users by configuring a specific role
+which will be set for all unauthenticated requests.
+
 Authentication options
 ----------------------
 
 Hasura supports two modes of authentication configuration:
 
-1) **Webhook**: Your auth server exposes a webhook that is used to authenticate all incoming requests
-   to the Hasura GraphQL engine server and to get metadata about the request, to evaluate access control
-   rules. Here's how a GraphQL request is processed in webhook mode:
+1. Webhook
+^^^^^^^^^^
 
-   .. thumbnail:: ../../../../img/graphql/manual/auth/auth-webhook-overview.png
+Your auth server exposes a webhook that is used to authenticate all incoming requests
+to the Hasura GraphQL engine server and to get metadata about the request to evaluate access control
+rules.
 
-2) **JWT** (JSON Web Token): Your auth server issues JWTs to your client app, which, when sent as part
-   of the request, are verified and decoded by the GraphQL engine to get metadata about the request to
-   evaluate access control rules. Here's how a GraphQL query is processed in JWT mode:
+Here's how a GraphQL request is processed in webhook mode:
 
-   .. thumbnail:: ../../../../img/graphql/manual/auth/auth-jwt-overview.png
+.. thumbnail:: ../../../../img/graphql/manual/auth/auth-webhook-overview.png
 
-**See more details about these at:**
+2. JWT (JSON Web Token)
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Your auth server issues JWTs to your client app, which, when sent as part
+of the request, are verified and decoded by the GraphQL engine to get metadata about the request to
+evaluate access control rules.
+
+Here's how a GraphQL query is processed in JWT mode:
+
+.. thumbnail:: ../../../../img/graphql/manual/auth/auth-jwt-overview.png
+
+**See more details at:**
 
 .. toctree::
   :maxdepth: 1
 
   Using webhooks <webhook>
   Using JWT <jwt>
+  Unauthenticated access <unauthenticated-access>

--- a/docs/graphql/manual/auth/authentication/unauthenticated-access.rst
+++ b/docs/graphql/manual/auth/authentication/unauthenticated-access.rst
@@ -1,0 +1,42 @@
+Unauthenticated access
+======================
+
+.. contents:: Table of contents
+  :backlinks: none
+  :depth: 1
+  :local:
+
+Use case
+--------
+
+It is a common requirement to have requests which are accessible to all users without the need for any authentication
+(logging in). For example, to display a public feed of events.
+
+You can configure Hasura GraphQL engine to allow access to unauthenticated users by defining a specific role
+which will be set for all unauthenticated requests.
+
+Configuring unauthenticated access
+----------------------------------
+
+You can use the env variable ``HASURA_GRAPHQL_UNAUTHORIZED_ROLE`` or ``--unauthorized-role`` flag to set a role
+for unauthenticated (non-logged in) users. See :doc:`../../deployment/graphql-engine-flags/reference` for more details
+on setting this flag/env var.
+
+This role can then be used to define the permissions for unauthenticated users as described in :doc:`../authorization/index`.
+A guide on setting up unauthenticated user permissions can be found :ref:`here <anonymous_users_example>`.
+
+How it works
+------------
+
+Once you have configured authentication, by default Hasura GraphQL engine will reject any unauthenticated request it
+receives.
+
+Based on your authentication setup, an unauthenticated request is any request:
+
+- for which the webhook returns a ``401 Unauthorized`` response in case of :doc:`webhook authentication <./webhook>`.
+- which does not contain a JWT token in case of :doc:`JWT authentication <./jwt>`.
+
+Once an unauthenticated role is configured, unaunthenticated requests will not be rejected and instead the request will
+be made with the configured role.
+
+

--- a/docs/graphql/manual/auth/authorization/common-roles-auth-examples.rst
+++ b/docs/graphql/manual/auth/authorization/common-roles-auth-examples.rst
@@ -12,6 +12,8 @@ that will be referred to throughout this guide.
 
 Here are some examples of common use cases.
 
+.. _anonymous_users_example:
+
 Anonymous (not logged in) users
 -------------------------------
 
@@ -26,9 +28,7 @@ Anonymous (not logged in) users
 .. thumbnail:: ../../../../img/graphql/manual/auth/anonymous-role-examples.png
    :class: no-shadow
 
-You can use the env variable ``HASURA_GRAPHQL_UNAUTHORIZED_ROLE`` or ``--unauthorized-role`` flag to set a role
-for non-logged in users. The configured unauthorized role will be used whenever an access token is not present
-in a request to the GraphQL API.
+See :doc:`../authentication/unauthenticated-access` for steps to configure the anonymous user role in Hasura.
 
 Logged-in users
 ---------------

--- a/event-triggers.md
+++ b/event-triggers.md
@@ -69,7 +69,7 @@ Trigger push notifications and emails based on database events. Try the demo and
 
 * [Watch demo](https://www.youtube.com/watch?v=nuSHkzE2-zo)
 * [Try it out](https://serverless-push.demo.hasura.app/)
-* [Tutorial](community/examples/serverless-push)
+* [Tutorial](community/sample-apps/serverless-push)
 
 
 <!--
@@ -89,7 +89,7 @@ Transform and load data into external data-stores. Check out this demo and tutor
 
 * [Watch demo](https://youtu.be/kWVEBWdEVAA)
 * [Try it out](https://serverless-etl.demo.hasura.app/)
-* [Tutorial](community/examples/serverless-etl)
+* [Tutorial](community/sample-apps/serverless-etl)
 
 ### Building reactive UX for your async backend with realtime GraphQL
 

--- a/translations/README.french.md
+++ b/translations/README.french.md
@@ -123,18 +123,18 @@ Consultez toutes les applications d'example dans le répertoire
 - Application de messagerie de groupe développée avec React, incluant un indicateur de frappe, les utilisateurs connectés & les
   notifications de nouveaux messages.
   - [Essayez la](https://realtime-chat.demo.hasura.app/)
-  - [Tutoriel](../community/examples/realtime-chat)
+  - [Tutoriel](../community/sample-apps/realtime-chat)
   - [Explorez les APIs](https://realtime-chat.demo.hasura.app/console)
 
 - Application de localisation en temps-réel montrant un véhicule dont les coordonnées GPS évoluent
   se déplacer sur une carte.
   - [Essayez la](https://realtime-location-tracking.demo.hasura.app/)
-  - [Tutoriel](../community/examples/realtime-location-tracking)
+  - [Tutoriel](../community/sample-apps/realtime-location-tracking)
   - [Explorez les APIs](https://realtime-location-tracking.demo.hasura.app/console)
 
 - Un tableau de bord temps-réel pour l'aggrégation de données en constante évolution.
   - [Essayez la](https://realtime-poll.demo.hasura.app/)
-  - [Tutoriel](../community/examples/realtime-poll)
+  - [Tutoriel](../community/sample-apps/realtime-poll)
   - [Explorez les APIs](https://realtime-poll.demo.hasura.app/console)
 
 ### Vidéos

--- a/translations/event-triggers.french.md
+++ b/translations/event-triggers.french.md
@@ -68,7 +68,7 @@ Déclenchez des notifications push et des emails à partir d'évènements de la 
 
 * [Regardez la démo](https://www.youtube.com/watch?v=nuSHkzE2-zo)
 * [Essayez la](https://serverless-push.demo.hasura.app/)
-* [Tutoriel](../community/examples/serverless-push)
+* [Tutoriel](../community/sample-apps/serverless-push)
 
 
 <!--
@@ -88,7 +88,7 @@ Transformez et chargez de la donnée dans des data-stores externes. Allez voir c
 
 * [Regardez la démo](https://youtu.be/kWVEBWdEVAA)
 * [Essayez la](https://serverless-etl.demo.hasura.app/)
-* [Tutoriel](../community/examples/serverless-etl)
+* [Tutoriel](../community/sample-apps/serverless-etl)
 
 ### Construction d'UX réactive pour votre backend asynchrone avec une API GraphQL temps-réel
 


### PR DESCRIPTION
Some links in the readme files are referring to `community/examples` folder. Since this folder does not exist anymore, I correct it with the updated one: `community/sample-apps`.