### PR TITLE
console(make): fix the gcs bucket name (close #3026)

### DIFF
--- a/console/Makefile
+++ b/console/Makefile
@@ -1,6 +1,6 @@
 export PATH := node_modules/.bin:$(PATH)
 DIST_PATH ?= ./static/dist
-BUCKET_NAME ?= hasura-graphql-engine
+BUCKET_NAME ?= graphql-engine-cdn.hasura.io
 VERSION ?= $(shell ../scripts/get-version.sh)
 
 all: deps build gzip-assets gcloud-cp-stable gcloud-set-metadata


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
This PR fixes `make server-build` command for console.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [x] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#3026 
### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
While releasing the first beta version, the GCS bucket was changed from `hasura-graphql-engine` to `graphql-engine-cdn.hasura.io`. I am not sure why none of those PRs changed https://github.com/hasura/graphql-engine/blame/master/console/Makefile#L3

This PR adds the correct bucket name and thus server-build does not throw the bucket not found error anymore.
### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Checkout to this branch, go to `console` dir and execute `make server-build`. This should happen:
```bash
$ make server-build
if [ ! -d "./static/dist/common" ]; then \
	mkdir -p ./static/dist; \
	gsutil -m cp -r gs://graphql-engine-cdn.hasura.io/console/assets/common "./static/dist"; \
	mv "./static/dist/common/css/font-awesome.min.css.gz" "./static/dist/common/css/font-awesome.min.css"; \
	gzip "./static/dist/common/css/font-awesome.min.css"; \
fi
Copying gs://graphql-engine-cdn.hasura.io/console/assets/common/css/font-awesome.min.css.gz...
Downloading to temp gzip filename ./static/dist/common/css/font-awesome.min.css.gz_.gztmp
Copying gs://graphql-engine-cdn.hasura.io/console/assets/common/fonts/fontawesome-webfont.eot...
Copying gs://graphql-engine-cdn.hasura.io/console/assets/common/fonts/ARCADECLASSIC.ttf...
Copying gs://graphql-engine-cdn.hasura.io/console/assets/common/fonts/fontawesome-webfont.svg...
Copying gs://graphql-engine-cdn.hasura.io/console/assets/common/fonts/fontawesome-webfont.ttf...
Copying gs://graphql-engine-cdn.hasura.io/console/assets/common/fonts/fontawesome-webfont.woff...
Copying gs://graphql-engine-cdn.hasura.io/console/assets/common/img/favicon_green.png...
Copying gs://graphql-engine-cdn.hasura.io/console/assets/common/fonts/fontawesome-webfont.woff2...
Copying gs://graphql-engine-cdn.hasura.io/console/assets/common/img/event-trigger.png...
Copying gs://graphql-engine-cdn.hasura.io/console/assets/common/img/githubicon.png...
Copying gs://graphql-engine-cdn.hasura.io/console/assets/common/img/hasura_icon_green.svg...
Copying gs://graphql-engine-cdn.hasura.io/console/assets/common/img/remote_schema.png...
Copying gs://graphql-engine-cdn.hasura.io/console/assets/common/img/twittericon.png...
rm -rf "./static/dist/versioned"KiB]  99% Done   1.9 MiB/s ETA 00:00:00         
npm run build

> graphql-engine-console@0.1.0 build /home/shahidh/go/src/github.com/hasura/graphql-engine/console
> webpack --progress -p --colors --display-error-details --config webpack/prod.config.js...
```
