### PR TITLE
Fix mishandling of GeoJSON inputs in subscriptions (fix #3239)

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Plan.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Plan.hs
@@ -43,12 +43,16 @@ import           Data.Has
 import           Data.UUID                              (UUID)
 
 import qualified Hasura.GraphQL.Resolve                 as GR
+import qualified Hasura.GraphQL.Resolve.Select          as GR
+import qualified Hasura.GraphQL.Resolve.Types           as GR
 import qualified Hasura.GraphQL.Transport.HTTP.Protocol as GH
 import qualified Hasura.GraphQL.Validate                as GV
+import qualified Hasura.GraphQL.Validate.Types          as GV
 import qualified Hasura.SQL.DML                         as S
 
 import           Hasura.Db
 import           Hasura.EncJSON
+import           Hasura.GraphQL.Utils
 import           Hasura.RQL.Types
 import           Hasura.SQL.Error
 import           Hasura.SQL.Types
@@ -60,26 +64,39 @@ import           Hasura.SQL.Value
 newtype MultiplexedQuery = MultiplexedQuery { unMultiplexedQuery :: Q.Query }
   deriving (Show, Eq, Hashable, J.ToJSON)
 
-mkMultiplexedQuery :: Q.Query -> MultiplexedQuery
-mkMultiplexedQuery baseQuery =
-  MultiplexedQuery . Q.fromText $ foldMap Q.getQueryText [queryPrefix, baseQuery, querySuffix]
+mkMultiplexedQuery :: Map.HashMap G.Alias GR.QueryRootFldResolved -> MultiplexedQuery
+mkMultiplexedQuery rootFields = MultiplexedQuery . Q.fromBuilder . toSQL $ S.mkSelect
+  { S.selExtr =
+    -- SELECT _subs.result_id, _fld_resp.root AS result
+    [ S.Extractor (mkQualIden (Iden "_subs") (Iden "result_id")) Nothing
+    , S.Extractor (mkQualIden (Iden "_fld_resp") (Iden "root")) (Just . S.Alias $ Iden "result") ]
+  , S.selFrom = Just $ S.FromExp [S.FIJoin $
+      S.JoinExpr subsInputFromItem S.LeftOuter responseLateralFromItem (S.JoinOn $ S.BELit True)]
+  }
   where
-    queryPrefix =
-      [Q.sql|
-        select
-          _subs.result_id, _fld_resp.root as result
-          from
-            unnest(
-              $1::uuid[], $2::json[]
-            ) _subs (result_id, result_vars)
-          left outer join lateral
-            (
-        |]
+    -- FROM unnest($1::uuid[], $2::json[]) _subs (result_id, result_vars)
+    subsInputFromItem = S.FIUnnest
+      [S.SEPrep 1 `S.SETyAnn` S.TypeAnn "uuid[]", S.SEPrep 2 `S.SETyAnn` S.TypeAnn "json[]"]
+      (S.Alias $ Iden "_subs")
+      [S.SEIden $ Iden "result_id", S.SEIden $ Iden "result_vars"]
 
-    querySuffix =
-      [Q.sql|
-            ) _fld_resp ON ('true')
-        |]
+    -- LEFT OUTER JOIN LATERAL ( ... ) _fld_resp
+    responseLateralFromItem = S.mkLateralFromItem selectRootFields (S.Alias $ Iden "_fld_resp")
+    selectRootFields = S.mkSelect
+      { S.selExtr = [S.Extractor rootFieldsJsonAggregate (Just . S.Alias $ Iden "root")]
+      , S.selFrom = Just . S.FromExp $
+          flip map (Map.toList rootFields) $ \(fieldAlias, resolvedAST) ->
+            S.mkSelFromItem (GR.toSQLSelect resolvedAST) (S.Alias $ aliasToIden fieldAlias)
+      }
+
+    -- json_build_object('field1', field1.root, 'field2', field2.root, ...)
+    rootFieldsJsonAggregate = S.SEFnApp "json_build_object" rootFieldsJsonPairs Nothing
+    rootFieldsJsonPairs = flip concatMap (Map.keys rootFields) $ \fieldAlias ->
+      [ S.SELit (G.unName $ G.unAlias fieldAlias)
+      , mkQualIden (aliasToIden fieldAlias) (Iden "root") ]
+
+    mkQualIden prefix = S.SEQIden . S.QIden (S.QualIden prefix)
+    aliasToIden = Iden . G.unName . G.unAlias
 
 -- | Resolves an 'GR.UnresolvedVal' by converting 'GR.UVPG' values to SQL expressions that refer to
 -- the @result_vars@ input object, collecting variable values along the way.
@@ -229,7 +246,6 @@ data LiveQueryPlan
 data ParameterizedLiveQueryPlan
   = ParameterizedLiveQueryPlan
   { _plqpRole  :: !RoleName
-  , _plqpAlias :: !G.Alias
   , _plqpQuery :: !MultiplexedQuery
   } deriving (Show)
 $(J.deriveToJSON (J.aesonDrop 4 J.snakeCase) ''ParameterizedLiveQueryPlan)
@@ -248,29 +264,38 @@ buildLiveQueryPlan
   :: ( MonadError QErr m
      , MonadReader r m
      , Has UserInfo r
+     , Has GR.FieldMap r
+     , Has GR.OrdByCtx r
+     , Has GR.QueryCtxMap r
+     , Has SQLGenCtx r
      , MonadIO m
      )
   => PGExecCtx
-  -> G.Alias
-  -> GR.QueryRootFldUnresolved
-  -> Maybe GV.ReusableVariableTypes
+  -> GV.QueryReusability
+  -> GV.SelSet
   -> m (LiveQueryPlan, Maybe ReusableLiveQueryPlan)
-buildLiveQueryPlan pgExecCtx fieldAlias astUnresolved varTypes = do
+buildLiveQueryPlan pgExecCtx initialReusability fields = do
+  ((resolvedASTs, (queryVariableValues, syntheticVariableValues)), finalReusability) <-
+    GV.runReusabilityTWith initialReusability . flip runStateT mempty $
+      fmap Map.fromList . for (toList fields) $ \field -> case GV._fName field of
+        "__typename" -> throwVE "you cannot create a subscription on '__typename' field"
+        _ -> do
+          unresolvedAST <- GR.queryFldToPGAST field
+          resolvedAST <- GR.traverseQueryRootFldAST resolveMultiplexedValue unresolvedAST
+          pure (GV._fAlias field, resolvedAST)
+
   userInfo <- asks getter
+  let multiplexedQuery = mkMultiplexedQuery resolvedASTs
+      parameterizedPlan = ParameterizedLiveQueryPlan (userRole userInfo) multiplexedQuery
 
-  (astResolved, (queryVariableValues, syntheticVariableValues)) <- flip runStateT mempty $
-    GR.traverseQueryRootFldAST resolveMultiplexedValue astUnresolved
-  let pgQuery = mkMultiplexedQuery $ GR.toPGQuery astResolved
-      parameterizedPlan = ParameterizedLiveQueryPlan (userRole userInfo) fieldAlias pgQuery
-
-  -- We need to ensure that the values provided for variables
-  -- are correct according to Postgres. Without this check
-  -- an invalid value for a variable for one instance of the
-  -- subscription will take down the entire multiplexed query
+  -- We need to ensure that the values provided for variables are correct according to Postgres.
+  -- Without this check an invalid value for a variable for one instance of the subscription will
+  -- take down the entire multiplexed query.
   validatedQueryVars <- validateVariables pgExecCtx queryVariableValues
   validatedSyntheticVars <- validateVariables pgExecCtx (toList syntheticVariableValues)
   let cohortVariables = CohortVariables (userVars userInfo) validatedQueryVars validatedSyntheticVars
       plan = LiveQueryPlan parameterizedPlan cohortVariables
+      varTypes = finalReusability ^? GV._Reusable
       reusablePlan = ReusableLiveQueryPlan parameterizedPlan validatedSyntheticVars <$> varTypes
   pure (plan, reusablePlan)
 

--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Plan.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Plan.hs
@@ -119,11 +119,13 @@ resolveMultiplexedValue = \case
   GR.UVSQL sqlExp -> pure sqlExp
   GR.UVSession -> pure $ fromResVars (PGTypeScalar PGJSON) ["session"]
   where
-    fromResVars ty jPath =
-      flip S.SETyAnn (S.mkTypeAnn ty) $ S.SEOpApp (S.SQLOp "#>>")
+    fromResVars pgType jPath = addTypeAnnotation pgType $ S.SEOpApp (S.SQLOp "#>>")
       [ S.SEQIden $ S.QIden (S.QualIden $ Iden "_subs") (Iden "result_vars")
       , S.SEArray $ map S.SELit jPath
       ]
+    addTypeAnnotation pgType = flip S.SETyAnn (S.mkTypeAnn pgType) . case pgType of
+      PGTypeScalar scalarType -> withConstructorFn scalarType
+      PGTypeArray _           -> id
 
 newtype CohortId = CohortId { unCohortId :: UUID }
   deriving (Show, Eq, Hashable, J.ToJSON, Q.FromCol)

--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Poll.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Poll.hs
@@ -43,7 +43,6 @@ import qualified Data.HashMap.Strict                      as Map
 import qualified Data.Time.Clock                          as Clock
 import qualified Data.UUID                                as UUID
 import qualified Data.UUID.V4                             as UUID
-import qualified Language.GraphQL.Draft.Syntax            as G
 import qualified ListT
 import qualified StmContainers.Map                        as STMMap
 import qualified System.Metrics.Distribution              as Metrics
@@ -62,11 +61,7 @@ import           Hasura.RQL.Types
 -- -------------------------------------------------------------------------------------------------
 -- Subscribers
 
-data Subscriber
-  = Subscriber
-  { _sRootAlias        :: !G.Alias
-  , _sOnChangeCallback :: !OnChange
-  }
+newtype Subscriber = Subscriber { _sOnChangeCallback :: OnChange }
 
 -- | live query onChange metadata, used for adding more extra analytics data
 data LiveQueryMetadata
@@ -81,7 +76,6 @@ data LiveQueryResponse
   }
 
 type LGQResponse = GQResult LiveQueryResponse
-
 type OnChange = LGQResponse -> IO ()
 
 newtype SubscriberId = SubscriberId { _unSinkId :: UUID.UUID }
@@ -175,7 +169,6 @@ data CohortSnapshot
 
 pushResultToCohort
   :: GQResult EncJSON
-  -- ^ a response that still needs to be wrapped with each 'Subscriber'’s root 'G.Alias'
   -> Maybe ResponseHash
   -> LiveQueryMetadata
   -> CohortSnapshot
@@ -193,13 +186,8 @@ pushResultToCohort result respHashM (LiveQueryMetadata dTime) cohortSnapshot = d
   pushResultToSubscribers sinks
   where
     CohortSnapshot _ respRef curSinks newSinks = cohortSnapshot
-    pushResultToSubscribers = A.mapConcurrently_ $ \(Subscriber alias action) ->
-      let aliasText = G.unName $ G.unAlias alias
-          wrapWithAlias response = LiveQueryResponse
-            { _lqrPayload = encJToLBS $ encJFromAssocList [(aliasText, response)]
-            , _lqrExecutionTime = dTime
-            }
-      in action (wrapWithAlias <$> result)
+    response = result <&> \payload -> LiveQueryResponse (encJToLBS payload) dTime
+    pushResultToSubscribers = A.mapConcurrently_ $ \(Subscriber action) -> action response
 
 -- -------------------------------------------------------------------------------------------------
 -- Pollers

--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/State.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/State.hs
@@ -92,12 +92,12 @@ addLiveQuery lqState plan onResultAction = do
   where
     LiveQueriesState lqOpts pgExecCtx lqMap = lqState
     LiveQueriesOptions batchSize refetchInterval = lqOpts
-    LiveQueryPlan (ParameterizedLiveQueryPlan role alias query) cohortKey = plan
+    LiveQueryPlan (ParameterizedLiveQueryPlan role query) cohortKey = plan
 
     handlerId = PollerKey role query
 
     addToCohort sinkId handlerC =
-      TMap.insert (Subscriber alias onResultAction) sinkId $ _cNewSubscribers handlerC
+      TMap.insert (Subscriber onResultAction) sinkId $ _cNewSubscribers handlerC
 
     addToPoller sinkId responseId handler = do
       newCohort <- Cohort responseId <$> STM.newTVar Nothing <*> TMap.new <*> TMap.new

--- a/server/src-lib/Hasura/GraphQL/Resolve/Select.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/Select.hs
@@ -10,6 +10,7 @@ module Hasura.GraphQL.Resolve.Select
   , traverseQueryRootFldAST
   , QueryRootFldUnresolved
   , QueryRootFldResolved
+  , toSQLSelect
   , toPGQuery
   ) where
 
@@ -553,8 +554,11 @@ traverseQueryRootFldAST f = \case
   QRFSimple s   -> QRFSimple <$> RS.traverseAnnSimpleSel f s
   QRFAgg s      -> QRFAgg <$> RS.traverseAnnAggSel f s
 
+toSQLSelect :: QueryRootFldResolved -> S.Select
+toSQLSelect = \case
+  QRFPk s       -> RS.mkSQLSelect True s
+  QRFSimple s   -> RS.mkSQLSelect False s
+  QRFAgg s      -> RS.mkAggSelect s
+
 toPGQuery :: QueryRootFldResolved -> Q.Query
-toPGQuery = \case
-  QRFPk s       -> RS.selectQuerySQL True s
-  QRFSimple s   -> RS.selectQuerySQL False s
-  QRFAgg s      -> RS.selectAggQuerySQL s
+toPGQuery = Q.fromBuilder . toSQL . toSQLSelect

--- a/server/src-lib/Hasura/GraphQL/Validate/Types.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate/Types.hs
@@ -805,6 +805,9 @@ class (Monad m) => MonadReusability m where
 instance (MonadReusability m) => MonadReusability (ReaderT r m) where
   recordVariableUse a b = lift $ recordVariableUse a b
   markNotReusable = lift markNotReusable
+instance (MonadReusability m) => MonadReusability (StateT s m) where
+  recordVariableUse a b = lift $ recordVariableUse a b
+  markNotReusable = lift markNotReusable
 
 newtype ReusabilityT m a = ReusabilityT { unReusabilityT :: StateT QueryReusability m a }
   deriving (Functor, Applicative, Monad, MonadError e, MonadReader r)

--- a/server/src-lib/Hasura/RQL/DML/Select.hs
+++ b/server/src-lib/Hasura/RQL/DML/Select.hs
@@ -1,7 +1,5 @@
 module Hasura.RQL.DML.Select
   ( selectP2
-  , selectQuerySQL
-  , selectAggQuerySQL
   , convSelectQuery
   , asSingleRowJsonResp
   , module Hasura.RQL.DML.Select.Internal
@@ -274,14 +272,6 @@ selectP2 asSingleObject (sel, p) =
   <$> Q.rawQE dmlTxErrorHandler (Q.fromBuilder selectSQL) (toList p) True
   where
     selectSQL = toSQL $ mkSQLSelect asSingleObject sel
-
-selectQuerySQL :: Bool -> AnnSimpleSel -> Q.Query
-selectQuerySQL asSingleObject sel =
-  Q.fromBuilder $ toSQL $ mkSQLSelect asSingleObject sel
-
-selectAggQuerySQL :: AnnAggSel -> Q.Query
-selectAggQuerySQL =
-  Q.fromBuilder . toSQL . mkAggSelect
 
 asSingleRowJsonResp :: Q.Query -> [Q.PrepArg] -> Q.TxE QErr EncJSON
 asSingleRowJsonResp query args =

--- a/server/src-lib/Hasura/RQL/DML/Select/Internal.hs
+++ b/server/src-lib/Hasura/RQL/DML/Select/Internal.hs
@@ -710,7 +710,7 @@ baseNodeToSel joinCond baseNode =
       , S.selWhere = Just $ injectJoinCond joinCond whr
       }
     baseSelAls = S.Alias $ mkBaseTableAls pfx
-    baseFromItem = S.FISelect (S.Lateral False) baseSel baseSelAls
+    baseFromItem = S.mkSelFromItem baseSel baseSelAls
 
     -- function to create a joined from item from two from items
     leftOuterJoin current new =

--- a/server/src-lib/Hasura/SQL/DML.hs
+++ b/server/src-lib/Hasura/SQL/DML.hs
@@ -23,7 +23,10 @@ paren t = TB.char '(' <> t <> TB.char ')'
 
 data Select
   = Select
-    { selDistinct :: !(Maybe DistinctExpr)
+    { selCTEs     :: ![(Alias, Select)]
+    -- ^ Unlike 'SelectWith', does not allow data-modifying statements (as those are only allowed at
+    -- the top level of a query).
+    , selDistinct :: !(Maybe DistinctExpr)
     , selExtr     :: ![Extractor]
     , selFrom     :: !(Maybe FromExp)
     , selWhere    :: !(Maybe WhereFrag)
@@ -37,7 +40,7 @@ instance NFData Select
 instance Cacheable Select
 
 mkSelect :: Select
-mkSelect = Select Nothing [] Nothing
+mkSelect = Select [] Nothing [] Nothing
            Nothing Nothing Nothing
            Nothing Nothing Nothing
 
@@ -163,17 +166,20 @@ instance ToSQL WhereFrag where
     "WHERE" <-> paren (toSQL be)
 
 instance ToSQL Select where
-  toSQL sel =
-    "SELECT"
-    <-> toSQL (selDistinct sel)
-    <-> (", " <+> selExtr sel)
-    <-> toSQL (selFrom sel)
-    <-> toSQL (selWhere sel)
-    <-> toSQL (selGroupBy sel)
-    <-> toSQL (selHaving sel)
-    <-> toSQL (selOrderBy sel)
-    <-> toSQL (selLimit sel)
-    <-> toSQL (selOffset sel)
+  toSQL sel = case selCTEs sel of
+    [] -> "SELECT"
+      <-> toSQL (selDistinct sel)
+      <-> (", " <+> selExtr sel)
+      <-> toSQL (selFrom sel)
+      <-> toSQL (selWhere sel)
+      <-> toSQL (selGroupBy sel)
+      <-> toSQL (selHaving sel)
+      <-> toSQL (selOrderBy sel)
+      <-> toSQL (selLimit sel)
+      <-> toSQL (selOffset sel)
+    -- reuse SelectWith if there are any CTEs, since the generated SQL is the same
+    ctes -> toSQL $ SelectWith (map (CTESelect <$>) ctes) sel { selCTEs = [] }
+
 
 mkSIdenExp :: (IsIden a) => a -> SQLExp
 mkSIdenExp = SEIden . toIden

--- a/server/tests-py/queries/graphql_query/boolexp/postgis/query_cast_geography_to_geometry.yaml
+++ b/server/tests-py/queries/graphql_query/boolexp/postgis/query_cast_geography_to_geometry.yaml
@@ -7,7 +7,7 @@ response:
     - name: New York
 query:
   query: |
-    {
+    query {
       geog_table(where: {
         geog_col: {
           _cast: {

--- a/server/tests-py/queries/graphql_query/boolexp/postgis/query_cast_geometry_to_geography.yaml
+++ b/server/tests-py/queries/graphql_query/boolexp/postgis/query_cast_geometry_to_geography.yaml
@@ -8,7 +8,7 @@ response:
     - name: Paris
 query:
   query: |
-    {
+    query {
       geog_as_geom_table(where: {
         geom_col: {
           _cast: {

--- a/server/tests-py/queries/graphql_query/boolexp/postgis/query_illegal_cast_is_not_allowed.yaml
+++ b/server/tests-py/queries/graphql_query/boolexp/postgis/query_illegal_cast_is_not_allowed.yaml
@@ -9,7 +9,7 @@ response:
     message: 'field "integer" not found in type: ''geography_cast_exp'''
 query:
   query: |
-    {
+    query {
       geog_table(where: {geog_col: {_cast: {integer: {_eq: 0}}}}) {
         name
       }

--- a/server/tests-py/test_graphql_queries.py
+++ b/server/tests-py/test_graphql_queries.py
@@ -371,7 +371,7 @@ class TestGraphQLQueryBoolExpJsonB(DefaultTestSelectQueries):
     def dir(cls):
         return 'queries/graphql_query/boolexp/jsonb'
 
-@pytest.mark.parametrize("transport", ['http', 'websocket'])
+@pytest.mark.parametrize("transport", ['http', 'websocket', 'subscription'])
 class TestGraphQLQueryBoolExpPostGIS(DefaultTestSelectQueries):
 
     def test_query_using_point(self, hge_ctx, transport):

--- a/server/tests-py/validate.py
+++ b/server/tests-py/validate.py
@@ -12,6 +12,7 @@ import base64
 import json
 import jsondiff
 import jwt
+import queue
 import random
 import time
 import warnings
@@ -180,27 +181,31 @@ def check_query(hge_ctx, conf, transport='http', add_auth=True):
             test_forbidden_when_admin_secret_reqd(hge_ctx, conf)
             headers['X-Hasura-Admin-Secret'] = hge_ctx.hge_key
 
-    assert transport in ['websocket', 'http'], "Unknown transport type " + transport
-    if transport == 'websocket':
-        assert 'response' in conf
-        assert conf['url'].endswith('/graphql')
-        print('running on websocket')
-        return validate_gql_ws_q(
-            hge_ctx,
-            conf['url'],
-            conf['query'],
-            headers,
-            conf['response'],
-            True
-        )
-    elif transport == 'http':
+    assert transport in ['http', 'websocket', 'subscription'], "Unknown transport type " + transport
+    if transport == 'http':
         print('running on http')
         return validate_http_anyq(hge_ctx, conf['url'], conf['query'], headers,
                                   conf['status'], conf.get('response'))
+    elif transport == 'websocket':
+        print('running on websocket')
+        return validate_gql_ws_q(hge_ctx, conf, headers, retry=True)
+    elif transport == 'subscription':
+        print('running via subscription')
+        return validate_gql_ws_q(hge_ctx, conf, headers, retry=True, via_subscription=True)
 
 
+def validate_gql_ws_q(hge_ctx, conf, headers, retry=False, via_subscription=False):
+    assert 'response' in conf
+    assert conf['url'].endswith('/graphql')
+    endpoint = conf['url']
+    query = conf['query']
+    exp_http_response = conf['response']
 
-def validate_gql_ws_q(hge_ctx, endpoint, query, headers, exp_http_response, retry=False):
+    if via_subscription:
+        query_text = query['query']
+        assert query_text.startswith('query '), query_text
+        query['query'] = 'subscription' + query_text[len('query'):]
+
     if endpoint == '/v1alpha1/graphql':
         ws_client = GQLWsClient(hge_ctx, '/v1alpha1/graphql')
     else:
@@ -209,7 +214,7 @@ def validate_gql_ws_q(hge_ctx, endpoint, query, headers, exp_http_response, retr
     if not headers or len(headers) == 0:
         ws_client.init({})
 
-    query_resp = ws_client.send_query(query, headers=headers, timeout=15)
+    query_resp = ws_client.send_query(query, query_id='hge_test', headers=headers, timeout=15)
     resp = next(query_resp)
     print('websocket resp: ', resp)
 
@@ -226,10 +231,15 @@ def validate_gql_ws_q(hge_ctx, endpoint, query, headers, exp_http_response, retr
         assert resp['type'] in ['data', 'error'], resp
     else:
         assert resp['type'] == 'data', resp
-
     assert 'payload' in resp, resp
-    resp_done = next(query_resp)
-    assert resp_done['type'] == 'complete'
+
+    if via_subscription:
+        ws_client.send({ 'id': 'hge_test', 'type': 'stop' })
+        with pytest.raises(queue.Empty):
+            ws_client.get_ws_event(0)
+    else:
+        resp_done = next(query_resp)
+        assert resp_done['type'] == 'complete'
 
     return assert_graphql_resp_expected(resp['payload'], exp_http_response, query)
 


### PR DESCRIPTION
### Description

This PR fixes #3239, which was caused by an oversight in the way we generate multiplexed queries. The actual fix is minuscule, so most of the change set is to support the tests. More details below.

### Affected components

- Server
- Tests

### Related Issues

#3239

### Solution and Design

One of the reasons it’s easy for these bugs to happen is that our test coverage of subscriptions is fairly poor. It would be silly to duplicate all of our existing query tests just to test subscriptions (and because it’s an unreasonable amount of effort, those tests never get written). Therefore, this PR adds a new transport option to the pytest test suite that allows query tests to be executed as if they were subscriptions.

The only problem with this is that the GraphQL spec disallows multiple root fields in a single subscription, which means tons of queries are rejected just because of that artificial limitation. Therefore, this PR removes it, but that technically means we are not in full compliance with the GraphQL spec.

One solution to this dilemma would be to hide our noncompliant support for multiple root fields in subscriptions behind a command-line flag that we can enable during testing. I think that’s a good compromise, but I’ll let other people weigh in before I make that call.

### Server checklist

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No


#### GraphQL
- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No Breaking changes

### Steps to test and verify

This fix is exercised by the automated test suite.