### PR TITLE
make transactionality clearer in mutations docs

### DIFF
--- a/docs/graphql/manual/mutations/multiple-mutations.rst
+++ b/docs/graphql/manual/mutations/multiple-mutations.rst
@@ -6,8 +6,8 @@ Multiple mutations in a request
   :depth: 1
   :local:
 
-If multiple mutations are part of the same request, they are executed **sequentially**. If any of the mutations fail,
-all the executed mutations will be rolled back (i.e. all the mutations are run as a **transaction**).
+If multiple mutations are part of the same request, they are executed **sequentially** in a single **transaction**. If any of the mutations fail,
+all the executed mutations will be rolled back.
 
 Run multiple top level mutations transactionally
 ------------------------------------------------


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description

Reading the first line, it's not obvious that mutations are run in a transaction. Fixed this.

### Affected components
<!-- Remove non-affected components from the list -->


- [x] Docs

