### PR TITLE
add default browser option to cli (close #3333)

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -182,6 +182,9 @@ type ExecutionContext struct {
 
 	// SkipUpdateCheck will skip the auto update check if set to true
 	SkipUpdateCheck bool
+
+	// CliDefaultBrowser is the browser used by the cli to open the console
+	CliDefaultBrowser string
 }
 
 // NewExecutionContext returns a new instance of execution context
@@ -314,6 +317,7 @@ func (ec *ExecutionContext) readConfig() error {
 	if err != nil {
 		return errors.Wrap(err, "cannot read config from file/env")
 	}
+	ec.CliDefaultBrowser = v.GetString("cli_default_browser")
 	adminSecret := v.GetString("admin_secret")
 	if adminSecret == "" {
 		adminSecret = v.GetString("access_key")

--- a/cli/commands/console.go
+++ b/cli/commands/console.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/fatih/color"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-contrib/static"
 	"github.com/gin-gonic/gin"
@@ -157,16 +156,18 @@ func (o *consoleOptions) run() error {
 	consoleURL := fmt.Sprintf("http://%s:%s/", o.Address, o.ConsolePort)
 
 	if !o.DontOpenBrowser {
-		o.EC.Spin(color.CyanString("Opening console using default browser..."))
-		defer o.EC.Spinner.Stop()
-
-		err = open.Run(consoleURL)
+		if o.EC.CliDefaultBrowser != "" {
+			log.Infof("opening console using %s", o.EC.CliDefaultBrowser)
+			err = open.RunWith(consoleURL, o.EC.CliDefaultBrowser)
+		} else {
+			log.Info("opening console using default browser")
+			err = open.Run(consoleURL)
+		}
 		if err != nil {
 			o.EC.Logger.WithError(err).Warn("Error opening browser, try to open the url manually?")
 		}
 	}
 
-	o.EC.Spinner.Stop()
 	log.Infof("console running at: %s", consoleURL)
 
 	o.EC.Telemetry.Beam()


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Hi!

This is the PR discussed in #3333 with @shahidhk. It adds the possibility to add `HASURA_GRAPHQL_CLI_DEFAULT_BROWSER` in your environment variables, which is picked up and used when running `hasura console`. If no value is provided, the default browser is used (doesn't change behaviour).

I have replaced `Spin` by normal logs as we may prefer to **always** see the browser being used.

Also I would have liked to add a note to the docs but it seems the CLI docs are auto generated by cobra so I'm not sure if I should touch these files.

Note that I am new to go so you might need to guide me a bit. 


### Affected components
<!-- Remove non-affected components from the list -->

- [x] CLI
- [ ] Docs
- [ ] Tests > is it needed for this changes?

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#3333 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://docs.hasura.io/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->


### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
To try it run `HASURA_GRAPHQL_CLI_DEFAULT_BROWSER='Firefox Developer Edition' hasura console`. Change to your browser of choice that is not your default browser.

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
