### PR TITLE
Fix property name in metadata docs

### DIFF
--- a/docs/graphql/manual/api-reference/schema-metadata-api/relationship.rst
+++ b/docs/graphql/manual/api-reference/schema-metadata-api/relationship.rst
@@ -390,7 +390,7 @@ Args syntax
      - true
      - :ref:`TableName`
      - Name of the table
-   * - name
+   * - relationship
      - true
      - :ref:`RelationshipName`
      - Name of the relationship that needs to be dropped

--- a/docs/graphql/manual/api-reference/schema-metadata-api/relationship.rst
+++ b/docs/graphql/manual/api-reference/schema-metadata-api/relationship.rst
@@ -445,7 +445,7 @@ Args syntax
      - true
      - :ref:`TableName`
      - Name of the table
-   * - name
+   * - relationship
      - true
      - :ref:`RelationshipName`
      - The relationship


### PR DESCRIPTION

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
The key for the 'relationship' property is 'relationship' and not 'name'. The example is correct but the syntax table was wrong.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [ ] CLI
- [x] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

