### PR TITLE
docs: fix confusion in PG types docs (close #2643)

### DIFF
--- a/docs/graphql/manual/api-reference/pgtypes.csv
+++ b/docs/graphql/manual/api-reference/pgtypes.csv
@@ -1,4 +1,4 @@
-Name,Aliases,Description,Hasura Type
+Name,Aliases,Description,Input type
 bigint,int8,signed eight-byte integer,String_
 bigserial,serial8,autoincrementing eight-byte integer,String_
 bit [ (n) ],,fixed-length bit string,Implicit_


### PR DESCRIPTION
### Description
After checking with @rakeshkky, we realized that the type is actually right in the documentation (in the table it's the input type that is specified - if you click on it, there is an explanation and the corresponding custom scalar GraphQL type). The column title `Hasura type` seems to lead to confusion, so we decided to change it to `Input type`.

### Affected components
- [x] Docs


