### PR TITLE
read cache control header to refresh JWK (fix #3301)

### DIFF
--- a/.circleci/test-server.sh
+++ b/.circleci/test-server.sh
@@ -551,23 +551,50 @@ unset HASURA_GRAPHQL_AUTH_HOOK_MODE
 unset HASURA_GRAPHQL_JWT_SECRET
 
 echo -e "\n$(time_elapsed): <########## TEST GRAPHQL-ENGINE WITH JWK URL ########> \n"
-export HASURA_GRAPHQL_JWT_SECRET='"type": "RS256", "jwk_url": "http://localhost:5001/jwk-cache-control}'
 TEST_TYPE="jwk-url"
 
+# start the JWK server
+python3 jwk_server.py > "$OUTPUT_FOLDER/jwk_server.log" 2>&1  & JWKS_PID=$!
+wait_for_port 5001
+
+cache_control_jwk_url='{"type": "RS256", "jwk_url": "http://localhost:5001/jwk-cache-control"}'
+expires_jwk_url='{"type": "RS256", "jwk_url": "http://localhost:5001/jwk-expires"}'
+
+# start HGE with cache control JWK URL
+export HASURA_GRAPHQL_JWT_SECRET=$cache_control_jwk_url
 run_hge_with_args serve
 wait_for_port 8080
 
-pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-jwk-url test_jwk.py
+pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-jwk-url test_jwk.py -k 'test_cache_control_header'
 
 kill_hge_servers
 unset HASURA_GRAPHQL_JWT_SECRET
 
-run_hge_with_args serve --jwt-secret '{"type": "RS256", "jwk_url": "http://localhost:5001/jwk-cache-control}'
+run_hge_with_args serve --jwt-secret "$cache_control_jwk_url"
 wait_for_port 8080
 
-pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-jwk-url test_jwk.py
+pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-jwk-url test_jwk.py -k 'test_cache_control_header'
 
 kill_hge_servers
+
+# start HGE with expires JWK URL
+export HASURA_GRAPHQL_JWT_SECRET=$expires_jwk_url
+run_hge_with_args serve
+wait_for_port 8080
+
+pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-jwk-url test_jwk.py -k 'test_expires_header'
+
+kill_hge_servers
+unset HASURA_GRAPHQL_JWT_SECRET
+
+run_hge_with_args serve --jwt-secret "$expires_jwk_url"
+wait_for_port 8080
+
+pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-jwk-url test_jwk.py -k 'test_expires_header'
+
+kill_hge_servers
+
+kill $JWKS_PID
 
 # end jwk url test
 

--- a/.circleci/test-server.sh
+++ b/.circleci/test-server.sh
@@ -545,6 +545,32 @@ kill_hge_servers
 
 # end allowlist queries test
 
+# jwk test
+unset HASURA_GRAPHQL_AUTH_HOOK
+unset HASURA_GRAPHQL_AUTH_HOOK_MODE
+unset HASURA_GRAPHQL_JWT_SECRET
+
+echo -e "\n$(time_elapsed): <########## TEST GRAPHQL-ENGINE WITH JWK URL ########> \n"
+export HASURA_GRAPHQL_JWT_SECRET='"type": "RS256", "jwk_url": "http://localhost:5001/jwk-cache-control}'
+TEST_TYPE="jwk-url"
+
+run_hge_with_args serve
+wait_for_port 8080
+
+pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-jwk-url test_jwk.py
+
+kill_hge_servers
+unset HASURA_GRAPHQL_JWT_SECRET
+
+run_hge_with_args serve --jwt-secret '{"type": "RS256", "jwk_url": "http://localhost:5001/jwk-cache-control}'
+wait_for_port 8080
+
+pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-jwk-url test_jwk.py
+
+kill_hge_servers
+
+# end jwk url test
+
 # horizontal scale test
 unset HASURA_GRAPHQL_AUTH_HOOK
 unset HASURA_GRAPHQL_AUTH_HOOK_MODE

--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -30,6 +30,9 @@ common common-all
     -O2 -foptimal-applicative-do
     -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
     -fdefer-typed-holes
+    -- this seem to parallelize building the modules. using stack build -j4 does not have any
+    -- effect, but adding this seems to help
+    -j4
 
   if flag(profile)
     ghc-prof-options: -fprof-auto -fno-prof-count-entries

--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -30,9 +30,6 @@ common common-all
     -O2 -foptimal-applicative-do
     -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
     -fdefer-typed-holes
-    -- this seem to parallelize building the modules. using stack build -j4 does not have any
-    -- effect, but adding this seems to help
-    -j4
 
   if flag(profile)
     ghc-prof-options: -fprof-auto -fno-prof-count-entries

--- a/server/tests-py/conftest.py
+++ b/server/tests-py/conftest.py
@@ -82,6 +82,14 @@ def pytest_addoption(parser):
     )
 
     parser.addoption(
+        "--test-jwk-url",
+        action="store_true",
+        default=False,
+        required=False,
+        help="Run testcases for JWK url behaviour"
+    )
+
+    parser.addoption(
         "--accept",
         action="store_true",
         default=False,

--- a/server/tests-py/jwk_server.py
+++ b/server/tests-py/jwk_server.py
@@ -80,7 +80,7 @@ handlers = MkHandlers({
     '/state': StateHandler
 })
 
-def create_server(host='127.0.0.1', port=5000):
+def create_server(host='127.0.0.1', port=5001):
     return WebServer((host, port), handlers)
 
 def stop_server(server):

--- a/server/tests-py/jwk_server.py
+++ b/server/tests-py/jwk_server.py
@@ -1,0 +1,94 @@
+# A "fake" JWK server. Which returns `Cache-Control` and `Expires` headers in its response
+# This is useful for testing our `jwk_url` behaviour
+
+import datetime
+import requests
+from http import HTTPStatus
+
+from webserver import RequestHandler, WebServer, MkHandlers, Response
+
+def mkJSONResp(json_result):
+    return Response(HTTPStatus.OK, json_result, {'Content-Type': 'application/json'})
+
+state = {
+    'cache-control': 0,
+    'expires': 0
+}
+
+class JwkExpiresHandler(RequestHandler):
+    expires_in_secs = 3
+    jwk_url = 'https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com'
+    def post(self, request):
+        return Response(HTTPStatus.METHOD_NOT_ALLOWED)
+
+    def get(self, request):
+        # fetch a valid JWK from google servers - this seemed easier than
+        # generating key pairs and then constructing a JWK JSON response
+        jwk_resp = requests.get(self.jwk_url)
+        res = jwk_resp.json()
+        expiry = datetime.datetime.utcnow() + datetime.timedelta(seconds=self.expires_in_secs)
+        resp = mkJSONResp(res)
+        if request.qs and 'error' in request.qs and 'true' in request.qs['error']:
+            resp.headers['Expires'] = 'invalid-value'
+        else:
+            resp.headers['Expires'] = datetime.datetime.strftime(expiry, "%a, %d %b %Y %T GMT")
+        state['expires'] += 1
+        return resp
+
+class JwkCacheControlHandler(RequestHandler):
+    expires_in_secs = str(3)
+    jwk_url = 'https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com'
+    def post(self, request):
+        return Response(HTTPStatus.METHOD_NOT_ALLOWED)
+
+    def get(self, request):
+        # fetch a valid JWK from google servers - this seemed easier than
+        # generating key pairs and then constructing a JWK JSON response
+        jwk_resp = requests.get(self.jwk_url)
+        res = jwk_resp.json()
+        header_val = 'max-age=' + self.expires_in_secs
+        # see if query string contains 'smaxage', then we return `s-maxage` else `maxage`
+        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+        if request.qs:
+            if 'error' in request.qs and 'true' in request.qs['error']:
+                header_val = 'invalid-header-value=42'
+            elif 'field' in request.qs and 'smaxage' in request.qs['field']:
+                header_val = 's-maxage=' + self.expires_in_secs
+        resp = mkJSONResp(res)
+        resp.headers['Cache-Control'] = header_val
+        # HGE should always prefer Cache-Control over Expires header
+        expiry = datetime.datetime.utcnow() + datetime.timedelta(seconds=600)
+        resp.headers['Expires'] = datetime.datetime.strftime(expiry, "%a, %d %b %Y %T GMT")
+        state['cache-control'] += 1
+        return resp
+
+class StateHandler(RequestHandler):
+    def post(self, request):
+        return Response(HTTPStatus.METHOD_NOT_ALLOWED)
+
+    def get(self, request):
+        resp = mkJSONResp(state)
+        return resp
+
+handlers = MkHandlers({
+    # sending query string: `?field=smaxage`, will return Cache-Control with s-maxage, else with max-age
+    # sending query string: `error=true` will respond with invalid header value
+    '/jwk-cache-control': JwkCacheControlHandler,
+    # sending query string: `error=true` will respond with invalid header value
+    '/jwk-expires': JwkExpiresHandler,
+    # API so that testing can be done
+    '/state': StateHandler
+})
+
+def create_server(host='127.0.0.1', port=5000):
+    return WebServer((host, port), handlers)
+
+def stop_server(server):
+    server.shutdown()
+    server.server_close()
+
+# if you want to run this module to emulate a JWK server during development
+if __name__ == '__main__':
+    s = create_server(port=5001)
+    s.serve_forever()
+    stop_server(s)

--- a/server/tests-py/test_jwk.py
+++ b/server/tests-py/test_jwk.py
@@ -6,11 +6,17 @@ if not PytestConf.config.getoption("--test-jwk-url"):
     pytest.skip("--test-jwk-url flag is missing, skipping tests", allow_module_level=True)
 
 # assumes the JWK server is running on 127.0.0.1:5001
-class TestJwkUrlBehaviour():
 
-    def test_cache_control_header(self, hge_ctx):
-        print(hge_ctx)
-        resp = requests.get('http://localhost:5001/state')
-        state = resp.json()
-        print(state)
-        assert(state['cache-control'] > 0)
+def test_cache_control_header(hge_ctx):
+    print(hge_ctx)
+    resp = requests.get('http://localhost:5001/state')
+    state = resp.json()
+    print(state)
+    assert(state['cache-control'] > 0)
+
+def test_expires_header(hge_ctx):
+    print(hge_ctx)
+    resp = requests.get('http://localhost:5001/state')
+    state = resp.json()
+    print(state)
+    assert(state['expires'] > 0)

--- a/server/tests-py/test_jwk.py
+++ b/server/tests-py/test_jwk.py
@@ -1,0 +1,16 @@
+import requests
+import pytest
+from context import PytestConf
+
+if not PytestConf.config.getoption("--test-jwk-url"):
+    pytest.skip("--test-jwk-url flag is missing, skipping tests", allow_module_level=True)
+
+# assumes the JWK server is running on 127.0.0.1:5001
+class TestJwkUrlBehaviour():
+
+    def test_cache_control_header(self, hge_ctx):
+        print(hge_ctx)
+        resp = requests.get('http://localhost:5001/state')
+        state = resp.json()
+        print(state)
+        assert(state['cache-control'] > 0)


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

There is an option to pass a JWK URL in the JWT configuration with Hasura. A lot of providers rotate their JWKs, and hence add a `Cache-Control` or `Expires` header to indicate when to next fetch the updated JWKs.
 
Currently Hasura reads `Expires` header to figure out when to refresh the JWKs. With this PR, it prioritizes `Cache-Control` header over `Expires` to refresh the JWKs.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [x] Tests

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#3301 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
It checks for the presence of `Cache-Control` header in the JWK response. If it is present, it tries to parse the time out of it. If absent, it will try to check for `Expires` header and try to parse a timestamp out of it.
If it is successful in parsing time from any of the above headers, it will refresh the JWKs after that time. If not found, it defaults to 1min to refresh the JWKs.

This behaviour is same as current, except now `Cache-Control` header is also read and takes priority over `Expires` header.

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No Breaking changes

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Run a server that can respond with a JWK and add a `Cache-Control` header with `max-age=5` seconds. Run Hasura, with the `jwk_url` of this server in `HASURA_GRAPHQL_JWT_SECRET`. Observe, that Hasura makes request to this JWK server every 5 seconds.

### Limitations, known bugs & workarounds

