### PR TITLE
add read_only flag to run_sql select queries from console

### DIFF
--- a/console/src/components/Services/Data/DataActions.js
+++ b/console/src/components/Services/Data/DataActions.js
@@ -68,8 +68,8 @@ const useCompositeFnsNewCheck =
 const compositeFnCheck = useCompositeFnsNewCheck
   ? 'c'
   : {
-      $ilike: '%composite%',
-    };
+    $ilike: '%composite%',
+  };
 
 const initQueries = {
   schemaList: {
@@ -285,6 +285,7 @@ const loadSchema = configOptions => {
       }
     }
 
+    // TODO: make read_only sub-queries. blocked as query 2 is v1/query select
     const body = {
       type: 'bulk',
       args: [
@@ -563,12 +564,14 @@ const getBulkColumnInfoFetchQuery = schema => {
     type: 'run_sql',
     args: {
       sql: fetchColumnTypesQuery,
+      read_only: true,
     },
   };
   const fetchTypeDefaultValues = {
     type: 'run_sql',
     args: {
       sql: fetchColumnDefaultFunctions(schema),
+      read_only: true,
     },
   };
 
@@ -576,6 +579,7 @@ const getBulkColumnInfoFetchQuery = schema => {
     type: 'run_sql',
     args: {
       sql: fetchColumnCastsQuery,
+      read_only: true,
     },
   };
 

--- a/console/src/components/Services/Data/DataActions.js
+++ b/console/src/components/Services/Data/DataActions.js
@@ -285,7 +285,6 @@ const loadSchema = configOptions => {
       }
     }
 
-    // TODO: make read_only sub-queries. blocked as query 2 is v1/query select
     const body = {
       type: 'bulk',
       args: [

--- a/console/src/components/Services/Data/TableModify/ModifyActions.js
+++ b/console/src/components/Services/Data/TableModify/ModifyActions.js
@@ -493,14 +493,14 @@ const saveForeignKeys = (index, tableSchema, columns) => {
           alter table "${schemaName}"."${tableName}" drop constraint "${generatedConstraintName}",
           add constraint "${constraintName}"
           foreign key (${Object.keys(oldConstraint.column_mapping)
-            .map(lc => `"${lc}"`)
-            .join(', ')})
+    .map(lc => `"${lc}"`)
+    .join(', ')})
           references "${oldConstraint.ref_table_table_schema}"."${
-        oldConstraint.ref_table
-      }"
+  oldConstraint.ref_table
+}"
           (${Object.values(oldConstraint.column_mapping)
-            .map(rc => `"${rc}"`)
-            .join(', ')})
+    .map(rc => `"${rc}"`)
+    .join(', ')})
           on update ${pgConfTypes[oldConstraint.on_update]}
           on delete ${pgConfTypes[oldConstraint.on_delete]};
         `;
@@ -748,8 +748,8 @@ const deleteTrigger = (trigger, table) => {
 
     downMigrationSql += `CREATE TRIGGER "${triggerName}"
 ${trigger.action_timing} ${
-      trigger.event_manipulation
-    } ON "${tableSchema}"."${tableName}"
+  trigger.event_manipulation
+} ON "${tableSchema}"."${tableName}"
 FOR EACH ${trigger.action_orientation} ${trigger.action_statement};`;
 
     if (trigger.comment) {
@@ -940,6 +940,7 @@ const fetchViewDefinition = (viewName, isRedirect) => {
       type: 'run_sql',
       args: {
         sql: sqlQuery,
+        read_only: true,
       },
     };
 
@@ -1609,24 +1610,24 @@ const saveColumnChangesSql = (colName, column, onSuccess) => {
     const schemaChangesUp =
       originalColType !== colType
         ? [
-            {
-              type: 'run_sql',
-              args: {
-                sql: columnChangesUpQuery,
-              },
+          {
+            type: 'run_sql',
+            args: {
+              sql: columnChangesUpQuery,
             },
-          ]
+          },
+        ]
         : [];
     const schemaChangesDown =
       originalColType !== colType
         ? [
-            {
-              type: 'run_sql',
-              args: {
-                sql: columnChangesDownQuery,
-              },
+          {
+            type: 'run_sql',
+            args: {
+              sql: columnChangesDownQuery,
             },
-          ]
+          },
+        ]
         : [];
 
     /* column custom field up/down migration*/

--- a/console/src/components/Services/Data/utils.js
+++ b/console/src/components/Services/Data/utils.js
@@ -340,6 +340,7 @@ FROM
     type: 'run_sql',
     args: {
       sql: runSql,
+      // read_only: true, TODO
     },
   };
 };
@@ -375,6 +376,7 @@ FROM
     type: 'run_sql',
     args: {
       sql: runSql,
+      // read_only: true, TODO
     },
   };
 };
@@ -453,6 +455,7 @@ FROM
     type: 'run_sql',
     args: {
       sql: runSql,
+      // read_only: true, TODO
     },
   };
 };

--- a/console/src/components/Services/Data/utils.js
+++ b/console/src/components/Services/Data/utils.js
@@ -340,7 +340,7 @@ FROM
     type: 'run_sql',
     args: {
       sql: runSql,
-      // read_only: true, TODO
+      read_only: true,
     },
   };
 };
@@ -376,7 +376,7 @@ FROM
     type: 'run_sql',
     args: {
       sql: runSql,
-      // read_only: true, TODO
+      read_only: true,
     },
   };
 };
@@ -455,7 +455,7 @@ FROM
     type: 'run_sql',
     args: {
       sql: runSql,
-      // read_only: true, TODO
+      read_only: true,
     },
   };
 };

--- a/console/src/components/Services/Data/utils.js
+++ b/console/src/components/Services/Data/utils.js
@@ -1,6 +1,7 @@
 import {
   TABLE_ENUMS_SUPPORT,
   CUSTOM_GRAPHQL_FIELDS_SUPPORT,
+  READ_ONLY_RUN_SQL_QUERIES,
   checkFeatureSupport,
 } from '../../../helpers/versionUtils';
 
@@ -340,7 +341,7 @@ FROM
     type: 'run_sql',
     args: {
       sql: runSql,
-      read_only: true,
+      read_only: checkFeatureSupport(READ_ONLY_RUN_SQL_QUERIES) ? true : false,
     },
   };
 };
@@ -376,7 +377,7 @@ FROM
     type: 'run_sql',
     args: {
       sql: runSql,
-      read_only: true,
+      read_only: checkFeatureSupport(READ_ONLY_RUN_SQL_QUERIES) ? true : false,
     },
   };
 };
@@ -455,7 +456,7 @@ FROM
     type: 'run_sql',
     args: {
       sql: runSql,
-      read_only: true,
+      read_only: checkFeatureSupport(READ_ONLY_RUN_SQL_QUERIES) ? true : false,
     },
   };
 };

--- a/console/src/components/Services/EventTrigger/utils.js
+++ b/console/src/components/Services/EventTrigger/utils.js
@@ -140,6 +140,7 @@ FROM
     type: 'run_sql',
     args: {
       sql: runSql,
+      read_only: true,
     },
   };
 };

--- a/console/src/helpers/versionUtils.js
+++ b/console/src/helpers/versionUtils.js
@@ -11,6 +11,7 @@ export const EXISTS_PERMISSION_SUPPORT = 'existsPermissionSupport';
 export const CUSTOM_GRAPHQL_FIELDS_SUPPORT = 'customGraphQLFieldsSupport';
 export const COMPUTED_FIELDS_SUPPORT = 'computedFieldsSupport';
 export const IMPROVED_EVENT_FETCH_QUERY = 'improvedEventFetchQuery';
+export const READ_ONLY_RUN_SQL_QUERIES = 'readOnlyRunSqlQueries';
 
 // list of feature launch versions
 const featureLaunchVersions = {
@@ -23,6 +24,7 @@ const featureLaunchVersions = {
   [CUSTOM_GRAPHQL_FIELDS_SUPPORT]: 'v1.0.0-beta.8',
   [COMPUTED_FIELDS_SUPPORT]: 'v1.0.0-beta.8',
   [IMPROVED_EVENT_FETCH_QUERY]: 'v1.0.0-beta.10',
+  [READ_ONLY_RUN_SQL_QUERIES]: 'v1.0.0-rc.2',
 };
 
 export const checkValidServerVersion = version => {


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

Add `read_only` flag for all `run_sql` select queries run by console

**Blocker:**

Currently the largest and most common queries run by the console cannot use the flag as they are run in bulk along with one normal `select` query 

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [ ] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://docs.hasura.io/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [ ] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [ ] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [ ] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->


### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
