### PR TITLE
bulk query should not care about access mode of select or count queries

### DIFF
--- a/server/src-lib/Hasura/Server/Query.hs
+++ b/server/src-lib/Hasura/Server/Query.hs
@@ -301,31 +301,34 @@ queryNeedsReload (RQV2 qi) = case qi of
   RQV2SetTableCustomFields _ -> True
   RQV2TrackFunction _        -> True
 
--- TODO: RQSelect query should also be run in READ ONLY mode.
--- But this could be part of console's bulk statement and hence should be added after console changes
 getQueryAccessMode :: (MonadError QErr m) => RQLQuery -> m Q.TxAccess
-getQueryAccessMode (RQV1 q) =
-  case q of
-    RQRunSql RunSQL{rTxAccessMode} -> pure rTxAccessMode
-    RQBulk qs -> assertAllTxAccess (zip [0::Integer ..] qs)
-    _                              -> pure Q.ReadWrite
+getQueryAccessMode q = (fromMaybe Q.ReadOnly) <$> getQueryAccessMode' q
   where
-    assertAllTxAccess = \case
-      [] -> throw400 BadRequest "expected atleast one query in bulk"
-      (_i, q1):[] -> getQueryAccessMode q1
-      q1:q2:qs -> assertSameTxAccess q1 q2 >> assertAllTxAccess (q2:qs)
+    getQueryAccessMode' :: (MonadError QErr m) => RQLQuery -> m (Maybe Q.TxAccess)
+    getQueryAccessMode' (RQV1 q') =
+      case q' of
+        RQSelect _ -> pure Nothing -- RQSelect is don't care i.e. works with both types of TxAccess
+        RQCount _ -> pure Nothing  -- RQCount is don't care i.e. works with both types of TxAccess
+        RQRunSql RunSQL{rTxAccessMode} -> pure $ Just rTxAccessMode
+        RQBulk qs -> assertAllAccessMode Nothing (zip [0 ..] qs)
+        _                              -> pure $ Just Q.ReadWrite
+      where
+        assertAllAccessMode :: (MonadError QErr m) => Maybe Q.TxAccess -> [(Integer, RQLQuery)] -> m (Maybe Q.TxAccess)
+        assertAllAccessMode expectedAccessMode = \case
+          [] -> throw400 BadRequest "expected atleast one query in bulk"
+          q1:[] -> assertAccessMode expectedAccessMode q1
+          q1:qs -> assertAccessMode expectedAccessMode q1 >>= (flip assertAllAccessMode qs)
 
-    assertSameTxAccess (i1, q1) (i2, q2) = do
-      accessModeQ1 <- getQueryAccessMode q1
-      accessModeQ2 <- getQueryAccessMode q2
-      if (accessModeQ1 /= accessModeQ2)
-        then
-        throw400 BadRequest $ "incompatible access mode requirements in bulk query: "
-        <> "$.args[" <> (T.pack $ show i1) <> "] requires " <> (T.pack $ show accessModeQ1) <> ", "
-        <> "$.args[" <> (T.pack $ show i2) <> "] requires " <> (T.pack $ show accessModeQ2)
-        else
-        pure accessModeQ1
-getQueryAccessMode (RQV2 _) = pure Q.ReadWrite
+        assertAccessMode expectedAccessMode (index', query) = do
+          accessModeQ <- getQueryAccessMode' query
+          if isNothing expectedAccessMode || isNothing accessModeQ || (expectedAccessMode == accessModeQ)
+            then
+            pure $ expectedAccessMode <|> accessModeQ
+            else
+            throw400 BadRequest $ "incompatible access mode requirements in bulk query, "
+            <> "expected access mode: " <> (T.pack $ show expectedAccessMode) <> " but "
+            <> "$.args[" <> (T.pack $ show index') <> "] forces " <> (T.pack $ show accessModeQ)
+    getQueryAccessMode' (RQV2 _) = pure $ Just Q.ReadWrite
 
 runQueryM
   :: ( QErrM m, CacheRWM m, UserInfoM m, MonadTx m

--- a/server/tests-py/queries/v1/bulk/mixed_access_mode.yaml
+++ b/server/tests-py/queries/v1/bulk/mixed_access_mode.yaml
@@ -3,15 +3,11 @@ url: /v1/query
 status: 400
 response:
   path: $
-  error: "incompatible access mode requirements in bulk query: $.args[1] requires READ WRITE, $.args[2] requires READ ONLY"
+  error: "incompatible access mode requirements in bulk query, expected access mode: Just READ WRITE but $.args[1] forces Just READ ONLY"
   code: bad-request
 query:
   type: bulk
   args:
-  - type: track_table
-    args:
-      schema: public
-      name: author
   - type: insert
     args:
       table: author

--- a/server/tests-py/queries/v1/bulk/mixed_access_mode.yaml
+++ b/server/tests-py/queries/v1/bulk/mixed_access_mode.yaml
@@ -3,7 +3,7 @@ url: /v1/query
 status: 400
 response:
   path: $
-  error: "incompatible access mode requirements in bulk query, expected access mode: Just READ WRITE but $.args[1] forces Just READ ONLY"
+  error: "incompatible access mode requirements in bulk query, expected access mode: READ WRITE but $.args[1] forces READ ONLY"
   code: bad-request
 query:
   type: bulk

--- a/server/tests-py/queries/v1/bulk/select_with_reads.yaml
+++ b/server/tests-py/queries/v1/bulk/select_with_reads.yaml
@@ -1,0 +1,21 @@
+description: Bulk query
+url: /v1/query
+status: 200
+response:
+  - []
+  - result_type: TuplesOk
+    result:
+      - ['count']
+      - ['0']
+query:
+  type: bulk
+  args:
+  - type: select
+    args:
+      table: author
+      columns:
+        - name
+  - type: run_sql
+    args:
+      sql: "select count(*) from author"
+      read_only: true

--- a/server/tests-py/queries/v1/bulk/select_with_writes.yaml
+++ b/server/tests-py/queries/v1/bulk/select_with_writes.yaml
@@ -3,11 +3,9 @@ url: /v1/query
 status: 200
 response:
   - affected_rows: 2
-  - result_type: TuplesOk
-    result:
-      - ['id', 'name', 'is_registered']
-      - ['1', 'author1', 't']
-      - ['2', 'author2', 'f']
+  -
+    - name: "author1"
+    - name: "author2"
 query:
   type: bulk
   args:
@@ -19,6 +17,8 @@ query:
           is_registered: true
         - name: "author2"
           is_registered: false
-  - type: run_sql
+  - type: select
     args:
-      sql: "select * from author"
+      table: author
+      columns:
+        - name

--- a/server/tests-py/queries/v1/bulk/setup.yaml
+++ b/server/tests-py/queries/v1/bulk/setup.yaml
@@ -1,8 +1,14 @@
-type: run_sql
+type: bulk
 args:
-  sql: |
-    create table author(
+- type: run_sql
+  args:
+    sql: |
+      create table author(
         id serial primary key,
         name text unique,
         is_registered boolean
-    );
+        );
+- type: track_table
+  args:
+    schema: public
+    name: author

--- a/server/tests-py/test_v1_queries.py
+++ b/server/tests-py/test_v1_queries.py
@@ -722,3 +722,11 @@ class TestBulkQuery(DefaultTestQueries):
 
     def test_run_bulk_mixed_access_mode(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + '/mixed_access_mode.yaml')
+
+    def test_run_bulk_with_select_and_writes(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + '/select_with_writes.yaml')
+
+    def test_run_bulk_with_select_and_reads(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + '/select_with_reads.yaml')
+
+  


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description

Fixes the TODO in #3191 and fixes the commented code in #3465 

As RQSelect and RQCount statements could be combined with run_sql queries which mutate data, we had set the tx access mode for them to be READ WRITE to support backwards compatibility in the console.

But the console is doing lots of RQSelect alongside READ ONLY run_sql, which forces the console to continue using run_sql in READ WRITE. This would negate the performance benefit of READ ONLY run_sql in the first place.

This PR fixes that by making RQSelect and RQCount work with both types of access modes.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server

