### PR TITLE
fix insert permission views are not unique for long role names (fix #3444)

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Poll.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Poll.hs
@@ -98,10 +98,17 @@ data Cohort
   -- result changed, then merge them in the map of existing subscribers
   }
 
+{- Note [Blake2b faster than SHA-256]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+At the time of writing, from https://blake2.net, it is stated,
+"BLAKE2 is a cryptographic hash function faster than MD5, SHA-1, SHA-2, and SHA-3,
+yet is at least as secure as the latest standard SHA-3".
+-}
+
 -- | A hash used to determine if the result changed without having to keep the entire result in
 -- memory. Using a cryptographic hash ensures that a hash collision is almost impossible: with 256
 -- bits, even if a subscription changes once per second for an entire year, the probability of a
--- hash collision is ~4.294417×10-63. We use Blake2b because it is faster than SHA-256
+-- hash collision is ~4.294417×10-63. See Note [Blake2b faster than SHA-256].
 newtype ResponseHash = ResponseHash { unResponseHash :: CH.Digest CH.Blake2b_256 }
   deriving (Show, Eq)
 

--- a/server/src-lib/Hasura/RQL/DDL/Permission.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Permission.hs
@@ -87,8 +87,11 @@ type CreateInsPerm = CreatePerm InsPerm
 buildViewName :: QualifiedTable -> RoleName -> PermType -> QualifiedTable
 buildViewName qt rn pt = QualifiedObject hdbViewsSchema tableName
   where
+    -- Generate a unique hash for view name from role name, permission type and qualified table.
+    -- See Note [Postgres identifier length limitations].
+    -- Black2b_224 generates 56 character hash. See Note [Blake2b faster than SHA-256].
+    -- Refer https://github.com/hasura/graphql-engine/issues/3444.
     tableName = TableName $ T.pack $ show hash
-    -- Blake2b_224 generates 56 character length hash
     hash :: CH.Digest CH.Blake2b_224 =
       CH.hash $ txtToBs $ roleNameToTxt rn <> "__" <> T.pack (show pt) <> "__" <> qualObjectToText qt
 

--- a/server/src-lib/Hasura/RQL/DDL/Permission.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Permission.hs
@@ -66,6 +66,7 @@ import           Data.Aeson.Casing
 import           Data.Aeson.TH
 import           Language.Haskell.TH.Syntax         (Lift)
 
+import qualified Crypto.Hash                        as CH
 import qualified Data.HashMap.Strict                as HM
 import qualified Data.HashSet                       as HS
 import qualified Data.Text                          as T
@@ -84,12 +85,12 @@ type InsPermDef = PermDef InsPerm
 type CreateInsPerm = CreatePerm InsPerm
 
 buildViewName :: QualifiedTable -> RoleName -> PermType -> QualifiedTable
-buildViewName (QualifiedObject sn tn) rn pt =
-  QualifiedObject hdbViewsSchema $ TableName
-  (roleNameToTxt rn <> "__" <> T.pack (show pt) <> "__" <> snTxt <> "__" <> tnTxt)
+buildViewName qt rn pt = QualifiedObject hdbViewsSchema tableName
   where
-    snTxt = getSchemaTxt sn
-    tnTxt = getTableTxt tn
+    tableName = TableName $ T.pack $ show hash
+    -- Blake2b_224 generates 56 character length hash
+    hash :: CH.Digest CH.Blake2b_224 =
+      CH.hash $ txtToBs $ roleNameToTxt rn <> "__" <> T.pack (show pt) <> "__" <> qualObjectToText qt
 
 buildView :: QualifiedTable -> QualifiedTable -> Q.Query
 buildView tn vn =

--- a/server/src-lib/Hasura/SQL/Rewrite.hs
+++ b/server/src-lib/Hasura/SQL/Rewrite.hs
@@ -8,11 +8,14 @@ import           Hasura.Prelude
 import qualified Hasura.SQL.DML      as S
 import           Hasura.SQL.Types    (Iden (..))
 
+{- Note [Postgres identifier length limitations]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Postgres truncates identifiers to a maximum of 63 characters by default (see
+https://www.postgresql.org/docs/12/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS).
+-}
 
--- add an int as a prefix to all aliases.
--- This is needed in cases identifiers exceed 63 chars
--- as postgres only considers first 63 chars of
--- an identifier
+-- Prefix an Int to all aliases to preserve the uniqueness of identifiers.
+-- See Note [Postgres identifier length limitations].
 prefixNumToAliases :: S.Select -> S.Select
 prefixNumToAliases s =
   uSelect s `evalState` UniqSt 0 Map.empty

--- a/server/tests-py/queries/v1/permissions/create_author_insert_permission_long_role.yaml
+++ b/server/tests-py/queries/v1/permissions/create_author_insert_permission_long_role.yaml
@@ -1,0 +1,27 @@
+- description: Create insert permission for author table with long (> 63 chars) role
+  url: /v1/query
+  status: 200
+  response:
+    message: success
+  query:
+    type: create_insert_permission
+    args:
+      table: author
+      role: this.is.really.a.very.long.and.long.role.more.than.63.characters.one
+      permission:
+        columns: '*'
+        check: {}
+
+- description: Create insert permission for author table with long (> 63 chars) role
+  url: /v1/query
+  status: 200
+  response:
+    message: success
+  query:
+    type: create_insert_permission
+    args:
+      table: author
+      role: this.is.really.a.very.long.and.long.role.more.than.63.characters.two
+      permission:
+        columns: '*'
+        check: {}

--- a/server/tests-py/queries/v1/permissions/teardown.yaml
+++ b/server/tests-py/queries/v1/permissions/teardown.yaml
@@ -4,10 +4,6 @@ args:
 - type: run_sql
   args:
     sql: |
-      drop table article
-
-- type: run_sql
-  args:
-    sql: |
-      drop table author
-
+      DROP TABLE article;
+      DROP TABLE author;
+    cascade: true

--- a/server/tests-py/test_v1_queries.py
+++ b/server/tests-py/test_v1_queries.py
@@ -629,6 +629,9 @@ class TestCreatePermission(DefaultTestQueries):
     def test_create_permission_user_role_error(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + '/create_article_permission_role_user.yaml')
 
+    def test_create_author_insert_permission_long_role(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + '/create_author_insert_permission_long_role.yaml')
+
     @classmethod
     def dir(cls):
         return "queries/v1/permissions"


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

All PostgreSQL identifiers are limited by 63 character length and longer ones are truncated. See [Postgres docs](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS). 

The server makes use of views to define an insert trigger with check permission. The auto-generated view name is of format `{role}__insert__{table-schema}__{table-name}`. For the really long role names, the generated view names may exceed 63 characters and truncated names may not be unique.

This PR fixes the above issue by using hash string instead of formatted text.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [x] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
Fix #3444 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
Use Blake2b_224 algorithm, which generates 56 character length hash for insert permission view names.

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->


### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Define insert permissions with long role names which differ in the tail characters (> 63 characters).

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
