### PR TITLE
add fix for default error message (#3400)

### DIFF
--- a/cli/commands/migrate_squash.go
+++ b/cli/commands/migrate_squash.go
@@ -43,6 +43,7 @@ func newMigrateSquashCmd(ec *cli.ExecutionContext) *cobra.Command {
 
 	f := migrateSquashCmd.Flags()
 	f.Uint64Var(&opts.from, "from", 0, "start squashing form this version")
+	f.MarkFlagRequired("from")
 	f.StringVar(&opts.name, "name", "squashed", "name for the new squashed migration")
 	f.BoolVar(&opts.deleteSource, "delete-source", false, "delete the source files after squashing without any confirmation")
 

--- a/cli/commands/migrate_squash.go
+++ b/cli/commands/migrate_squash.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
 	"github.com/spf13/viper"
 
 	mig "github.com/hasura/graphql-engine/cli/migrate/cmd"
@@ -43,7 +44,6 @@ func newMigrateSquashCmd(ec *cli.ExecutionContext) *cobra.Command {
 
 	f := migrateSquashCmd.Flags()
 	f.Uint64Var(&opts.from, "from", 0, "start squashing form this version")
-	f.MarkFlagRequired("from")
 	f.StringVar(&opts.name, "name", "squashed", "name for the new squashed migration")
 	f.BoolVar(&opts.deleteSource, "delete-source", false, "delete the source files after squashing without any confirmation")
 
@@ -51,6 +51,9 @@ func newMigrateSquashCmd(ec *cli.ExecutionContext) *cobra.Command {
 	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
 	f.String("access-key", "", "access key for Hasura GraphQL Engine")
 	f.MarkDeprecated("access-key", "use --admin-secret instead")
+
+	// mark flag as required
+	migrateSquashCmd.MarkFlagRequired("from")
 
 	// need to create a new viper because https://github.com/spf13/viper/issues/233
 	v.BindPFlag("endpoint", f.Lookup("endpoint"))


### PR DESCRIPTION
### Description
#3400 
This commit adds a fix for the ambiguous error message for squash migrate command.
