### PR TITLE
avoid using CTE for querying custom SQL functions (close #3349)

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Resolve/Types.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/Types.hs
@@ -69,13 +69,12 @@ type FunctionArgSeq = Seq.Seq (InputArgument FunctionArgItem)
 
 data FuncQOpCtx
   = FuncQOpCtx
-  { _fqocTable    :: !QualifiedTable
+  { _fqocFunction :: !QualifiedFunction
+  , _fqocArgs     :: !FunctionArgSeq
   , _fqocHeaders  :: ![T.Text]
   , _fqocAllCols  :: !PGColGNameMap
   , _fqocFilter   :: !AnnBoolExpPartialSQL
   , _fqocLimit    :: !(Maybe Int)
-  , _fqocFunction :: !QualifiedFunction
-  , _fqocArgs     :: !FunctionArgSeq
   } deriving (Show, Eq)
 
 data UpdOpCtx

--- a/server/src-lib/Hasura/GraphQL/Schema.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema.hs
@@ -414,8 +414,7 @@ getRootFldsRole' tn primCols constraints fields funcs insM
 
     funcFldHelper f g pFltr pLimit hdrs =
       flip map funcs $ \fi ->
-      ( f $ FuncQOpCtx tn hdrs colGNameMap pFltr pLimit
-              (fiName fi) (mkFuncArgItemSeq fi)
+      ( f $ FuncQOpCtx (fiName fi) (mkFuncArgItemSeq fi) hdrs colGNameMap pFltr pLimit
       , g fi $ fiDescription fi
       )
 

--- a/server/src-lib/Hasura/RQL/DML/Select.hs
+++ b/server/src-lib/Hasura/RQL/DML/Select.hs
@@ -2,8 +2,6 @@ module Hasura.RQL.DML.Select
   ( selectP2
   , selectQuerySQL
   , selectAggQuerySQL
-  , mkFuncSelectSimple
-  , mkFuncSelectAgg
   , convSelectQuery
   , asSingleRowJsonResp
   , module Hasura.RQL.DML.Select.Internal
@@ -268,20 +266,6 @@ convSelectQuery sessVarBldr prepArgBuilder (DMLQuery qt selQ) = do
   validateHeaders $ spiRequiredHeaders selPermInfo
   convSelectQ (_tiFieldInfoMap tabInfo) selPermInfo
     extSelQ sessVarBldr prepArgBuilder
-
-mkFuncSelectSimple
-  :: AnnFnSelSimple
-  -> Q.Query
-mkFuncSelectSimple annFnSel =
-  Q.fromBuilder $ toSQL $
-  mkFuncSelectWith (mkSQLSelect False) annFnSel
-
-mkFuncSelectAgg
-  :: AnnFnSelAgg
-  -> Q.Query
-mkFuncSelectAgg annFnSel =
-  Q.fromBuilder $ toSQL $
-  mkFuncSelectWith mkAggSelect annFnSel
 
 selectP2 :: Bool -> (AnnSimpleSel, DS.Seq Q.PrepArg) -> Q.TxE QErr EncJSON
 selectP2 asSingleObject (sel, p) =

--- a/server/src-lib/Hasura/RQL/DML/Select/Internal.hs
+++ b/server/src-lib/Hasura/RQL/DML/Select/Internal.hs
@@ -1,7 +1,6 @@
 module Hasura.RQL.DML.Select.Internal
   ( mkSQLSelect
   , mkAggSelect
-  , mkFuncSelectWith
   , module Hasura.RQL.DML.Select.Types
   )
 where
@@ -773,30 +772,3 @@ mkSQLSelect isSingleObject annSel =
     baseNode = annSelToBaseNode False rootPrefix rootFldName annSel
     rootFldName = FieldName "root"
     rootFldAls  = S.Alias $ toIden rootFldName
-
-mkFuncSelectWith
-  :: (AnnSelG a S.SQLExp -> S.Select)
-  -> AnnFnSelG (AnnSelG a S.SQLExp) S.SQLExp
-  -> S.SelectWith
-mkFuncSelectWith f annFn =
-  S.SelectWith [(funcAls, S.CTESelect funcSel)] $
-  -- we'll need to modify the table from of the underlying
-  -- select to the alias of the select from function
-  f annSel { _asnFrom = newSelFrom }
-  where
-    AnnFnSel qf fnArgs annSel = annFn
-
-    -- SELECT * FROM function_name(args)
-    funcSel = S.mkSelect { S.selFrom = Just $ S.FromExp [frmItem]
-                         , S.selExtr = [S.Extractor S.SEStar Nothing]
-                         }
-    frmItem = S.mkFuncFromItem qf $ mkSQLFunctionArgs fnArgs
-
-    mkSQLFunctionArgs (FunctionArgsExp positional named) =
-      S.FunctionArgs positional named
-
-    newSelFrom = FromIden $ toIden funcAls
-
-    QualifiedObject sn fn = qf
-    funcAls = S.Alias $ Iden $
-      getSchemaTxt sn <> "_" <> getFunctionTxt fn <> "__result"

--- a/server/src-lib/Hasura/RQL/DML/Select/Types.hs
+++ b/server/src-lib/Hasura/RQL/DML/Select/Types.hs
@@ -353,40 +353,6 @@ insertFunctionArg argName index value (FunctionArgsExp positional named) =
   where
     insertAt i a = toList . Seq.insertAt i a . Seq.fromList
 
-data AnnFnSelG s v
-  = AnnFnSel
-  { _afFn     :: !QualifiedFunction
-  , _afFnArgs :: !(FunctionArgsExpG v)
-  , _afSelect :: !s
-  } deriving (Show, Eq)
-
-traverseAnnFnSel
-  :: (Applicative f)
-  => (a -> f b) -> (v -> f w)
-  -> AnnFnSelG a v -> f (AnnFnSelG b w)
-traverseAnnFnSel fs fv (AnnFnSel fn fnArgs s) =
-  AnnFnSel fn <$> traverse fv fnArgs <*> fs s
-
-type AnnFnSelSimpleG v = AnnFnSelG (AnnSimpleSelG v) v
-type AnnFnSelSimple = AnnFnSelSimpleG S.SQLExp
-
-traverseAnnFnSimple
-  :: (Applicative f)
-  => (a -> f b)
-  -> AnnFnSelSimpleG a -> f (AnnFnSelSimpleG b)
-traverseAnnFnSimple f =
-  traverseAnnFnSel (traverseAnnSimpleSel f) f
-
-type AnnFnSelAggG v = AnnFnSelG (AnnAggSelG v) v
-type AnnFnSelAgg = AnnFnSelAggG S.SQLExp
-
-traverseAnnFnAgg
-  :: (Applicative f)
-  => (a -> f b)
-  -> AnnFnSelAggG a -> f (AnnFnSelAggG b)
-traverseAnnFnAgg f =
-  traverseAnnFnSel (traverseAnnAggSel f) f
-
 data BaseNode
   = BaseNode
   { _bnPrefix              :: !Iden


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

Do not use [Common Table Expressions (CTE)](https://www.postgresql.org/docs/current/queries-with.html) for querying custom SQL functions.

Consider the following custom SQL query:-

```graphql
query {
  search_tracks(
    args: {search: "Night"}
    where: {id: {_gt: 100}}
  ){
    id
    name
  }
}
```

Generated SQL statements:-

With CTE
```sql
WITH "public_search_tracks__result" AS (
  SELECT
    *
  FROM
    "public"."search_tracks"(('Night') :: text)
)
SELECT
  coalesce(json_agg("root"), '[]') AS "root"
FROM
  (
    SELECT
      row_to_json(
        (
          SELECT
            "_1_e"
          FROM
            (
              SELECT
                "_0_root.base"."id" AS "id",
                "_0_root.base"."name" AS "name"
            ) AS "_1_e"
        )
      ) AS "root"
    FROM
      (
        SELECT
          *
        FROM
          "public_search_tracks__result"
        WHERE
          (
            ("public_search_tracks__result"."id") > (('100') :: integer)
          )
      ) AS "_0_root.base"
  ) AS "_2_root"
```
Without CTE (in this PR)
```sql
SELECT
  coalesce(json_agg("root"), '[]') AS "root"
FROM
  (
    SELECT
      row_to_json(
        (
          SELECT
            "_2_e"
          FROM
            (
              SELECT
                "_1_root.base"."id" AS "id",
                "_1_root.base"."name" AS "name"
            ) AS "_2_e"
        )
      ) AS "root"
    FROM
      (
        SELECT
          *
        FROM
          "public"."search_tracks"(('Night') :: text) AS "_0_search_tracks"
        WHERE
          (("_0_search_tracks"."id") > (('100') :: integer))
      ) AS "_1_root.base"
  ) AS "_3_root"
```

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
Close #3349 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
- Remove types related `function select` and `function aggregate select`. 
- SQL function queries are treated as normal `select` which differs only in `FROM` expression. 

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
 
#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:

#### Breaking changes

- [x] No Breaking changes

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
The custom SQL function queries shouldn't have Common Table Expressions (CTE). Use console `Analyze` to view the generated SQL statement.

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
