### PR TITLE
add subscribers count to '/dev/subscriptions' developer API

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/TMap.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/TMap.hs
@@ -7,11 +7,13 @@ module Hasura.GraphQL.Execute.LiveQuery.TMap
   , insert
   , delete
   , toList
+  , length
   ) where
 
-import           Hasura.Prelude         hiding (lookup, null, toList)
+import           Hasura.Prelude         hiding (length, lookup, null, toList)
 
 import qualified Data.HashMap.Strict    as Map
+import qualified Data.List              as L
 
 import           Control.Concurrent.STM
 
@@ -40,3 +42,6 @@ delete k mapTv = modifyTVar' (unTMap mapTv) $ Map.delete k
 
 toList :: TMap k v -> STM [(k, v)]
 toList = fmap Map.toList . readTVar . unTMap
+
+length :: TMap k v -> STM Int
+length = fmap L.length . toList


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

Request
```http
GET /dev/subscriptions HTTP/1.1

X-Hasura-Role: admin
```
Response:-
```json
{
  "live_queries_map": [
    {
      "thread_id": "ThreadId 41",
      "metrics": {
        "snapshot": {
          "max": 4.6619e-05,
          "mean": 3.1881e-05,
          "count": 7,
          "min": 0,
          "variance": 1.1347038485714285e-10
        },
        "query": {
          "max": 0.001925602,
          "mean": null,
          "count": 7,
          "min": 0,
          "variance": null
        },
        "total": {
          "max": 0.002412702,
          "mean": 0.0019166372857142855,
          "count": 7,
          "min": 0,
          "variance": 3.1594767019591844e-07
        },
        "push": {
          "max": 0.000349822,
          "mean": null,
          "count": 7,
          "min": 0,
          "variance": null
        }
      },
      "cohorts": null,
      "role": "admin",
      "multiplexed_query": "\n        select\n          _subs.result_id, _fld_resp.root as result\n          from\n            unnest(\n              $1::uuid[], $2::json[]\n            ) _subs (result_id, result_vars)\n          left outer join lateral\n            (\n        SELECT  coalesce(json_agg(\"root\" ), '[]' ) AS \"root\" FROM  (SELECT  row_to_json((SELECT  \"_1_e\"  FROM  (SELECT  \"_0_root.base\".\"id\" AS \"id\", \"_0_root.base\".\"name\" AS \"name\"       ) AS \"_1_e\"      ) ) AS \"root\" FROM  (SELECT  *  FROM \"public\".\"test\"  WHERE ('true')     ) AS \"_0_root.base\"      ) AS \"_2_root\"      \n            ) _fld_resp ON ('true')\n        ",
      "subscribers": 2
    }
  ],
  "options": {
    "batch_size": 100,
    "refetch_delay": 1
  }
}
```
`live_queries_map` is list of objects. Each object corresponds to a live query. `multiplexed_query` is generated query (prepared and not executable directly without prepared arguments) and `subscribers` is no.of clients subscribed to that query. 

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [ ] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://docs.hasura.io/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [ ] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [ ] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [ ] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->


### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
