### PR TITLE
cli: add directory name as an argument to init cmd

### DIFF
--- a/cli/commands/init.go
+++ b/cli/commands/init.go
@@ -25,23 +25,27 @@ func NewInitCmd(ec *cli.ExecutionContext) *cobra.Command {
 		EC: ec,
 	}
 	initCmd := &cobra.Command{
-		Use:   "init",
+		Use:   "init [directory-name]",
 		Short: "Initialize directory for Hasura GraphQL Engine migrations",
 		Long:  "Create directories and files required for enabling migrations on Hasura GraphQL Engine",
 		Example: `  # Create a directory to store migrations
-  hasura init
+  hasura init [directory-name]
 
   # Now, edit <my-directory>/config.yaml to add endpoint and admin secret
 
   # Create a directory with endpoint and admin secret configured:
-  hasura init --directory <my-project> --endpoint https://my-graphql-engine.com --admin-secret adminsecretkey
+  hasura init <my-project> --endpoint https://my-graphql-engine.com --admin-secret adminsecretkey
 
   # See https://docs.hasura.io/1.0/graphql/manual/migrations/index.html for more details`,
 		SilenceUsage: true,
+		Args:         cobra.MaximumNArgs(1),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			ec.Viper = viper.New()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				opts.InitDir = args[0]
+			}
 			return opts.run()
 		},
 	}
@@ -52,6 +56,7 @@ func NewInitCmd(ec *cli.ExecutionContext) *cobra.Command {
 	f.StringVar(&opts.AdminSecret, "admin-secret", "", "admin secret for Hasura GraphQL Engine")
 	f.StringVar(&opts.AdminSecret, "access-key", "", "access key for Hasura GraphQL Engine")
 	f.MarkDeprecated("access-key", "use --admin-secret instead")
+	f.MarkDeprecated("directory", "use directory-name argument instead")
 
 	return initCmd
 }

--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -5,6 +5,7 @@ package commands
 import (
 	"github.com/hasura/graphql-engine/cli"
 	"github.com/hasura/graphql-engine/cli/update"
+	"github.com/hasura/graphql-engine/cli/version"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -37,8 +38,8 @@ var rootCmd = &cobra.Command{
 					EC: ec,
 				}
 				err := u.run(true)
-				if err != nil {
-					ec.Logger.WithError(err).Error("auto-update failed, run 'hasura update-cli' to update manually")
+				if err != nil && u.EC.Version.GetCLIVersion() != version.DevVersion {
+					ec.Logger.WithError(err).Warn("auto-update failed, run 'hasura update-cli' to update manually")
 				}
 			}
 		}

--- a/cli/telemetry/telemetry_test.go
+++ b/cli/telemetry/telemetry_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 
 	"github.com/hasura/graphql-engine/cli/telemetry"
+	"github.com/hasura/graphql-engine/cli/version"
 )
 
 func TestBeamDev(t *testing.T) {
 	tm := telemetry.BuildEvent()
-	tm.Version = "dev"
+	tm.Version = version.DevVersion
 	tm.Command = "TEST"
 	tm.CanBeam = true
 	tm.Beam()

--- a/cli/version/compatibility.go
+++ b/cli/version/compatibility.go
@@ -14,7 +14,7 @@ const (
 // a message which states the reason for the result.
 func (v *Version) CheckCLIServerCompatibility() (compatible bool, reason string) {
 	// mark dev builds as compatible
-	if v.CLI == "dev" {
+	if v.CLI == DevVersion {
 		return true, devCLI
 	}
 	// empty cli version

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -7,9 +7,12 @@ import (
 	"github.com/Masterminds/semver"
 )
 
+// DevVersion is the version string for development versions.
+const DevVersion = "dev"
+
 // BuildVersion is the versin string with which CLI is built. Set during
 // the build time.
-var BuildVersion = "dev"
+var BuildVersion = DevVersion
 
 // Version defines the version object.
 type Version struct {


### PR DESCRIPTION
This PR adds an argument for init command so that directory name can be passed as an argument instead of a flag. The usage now becomes:

```
hasura init my-project
```

instead of 
```
hasura init --directory my-project
```

The `--directory` flag has been marked as deprecated and can still be used, hence there are no breaking changes.