### PR TITLE
Add seed ability and option to include data in migrations to CLI (close #2431, #2817)

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -141,6 +141,8 @@ type ExecutionContext struct {
 	ExecutionDirectory string
 	// MigrationDir is the name of directory where migrations are stored.
 	MigrationDir string
+	// SeedDir is the name of directory where migrations are stored.
+	SeedDir string
 	// ConfigFile is the file where endpoint etc. are stored.
 	ConfigFile string
 	// MetadataFile (optional) is a yaml|json file where Hasura metadata is stored.
@@ -255,6 +257,7 @@ func (ec *ExecutionContext) Validate() error {
 
 	// set names of files and directories
 	ec.MigrationDir = filepath.Join(ec.ExecutionDirectory, "migrations")
+	ec.SeedDir = filepath.Join(ec.ExecutionDirectory, "seeds")
 	ec.ConfigFile = filepath.Join(ec.ExecutionDirectory, "config.yaml")
 	ec.MetadataFile = append(ec.MetadataFile, filepath.Join(ec.MigrationDir, "metadata.yaml"))
 	ec.MetadataFile = append(ec.MetadataFile, filepath.Join(ec.MigrationDir, "metadata.json"))

--- a/cli/commands/init.go
+++ b/cli/commands/init.go
@@ -153,6 +153,13 @@ func (o *initOptions) createFiles() error {
 		return errors.Wrap(err, "cannot write migration directory")
 	}
 
+	// create seeds directory
+	o.EC.SeedDir = filepath.Join(o.EC.ExecutionDirectory, "seeds")
+	err = os.MkdirAll(o.EC.SeedDir, os.ModePerm)
+	if err != nil {
+		return errors.Wrap(err, "cannot write seed directory")
+	}
+
 	return nil
 }
 

--- a/cli/commands/migrate_create.go
+++ b/cli/commands/migrate_create.go
@@ -103,8 +103,6 @@ func (o *migrateCreateOptions) run() (version int64, err error) {
 	timestamp := getTime()
 	createOptions := mig.New(timestamp, o.name, o.EC.MigrationDir)
 
-	ec.Logger.Debugf("includeData value: %v", o.includeData)
-
 	if o.fromServer {
 		o.sqlServer = true
 		o.metaDataServer = true

--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -60,6 +60,7 @@ func init() {
 		NewConsoleCmd(ec),
 		NewMetadataCmd(ec),
 		NewMigrateCmd(ec),
+		NewSeedCmd(ec),
 		NewVersionCmd(ec),
 		NewDocsCmd(ec),
 		NewCompletionCmd(ec),

--- a/cli/commands/seed.go
+++ b/cli/commands/seed.go
@@ -1,0 +1,63 @@
+package commands
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/hasura/graphql-engine/cli"
+	"github.com/hasura/graphql-engine/cli/migrate"
+	mig "github.com/hasura/graphql-engine/cli/migrate/cmd"
+	"github.com/hasura/graphql-engine/cli/version"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// NewseedCmd returns the seed command
+func NewSeedCmd(ec *cli.ExecutionContext) *cobra.Command {
+	seedCmd := &cobra.Command{
+		Use:          "seed",
+		Short:        "Manage seeds on the database",
+		SilenceUsage: true,
+	}
+	seedCmd.AddCommand(
+		newSeedCreateCmd(ec),
+		newSeedApplyCmd(ec),
+	)
+	return seedCmd
+}
+
+func newSeed(dir string, db *url.URL, adminSecretValue string, logger *logrus.Logger, v *version.Version, isCmd bool) (*migrate.Migrate, error) {
+	dbURL := getDataPath(db, getAdminSecretHeaderName(v), adminSecretValue)
+	fileURL := getFilePath(dir)
+	t, err := migrate.New(fileURL.String(), dbURL.String(), isCmd, logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create seed instance")
+	}
+	return t, nil
+}
+
+// ExecuteMigration runs the actual migration
+func ExecuteSeed(cmd string, t *migrate.Migrate, stepOrVersion int64) error {
+	var err error
+
+	switch cmd {
+	case "up":
+		err = mig.UpCmd(t, stepOrVersion)
+	case "down":
+		err = mig.DownCmd(t, stepOrVersion)
+	case "version":
+		var direction string
+		if stepOrVersion >= 0 {
+			direction = "up"
+		} else {
+			direction = "down"
+			stepOrVersion = -(stepOrVersion)
+		}
+		err = mig.GotoCmd(t, uint64(stepOrVersion), direction)
+	default:
+		err = fmt.Errorf("Invalid command")
+	}
+
+	return err
+}

--- a/cli/commands/seed_apply.go
+++ b/cli/commands/seed_apply.go
@@ -18,25 +18,25 @@ func newSeedApplyCmd(ec *cli.ExecutionContext) *cobra.Command {
 	seedApplyCmd := &cobra.Command{
 		Use:   "apply",
 		Short: "Apply seeds on the database",
-		Example: `  # Apply all migrations
+		Example: `  # Apply all seeds
   hasura seed apply
 
   # Use with admin secret:
   hasura seed apply --admin-secret "<admin-secret>"
 
-  # Apply migrations on another Hasura instance:
+  # Apply seeds on another Hasura instance:
   hasura seed apply --endpoint "<endpoint>"
 
-  # Mark migration as applied on the server and skip execution:
+  # Mark seeds as applied on the server and skip execution:
   hasura seed apply --skip-execution
 
-  # Apply a particular migration version only:
+  # Apply a seed version only:
   hasura seed apply --version "<version>"
 
-  # Apply last 2 down migrations:
+  # Apply last 2 down seeds:
   hasura seed apply --down 2
 
-  # Apply only 2 up migrations:
+  # Apply only 2 up seeds:
   hasura seed apply --up 2
 
   # Apply only a particular version
@@ -45,7 +45,7 @@ func newSeedApplyCmd(ec *cli.ExecutionContext) *cobra.Command {
   # Rollback a particular version:
   hasura seed apply --type down --version "<version>"
 
-  # Rollback all migrations:
+  # Rollback all seeds:
   hasura seed apply --down all`,
 		SilenceUsage: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -59,7 +59,7 @@ func newSeedApplyCmd(ec *cli.ExecutionContext) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			opts.EC.Logger.Info("migrations applied")
+			opts.EC.Logger.Info("seeds applied")
 			return nil
 		},
 	}

--- a/cli/commands/seed_apply.go
+++ b/cli/commands/seed_apply.go
@@ -1,0 +1,124 @@
+package commands
+
+import (
+	"os"
+
+	"github.com/hasura/graphql-engine/cli"
+	migrate "github.com/hasura/graphql-engine/cli/migrate"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func newSeedApplyCmd(ec *cli.ExecutionContext) *cobra.Command {
+	v := viper.New()
+	opts := &seedApplyOptions{
+		EC: ec,
+	}
+	seedApplyCmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Apply seeds on the database",
+		Example: `  # Apply all migrations
+  hasura seed apply
+
+  # Use with admin secret:
+  hasura seed apply --admin-secret "<admin-secret>"
+
+  # Apply migrations on another Hasura instance:
+  hasura seed apply --endpoint "<endpoint>"
+
+  # Mark migration as applied on the server and skip execution:
+  hasura seed apply --skip-execution
+
+  # Apply a particular migration version only:
+  hasura seed apply --version "<version>"
+
+  # Apply last 2 down migrations:
+  hasura seed apply --down 2
+
+  # Apply only 2 up migrations:
+  hasura seed apply --up 2
+
+  # Apply only a particular version
+  hasura seed apply --type up --version "<version>"
+
+  # Rollback a particular version:
+  hasura seed apply --type down --version "<version>"
+
+  # Rollback all migrations:
+  hasura seed apply --down all`,
+		SilenceUsage: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			ec.Viper = v
+			return ec.Validate()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.EC.Spin("Applying seeds...")
+			err := opts.run()
+			opts.EC.Spinner.Stop()
+			if err != nil {
+				return err
+			}
+			opts.EC.Logger.Info("migrations applied")
+			return nil
+		},
+	}
+	f := seedApplyCmd.Flags()
+
+	f.StringVar(&opts.upMigration, "up", "", "apply all or N up seed steps")
+	f.StringVar(&opts.downMigration, "down", "", "apply all or N down seed steps")
+	f.StringVar(&opts.versionMigration, "version", "", "only apply this particular seed")
+	f.StringVar(&opts.migrationType, "type", "up", "type of seed (up, down) to be used with version flag")
+	f.BoolVar(&opts.skipExecution, "skip-execution", false, "skip executing the seed action, but mark them as applied")
+
+	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
+	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
+	f.String("access-key", "", "access key for Hasura GraphQL Engine")
+	f.MarkDeprecated("access-key", "use --admin-secret instead")
+
+	// need to create a new viper because https://github.com/spf13/viper/issues/233
+	v.BindPFlag("endpoint", f.Lookup("endpoint"))
+	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
+	v.BindPFlag("access_key", f.Lookup("access-key"))
+	return seedApplyCmd
+}
+
+type seedApplyOptions struct {
+	EC *cli.ExecutionContext
+
+	upMigration      string
+	downMigration    string
+	versionMigration string
+	migrationType    string
+	skipExecution    bool
+}
+
+func (o *seedApplyOptions) run() error {
+	migrationType, step, err := getMigrationTypeAndStep(o.upMigration, o.downMigration, o.versionMigration, o.migrationType, o.skipExecution)
+	if err != nil {
+		return errors.Wrap(err, "error validating flags")
+	}
+
+	migrateDrv, err := newMigrate(o.EC.SeedDir, o.EC.ServerConfig.ParsedEndpoint, o.EC.ServerConfig.AdminSecret, o.EC.Logger, o.EC.Version, true)
+	if err != nil {
+		return err
+	}
+	migrateDrv.SkipExecution = o.skipExecution
+
+	err = ExecuteMigration(migrationType, migrateDrv, step)
+	if err != nil {
+		if err == migrate.ErrNoChange {
+			o.EC.Logger.Info("nothing to apply")
+			return nil
+		}
+		if e, ok := err.(*os.PathError); ok {
+			// If Op is first, then log No migrations to apply
+			if e.Op == "first" {
+				o.EC.Logger.Info("No seeds to apply")
+				return nil
+			}
+		}
+		return errors.Wrap(err, "apply failed")
+	}
+	return nil
+}

--- a/cli/commands/seed_create.go
+++ b/cli/commands/seed_create.go
@@ -15,13 +15,13 @@ import (
 )
 
 const migrateSeedCmdExamples = `  # Setup seed files for tables:
-  hasura migrate seed --endpoint "<endpoint>" 
+  hasura seed create --endpoint "<endpoint>" 
 
   # Create seeds for specified tables only:
-  hasura migrate create --tables one,two,three
+  hasura seed create --tables one,two,three
 
   # Use with admin secret:
-  hasura migrate seed --admin-secret "<admin-secret>"`
+  hasura seed create --admin-secret "<admin-secret>"`
 
 func newSeedCreateCmd(ec *cli.ExecutionContext) *cobra.Command {
 	v := viper.New()
@@ -30,7 +30,7 @@ func newSeedCreateCmd(ec *cli.ExecutionContext) *cobra.Command {
 	}
 
 	migrateSeedCmd := &cobra.Command{
-		Use:          "create [migration-name]",
+		Use:          "create [seed-name]",
 		Short:        "Create files required for seeding",
 		Long:         "Create sql files required for seeding",
 		Example:      migrateSeedCmdExamples,

--- a/cli/commands/seed_create.go
+++ b/cli/commands/seed_create.go
@@ -1,0 +1,116 @@
+package commands
+
+import (
+	"time"
+
+	"github.com/hasura/graphql-engine/cli"
+	"github.com/hasura/graphql-engine/cli/migrate"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	mig "github.com/hasura/graphql-engine/cli/migrate/cmd"
+	log "github.com/sirupsen/logrus"
+)
+
+const migrateSeedCmdExamples = `  # Setup seed files for tables:
+  hasura migrate seed --endpoint "<endpoint>" 
+
+  # Create seeds for specified tables only:
+  hasura migrate create --tables one,two,three
+
+  # Use with admin secret:
+  hasura migrate seed --admin-secret "<admin-secret>"`
+
+func newSeedCreateCmd(ec *cli.ExecutionContext) *cobra.Command {
+	v := viper.New()
+	opts := &migrateSeedOptions{
+		EC: ec,
+	}
+
+	migrateSeedCmd := &cobra.Command{
+		Use:          "create [migration-name]",
+		Short:        "Create files required for seeding",
+		Long:         "Create sql files required for seeding",
+		Example:      migrateSeedCmdExamples,
+		SilenceUsage: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			ec.Viper = v
+			return ec.Validate()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.name = args[0]
+			opts.EC.Spin("Creating seed files...")
+			version, err := opts.run()
+			opts.EC.Spinner.Stop()
+			if err != nil {
+				return err
+			}
+			opts.EC.Logger.WithFields(log.Fields{
+				"version": version,
+				"name":    opts.name,
+			}).Info("Seed files created")
+			return nil
+		},
+	}
+	f := migrateSeedCmd.Flags()
+	opts.flags = f
+	f.StringArrayVar(&opts.schemaNames, "schema", []string{"public"}, "name of Postgres schema to export seed data from")
+	f.StringSliceVar(&opts.tableNames, "tables", []string{}, "name of schema tables to create seed data for (optional)")
+	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
+	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
+	f.String("access-key", "", "access key for Hasura GraphQL Engine")
+	f.MarkDeprecated("access-key", "use --admin-secret instead")
+
+	// need to create a new viper because https://github.com/spf13/viper/issues/233
+	v.BindPFlag("endpoint", f.Lookup("endpoint"))
+	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
+	v.BindPFlag("access_key", f.Lookup("access-key"))
+
+	return migrateSeedCmd
+}
+
+type migrateSeedOptions struct {
+	EC *cli.ExecutionContext
+
+	name  string
+	flags *pflag.FlagSet
+
+	// Flags
+	schemaNames []string
+	tableNames  []string
+}
+
+func (o *migrateSeedOptions) run() (version int64, err error) {
+	timestamp := getTimeSeed()
+	createOptions := mig.New(timestamp, o.name, o.EC.SeedDir)
+
+	var migrateDrv *migrate.Migrate
+	migrateDrv, err = newMigrate(o.EC.SeedDir, o.EC.ServerConfig.ParsedEndpoint, o.EC.ServerConfig.AdminSecret, o.EC.Logger, o.EC.Version, true)
+	if err != nil {
+		return 0, errors.Wrap(err, "cannot create seed instance")
+	}
+
+	data, err := migrateDrv.ExportDataDump(o.schemaNames, o.tableNames)
+	if err != nil {
+		return 0, errors.Wrap(err, "cannot fetch schema dump")
+	}
+	createOptions.SetSQLUp(string(data))
+
+	defer func() {
+		if err != nil {
+			createOptions.Delete()
+		}
+	}()
+	err = createOptions.Create()
+	if err != nil {
+		return 0, errors.Wrap(err, "error creating seed files")
+	}
+	return timestamp, nil
+}
+
+func getTimeSeed() int64 {
+	startTime := time.Now()
+	return startTime.UnixNano() / int64(time.Millisecond)
+}

--- a/cli/migrate/database/hasuradb/data_dump.go
+++ b/cli/migrate/database/hasuradb/data_dump.go
@@ -5,18 +5,19 @@ import (
 	"net/http"
 )
 
-func (h *HasuraDB) ExportSchemaDump(schemaNames []string, includeData bool) ([]byte, error) {
-	opts := []string{"--no-owner", "--no-acl"}
-
-	if includeData {
-		opts = append(opts, "--inserts")
-	} else {
-		opts = append(opts, "--schema-only")
-	}
+func (h *HasuraDB) ExportDataDump(schemaNames []string, tableNames []string) ([]byte, error) {
+	opts := []string{"--no-owner", "--no-acl", "--data-only", "--inserts"}
 
 	for _, s := range schemaNames {
 		opts = append(opts, "--schema", s)
 	}
+
+	if len(tableNames) != 0 {
+		for _, t := range tableNames {
+			opts = append(opts, "--table", t)
+		}
+	}
+
 	query := SchemaDump{
 		Opts:        opts,
 		CleanOutput: true,

--- a/cli/migrate/database/schema_dump.go
+++ b/cli/migrate/database/schema_dump.go
@@ -1,5 +1,6 @@
 package database
 
 type SchemaDriver interface {
-	ExportSchemaDump(schemaName []string) ([]byte, error)
+	ExportSchemaDump(schemaNames []string, includeData bool) ([]byte, error)
+	ExportDataDump(schemaNames []string, tableNames []string) ([]byte, error)
 }

--- a/cli/migrate/migrate.go
+++ b/cli/migrate/migrate.go
@@ -325,7 +325,7 @@ func (m *Migrate) ApplyMetadata(data interface{}) error {
 }
 
 func (m *Migrate) ExportSchemaDump(schemName []string, includeData bool) ([]byte, error) {
-	return m.databaseDrv.ExportSchemaDump(schemName, true)
+	return m.databaseDrv.ExportSchemaDump(schemName, includeData)
 }
 
 func (m *Migrate) ExportDataDump(schemName []string, tableNames []string) ([]byte, error) {

--- a/cli/migrate/migrate.go
+++ b/cli/migrate/migrate.go
@@ -324,8 +324,12 @@ func (m *Migrate) ApplyMetadata(data interface{}) error {
 	return m.databaseDrv.ApplyMetadata(data)
 }
 
-func (m *Migrate) ExportSchemaDump(schemName []string) ([]byte, error) {
-	return m.databaseDrv.ExportSchemaDump(schemName)
+func (m *Migrate) ExportSchemaDump(schemName []string, includeData bool) ([]byte, error) {
+	return m.databaseDrv.ExportSchemaDump(schemName, true)
+}
+
+func (m *Migrate) ExportDataDump(schemName []string, tableNames []string) ([]byte, error) {
+	return m.databaseDrv.ExportDataDump(schemName, tableNames)
 }
 
 func (m *Migrate) Query(data []interface{}) error {


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
This PR adds the ability to create and apply seed files for table data from the CLI, closing https://github.com/hasura/graphql-engine/issues/2431.

It also adds the ability to optionally include row data as part of a migration, which would solve the problem with https://github.com/hasura/graphql-engine/issues/2817
### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [x] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
https://github.com/hasura/graphql-engine/issues/2431
https://github.com/hasura/graphql-engine/issues/2817

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
An option `--include-data` was added to `hasura migrate`, which allows users to specify whether or not rows should be included when creating migrations. This is useful for either doing a full-database state migration from an initial server state (IE, prototype your data schema and populate it with seeds before standing up your initial staging instance), or for fixing the bugs where Enums break all migrations due to the Hasura spec that Enums must also contain at least one row.

A new command, `hasura seed` was created with sub-commands `create` and `apply`, which do as they suggest, following the pattern laid out by the `hasura migrate` command (the code from which the `seed` command was initially scaffolded from).
<details>
  <summary><b>🌟 Click to display the new command documentation 👇</b></summary>

  ![image](https://user-images.githubusercontent.com/26604994/71646254-495fba80-2cb3-11ea-8e7a-534815f17860.png)

  ![image](https://user-images.githubusercontent.com/26604994/71646272-a9566100-2cb3-11ea-872d-2fed5a19815f.png)

  ![image](https://user-images.githubusercontent.com/26604994/71646283-c8ed8980-2cb3-11ea-89fc-9c88049aa418.png)

</details>


### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Please view videos here:
[Migrate include data demo](https://cdn.discordapp.com/attachments/466551637683470348/659783099504132096/hasura-include-data-feature.webm)
[Seed demo](https://cdn.discordapp.com/attachments/466551637683470348/661795148870713344/hasura-seed.webm)

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->
I have not written Go prior to this, so it may be that I did not follow best-practices or known patterns. I have scheduled some time with @shahidhk For 10:30PM EST on Sunday, Jan. 5th per the CLI Contributors documentation. I had hoped to use that time to get a better set of eyes on this, as well as discuss how to write tests for the features.

Additionally, I switched the flagset text passed to `pg-loader` from `-o -X` to `--no-owner --no-acl` as they are equivalent but the latter carries more immediate semantic meaning. This way, the purpose should be relatively clear from first-sight rather than having to consult the `pg-loader` docs.

https://github.com/hasura/graphql-engine/blob/71cf0171976ba33eba8ceb60e3c04be87c6bf5f1/cli/migrate/database/hasuradb/schema_dump.go#L8-L9

```go
func (h *HasuraDB) ExportSchemaDump(schemaNames []string, includeData bool) ([]byte, error) {
	opts := []string{"--no-owner", "--no-acl"}

	if includeData {
		opts = append(opts, "--inserts")
	} else {
		opts = append(opts, "--schema-only")
	}
```
### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [ ] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://docs.hasura.io/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
