### PR TITLE
docs: update url for community wiki tools and boilerplates

### DIFF
--- a/docs/graphql/manual/guides/sample-apps/index.rst
+++ b/docs/graphql/manual/guides/sample-apps/index.rst
@@ -65,4 +65,4 @@ Videos
 Boilerplates
 ------------
 
-For boilerplates, please check our community wiki on `Github <https://github.com/hasura/graphql-engine/wiki/Community#tools-and-boilerplates>`__.
+For boilerplates, please check our community wiki on `Github <https://github.com/hasura/graphql-engine/wiki/Community-Wiki#tools-boilerplates--sample-apps>`__.


### PR DESCRIPTION
Before: https://github.com/hasura/graphql-engine/wiki/Community#tools-and-boilerplates 🙃
After: https://github.com/hasura/graphql-engine/wiki/Community-Wiki#tools-boilerplates--sample-apps

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
The github link to boilerplate community wiki page is now working.

### Affected components
<!-- Remove non-affected components from the list -->
- [x] Docs

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Navigate to [Sample Apps/Boilerplates](https://docs.hasura.io/1.0/graphql/manual/guides/sample-apps/index.html#boilerplates`)
Under header Boilerplates click on the 'Github' link.
The web browser navigates to the correct page.