### PR TITLE
Add request timings and count histograms to telemetry. Closes #3552

### DIFF
--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -196,6 +196,7 @@ library
                      , Control.Arrow.Trans
                      , Control.Monad.Stateless
                      , Control.Monad.Unique
+                     , Data.Time.Clock.Units
 
                      -- exposed for tests
                      , Data.Parser.CacheControl
@@ -222,6 +223,8 @@ library
                      , Hasura.Server.Migrate
                      , Hasura.Server.Compression
                      , Hasura.Server.PGDump
+                     -- Exposed for testing:
+                     , Hasura.Server.Telemetry.Counters
 
                      , Hasura.RQL.Types
                      , Hasura.RQL.Types.Run
@@ -358,7 +361,6 @@ library
                      , Data.Sequence.NonEmpty
                      , Data.TByteString
                      , Data.Text.Extended
-                     , Data.Time.Clock.Units
 
                      , Hasura.SQL.DML
                      , Hasura.SQL.Error
@@ -407,9 +409,11 @@ test-suite graphql-engine-tests
   main-is: Main.hs
   other-modules:
     Data.Parser.CacheControlSpec
+    Data.TimeSpec
     Hasura.IncrementalSpec
     Hasura.RQL.MetadataSpec
     Hasura.Server.MigrateSpec
+    Hasura.Server.TelemetrySpec
 
 -- Benchmarks related to caching (e.g. the plan cache).
 --

--- a/server/src-lib/Control/Concurrent/Extended.hs
+++ b/server/src-lib/Control/Concurrent/Extended.hs
@@ -1,5 +1,7 @@
 module Control.Concurrent.Extended
   ( module Control.Concurrent
+  , sleep
+  -- * Deprecated
   , threadDelay
   ) where
 
@@ -8,9 +10,15 @@ import           Prelude
 import qualified Control.Concurrent    as Base
 
 import           Control.Concurrent    hiding (threadDelay)
-import           Data.Time.Clock       (DiffTime)
-import           Data.Time.Clock.Units (Microseconds (..))
+import           Data.Time.Clock.Units (Microseconds (..), DiffTime)
 
--- | Like 'Base.threadDelay', but takes a 'DiffTime' instead of an 'Int'.
-threadDelay :: DiffTime -> IO ()
-threadDelay = Base.threadDelay . round . Microseconds
+-- | Like 'Base.threadDelay', but takes a 'DiffTime' instead of an 'Int' microseconds.
+--
+-- NOTE: you cannot simply replace e.g. @threadDelay 1000@ with @sleep 1000@ since those literals
+-- have different meanings!
+sleep :: DiffTime -> IO ()
+sleep = Base.threadDelay . round . Microseconds
+
+{-# DEPRECATED threadDelay "Please use `sleep` instead (and read the docs!)" #-}
+threadDelay :: Int -> IO ()
+threadDelay = Base.threadDelay

--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Options.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Options.hs
@@ -9,9 +9,6 @@ import           Hasura.Prelude
 
 import qualified Data.Aeson            as J
 
-import           Data.Time.Clock       (DiffTime)
-import           Data.Time.Clock.Units (seconds)
-
 data LiveQueriesOptions
   = LiveQueriesOptions
   { _lqoBatchSize       :: !BatchSize
@@ -21,7 +18,7 @@ data LiveQueriesOptions
 mkLiveQueriesOptions :: Maybe BatchSize -> Maybe RefetchInterval -> LiveQueriesOptions
 mkLiveQueriesOptions batchSize refetchInterval = LiveQueriesOptions
   { _lqoBatchSize = fromMaybe (BatchSize 100) batchSize
-  , _lqoRefetchInterval = fromMaybe (RefetchInterval $ seconds 1) refetchInterval
+  , _lqoRefetchInterval = fromMaybe (RefetchInterval 1) refetchInterval
   }
 
 instance J.ToJSON LiveQueriesOptions where
@@ -33,5 +30,7 @@ instance J.ToJSON LiveQueriesOptions where
 newtype BatchSize = BatchSize { unBatchSize :: Int }
   deriving (Show, Eq, J.ToJSON)
 
+-- TODO this is treated as milliseconds in fromEnv and as seconds in ToJSON. 
+--      ideally this would have e.g. ... unRefetchInterval :: Milliseconds
 newtype RefetchInterval = RefetchInterval { unRefetchInterval :: DiffTime }
   deriving (Show, Eq, J.ToJSON)

--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Poll.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Poll.hs
@@ -71,13 +71,14 @@ data Subscriber
 -- | live query onChange metadata, used for adding more extra analytics data
 data LiveQueryMetadata
   = LiveQueryMetadata
-  { _lqmExecutionTime :: !Clock.NominalDiffTime
+  { _lqmExecutionTime :: !Clock.DiffTime
+  -- ^ Time spent waiting on the generated query to execute on postgres or the remote.
   }
 
 data LiveQueryResponse
   = LiveQueryResponse
   { _lqrPayload       :: !BL.ByteString
-  , _lqrExecutionTime :: !Clock.NominalDiffTime
+  , _lqrExecutionTime :: !Clock.DiffTime
   }
 
 type LGQResponse = GQResult LiveQueryResponse
@@ -324,7 +325,7 @@ pollQuery metrics batchSize pgExecCtx pgQuery handler = do
     queryFinish <- Clock.getCurrentTime
     let dt = Clock.diffUTCTime queryFinish queryInit
         queryTime = realToFrac dt
-        lqMeta = LiveQueryMetadata dt
+        lqMeta = LiveQueryMetadata $ fromUnits dt
         operations = getCohortOperations cohortSnapshotMap lqMeta mxRes
     Metrics.add (_rmQuery metrics) queryTime
 

--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/State.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/State.hs
@@ -18,7 +18,7 @@ import qualified Control.Concurrent.STM                   as STM
 import qualified Data.Aeson.Extended                      as J
 import qualified StmContainers.Map                        as STMMap
 
-import           Control.Concurrent.Extended              (threadDelay)
+import           Control.Concurrent.Extended              (sleep)
 
 import qualified Hasura.GraphQL.Execute.LiveQuery.TMap    as TMap
 
@@ -85,7 +85,7 @@ addLiveQuery lqState plan onResultAction = do
     metrics <- initRefetchMetrics
     threadRef <- A.async $ forever $ do
       pollQuery metrics batchSize pgExecCtx query handler
-      threadDelay $ unRefetchInterval refetchInterval
+      sleep $ unRefetchInterval refetchInterval
     STM.atomically $ STM.putTMVar (_pIOState handler) (PollerIOState threadRef metrics)
 
   pure $ LiveQueryId handlerId cohortKey sinkId

--- a/server/src-lib/Hasura/GraphQL/Transport/HTTP.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/HTTP.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RecordWildCards #-}
 module Hasura.GraphQL.Transport.HTTP
   ( runGQ
   , runGQBatched
@@ -17,6 +18,8 @@ import           Hasura.Server.Version                  (HasVersion)
 import qualified Database.PG.Query                      as Q
 import qualified Hasura.GraphQL.Execute                 as E
 import qualified Hasura.Logging                         as L
+import qualified Hasura.Server.Telemetry.Counters       as Telem
+import qualified Language.GraphQL.Draft.Syntax          as G
 
 runGQ
   :: ( HasVersion
@@ -30,14 +33,25 @@ runGQ
   -> GQLReq GQLQueryText
   -> m (HttpResponse EncJSON)
 runGQ reqId userInfo reqHdrs req = do
-  E.ExecutionCtx _ sqlGenCtx pgExecCtx planCache sc scVer _ enableAL <- ask
-  execPlan <- E.getResolvedExecPlan pgExecCtx planCache
-              userInfo sqlGenCtx enableAL sc scVer req
-  case execPlan of
-    E.GExPHasura resolvedOp ->
-      flip HttpResponse Nothing <$> runHasuraGQ reqId req userInfo resolvedOp
-    E.GExPRemote rsi opDef  ->
-      E.execRemoteGQ reqId userInfo reqHdrs req rsi opDef
+  -- The response and misc telemetry data:
+  let telemTransport = Telem.HTTP
+  (telemTimeTot_DT, (telemCacheHit, telemLocality, (telemTimeIO_DT, telemQueryType, !resp))) <- withElapsedTime $ do
+    E.ExecutionCtx _ sqlGenCtx pgExecCtx planCache sc scVer _ enableAL <- ask
+    (telemCacheHit, execPlan) <- E.getResolvedExecPlan pgExecCtx planCache
+                userInfo sqlGenCtx enableAL sc scVer req
+    case execPlan of
+      E.GExPHasura resolvedOp -> do
+        (telemTimeIO, telemQueryType, resp) <- runHasuraGQ reqId req userInfo resolvedOp
+        return (telemCacheHit, Telem.Local, (telemTimeIO, telemQueryType, HttpResponse resp Nothing))
+      E.GExPRemote rsi opDef  -> do
+        let telemQueryType | G._todType opDef == G.OperationTypeMutation = Telem.Mutation
+                            | otherwise = Telem.Query
+        (telemTimeIO, resp) <- E.execRemoteGQ reqId userInfo reqHdrs req rsi opDef
+        return (telemCacheHit, Telem.Remote, (telemTimeIO, telemQueryType, resp))
+  let telemTimeIO = fromUnits telemTimeIO_DT
+      telemTimeTot = fromUnits telemTimeTot_DT
+  Telem.recordTimingMetric Telem.RequestDimensions{..} Telem.RequestTimings{..}
+  return resp
 
 runGQBatched
   :: ( HasVersion
@@ -75,10 +89,12 @@ runHasuraGQ
   -> GQLReqUnparsed
   -> UserInfo
   -> E.ExecOp
-  -> m EncJSON
+  -> m (DiffTime, Telem.QueryType, EncJSON)
+  -- ^ Also return 'Mutation' when the operation was a mutation, and the time
+  -- spent in the PG query; for telemetry.
 runHasuraGQ reqId query userInfo resolvedOp = do
   E.ExecutionCtx logger _ pgExecCtx _ _ _ _ _ <- ask
-  respE <- liftIO $ runExceptT $ case resolvedOp of
+  (telemTimeIO, respE) <- withElapsedTime $ liftIO $ runExceptT $ case resolvedOp of
     E.ExOpQuery tx genSql  -> do
       -- log the generated SQL and the graphql query
       L.unLogger logger $ QueryLog query genSql reqId
@@ -91,4 +107,6 @@ runHasuraGQ reqId query userInfo resolvedOp = do
       throw400 UnexpectedPayload
       "subscriptions are not supported over HTTP, use websockets instead"
   resp <- liftEither respE
-  return $ encodeGQResp $ GQSuccess $ encJToLBS resp
+  let !json = encodeGQResp $ GQSuccess $ encJToLBS resp
+      telemQueryType = case resolvedOp of E.ExOpMutation{} -> Telem.Mutation ; _ -> Telem.Query
+  return (telemTimeIO, telemQueryType, json)

--- a/server/src-lib/Hasura/Server/Auth.hs
+++ b/server/src-lib/Hasura/Server/Auth.hs
@@ -137,7 +137,7 @@ mkJwtCtx conf httpManager logger = do
       case mTime of
         Nothing -> return ref
         Just t -> do
-          jwkRefreshCtrl logger httpManager url ref t
+          jwkRefreshCtrl logger httpManager url ref (fromUnits t)
           return ref
   let claimsFmt = fromMaybe JCFJson (jcClaimsFormat conf)
   return $ JWTCtx jwkRef (jcClaimNs conf) (jcAudience conf) claimsFmt (jcIssuer conf)

--- a/server/src-lib/Hasura/Server/CheckUpdates.hs
+++ b/server/src-lib/Hasura/Server/CheckUpdates.hs
@@ -8,15 +8,15 @@ import           Control.Monad         (forever)
 import           Data.Text.Conversions (toText)
 
 import qualified CI
-import qualified Control.Concurrent    as C
-import qualified Data.Aeson            as A
-import qualified Data.Aeson.Casing     as A
-import qualified Data.Aeson.TH         as A
-import qualified Data.Text             as T
-import qualified Network.HTTP.Client   as H
-import qualified Network.URI.Encode    as URI
-import qualified Network.Wreq          as Wreq
-import qualified System.Log.FastLogger as FL
+import qualified Control.Concurrent.Extended as C
+import qualified Data.Aeson                  as A
+import qualified Data.Aeson.Casing           as A
+import qualified Data.Aeson.TH               as A
+import qualified Data.Text                   as T
+import qualified Network.HTTP.Client         as H
+import qualified Network.URI.Encode          as URI
+import qualified Network.Wreq                as Wreq
+import qualified System.Log.FastLogger       as FL
 
 import           Hasura.HTTP
 import           Hasura.Logging        (LoggerCtx (..))
@@ -44,7 +44,7 @@ checkForUpdates (LoggerCtx loggerSet _ _ _) manager = do
         when (latestVersion /= currentVersion) $
           FL.pushLogStrLn loggerSet $ FL.toLogStr $ updateMsg latestVersion
 
-    C.threadDelay aDay
+    C.sleep $ days 1
 
   where
     updateMsg v = "Update: A new version is available: " <> toText v
@@ -55,8 +55,6 @@ checkForUpdates (LoggerCtx loggerSet _ _ _) manager = do
       return . buildUrl $ case ciM of
         Nothing -> "server"
         Just ci -> "server-" <> (T.toLower . T.pack $ show ci)
-
-    aDay = 86400 * 1000 * 1000
 
     -- ignoring if there is any error in response and returning the current version
     decodeResp bs = case A.eitherDecode bs of

--- a/server/src-lib/Hasura/Server/SchemaUpdate.hs
+++ b/server/src-lib/Hasura/Server/SchemaUpdate.hs
@@ -18,13 +18,13 @@ import           Data.Aeson.Casing
 import           Data.Aeson.TH
 import           Data.IORef
 
-import qualified Control.Concurrent        as C
-import qualified Control.Concurrent.STM    as STM
-import qualified Data.Text                 as T
-import qualified Data.Time                 as UTC
-import qualified Database.PG.Query         as PG
-import qualified Database.PostgreSQL.LibPQ as PQ
-import qualified Network.HTTP.Client       as HTTP
+import qualified Control.Concurrent.Extended as C
+import qualified Control.Concurrent.STM      as STM
+import qualified Data.Text                   as T
+import qualified Data.Time                   as UTC
+import qualified Database.PG.Query           as PG
+import qualified Database.PostgreSQL.LibPQ   as PQ
+import qualified Network.HTTP.Client         as HTTP
 
 pgChannel :: PG.PGChannel
 pgChannel = "hasura_schema_update"
@@ -126,7 +126,7 @@ listener sqlGenCtx pool logger httpMgr updateEventRef
       liftIO $ runExceptT $ PG.listen pool pgChannel notifyHandler
     either onError return listenResE
     logWarn
-    C.threadDelay $ 1 * 1000 * 1000 -- 1 second
+    C.sleep $ seconds 1
   where
     threadType = TTListener
 

--- a/server/src-lib/Hasura/Server/Telemetry/Counters.hs
+++ b/server/src-lib/Hasura/Server/Telemetry/Counters.hs
@@ -1,0 +1,183 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-|
+  Counters used in telemetry collection. Additional counters can be added here.and
+  serviced in "Hasura.Server.Telemetry".
+-}
+
+module Hasura.Server.Telemetry.Counters
+  (
+  -- * Service timing and counts, by various dimensions
+  -- ** Local metric recording
+    recordTimingMetric
+  , RequestDimensions(..), RequestTimings(..)
+  -- *** Dimensions
+  , CacheHit(..), QueryType(..), Locality(..), Transport(..)
+  -- ** Metric upload
+  , dumpServiceTimingMetrics
+  , ServiceTimingMetrics(..)
+  , ServiceTimingMetric(..)
+  , RunningTimeBucket(..)
+  , RequestTimingsCount(..)
+  )
+  where
+
+import qualified Data.Aeson            as A
+import qualified Data.Aeson.Casing     as A
+import qualified Data.Aeson.TH         as A
+import           Data.Hashable
+import qualified Data.HashMap.Strict   as HM
+import           Data.IORef
+import           Data.Time.Clock.POSIX (POSIXTime, getPOSIXTime)
+import           GHC.IO.Unsafe         (unsafePerformIO)
+import           Hasura.Prelude
+
+-- | The properties that characterize this request. The dimensions over which
+-- we collect metrics for each serviced request.
+data RequestDimensions =
+  RequestDimensions {
+        telemCacheHit  :: !CacheHit
+      , telemQueryType :: !QueryType
+      , telemLocality  :: !Locality
+      , telemTransport :: !Transport
+      }
+      deriving (Show, Generic, Eq)
+
+instance Hashable RequestDimensions
+
+
+-- | Accumulated time metrics.
+data RequestTimings  =
+  RequestTimings {
+      telemTimeIO  :: !Seconds
+    -- ^ Time spent waiting on PG/remote http calls
+    , telemTimeTot :: !Seconds
+    -- ^ Total service time for request (including 'telemTimeIO')
+    }
+
+-- | Sum
+instance Semigroup RequestTimings where
+  RequestTimings a b <> RequestTimings x y = RequestTimings (a+x) (b+y)
+
+-- | 'RequestTimings' along with the count
+data RequestTimingsCount  =
+  RequestTimingsCount {
+      telemTimeIO  :: !Seconds
+    , telemTimeTot :: !Seconds
+    , telemCount   :: !Word
+    -- ^ The number of requests that have contributed to the accumulated timings above.
+    -- So e.g. @telemTimeTot / count@ would give the mean service time.
+    }
+      deriving (Show, Generic, Eq)
+
+-- | Sum
+instance Semigroup RequestTimingsCount where
+  RequestTimingsCount a b c <> RequestTimingsCount x y z =
+    RequestTimingsCount (a+x) (b+y) (c+z)
+
+-- | Internal. Counts and durations across many 'RequestDimensions'.
+--
+-- NOTE: We use the global mutable variable pattern for metric collection
+-- counters for convenience at collection site (don't wear hairshirts that
+-- discourage useful reporting).
+requestCounters :: IORef (HM.HashMap (RequestDimensions, RunningTimeBucket) RequestTimingsCount)
+{-# NOINLINE requestCounters #-}
+requestCounters = unsafePerformIO $ newIORef HM.empty
+
+-- | Internal. Since these metrics are accumulated while graphql-engine is
+-- running and sent periodically, we need to include a tag that is unique for
+-- each start of hge. This lets us e.g. query for just the latest uploaded
+-- sample for each start of hge.
+--
+-- We use time rather than a UUID since having this be monotonic increasing is
+-- convenient.
+approxStartTime :: POSIXTime
+{-# NOINLINE approxStartTime #-}
+approxStartTime = unsafePerformIO getPOSIXTime
+
+-- | Did this request hit the plan cache?
+data CacheHit = Hit | Miss
+  deriving (Enum, Show, Eq, Generic)
+instance Hashable CacheHit
+instance A.ToJSON CacheHit
+instance A.FromJSON CacheHit
+
+-- | Was this request a mutation (involved DB writes)?
+data QueryType = Mutation | Query
+  deriving (Enum, Show, Eq, Generic)
+instance Hashable QueryType
+instance A.ToJSON QueryType
+instance A.FromJSON QueryType
+
+-- | Was this a PG local query, or did it involve remote execution?
+data Locality = Local | Remote
+  deriving (Enum, Show, Eq, Generic)
+instance Hashable Locality
+instance A.ToJSON Locality
+instance A.FromJSON Locality
+
+-- | Was this a query over http or websockets?
+data Transport = HTTP | WebSocket
+  deriving (Enum, Show, Eq, Generic)
+instance Hashable Transport
+instance A.ToJSON Transport
+instance A.FromJSON Transport
+
+-- | The timings and counts here were from requests with total time longer than
+-- 'bucketGreaterThan' (but less than any larger bucket cutoff times).
+newtype RunningTimeBucket = RunningTimeBucket { bucketGreaterThan :: Seconds }
+  deriving (Fractional, Num, Ord, Eq, Show, Generic, A.ToJSON, A.FromJSON, Hashable)
+
+
+-- NOTE: an HDR histogram is a nice way to collect metrics when you don't know
+-- a priori what the most useful binning is. It's not clear how we'd make use
+-- of that here though.
+totalTimeBuckets :: [RunningTimeBucket]
+totalTimeBuckets = [0, 1000, 10*1000, 100*1000]
+
+-- | Save a timing metric sample in our in-memory store. These will be
+-- accumulated and uploaded periodically in "Hasura.Server.Telemetry".
+recordTimingMetric :: MonadIO m=> RequestDimensions -> RequestTimings -> m ()
+recordTimingMetric reqDimensions RequestTimings{..} = liftIO $ do
+  let ourBucket = fromMaybe 0 $ -- although we expect 'head' would be safe here
+        listToMaybe $ dropWhile (> realToFrac telemTimeTot) $
+        reverse $ sort totalTimeBuckets
+  atomicModifyIORef' requestCounters $ (,()) .
+    HM.insertWith (<>) (reqDimensions, ourBucket) RequestTimingsCount{telemCount = 1, ..}
+
+-- | The final shape of this part of our metrics data JSON. This should allow
+-- reasonably efficient querying using GIN indexes and JSONB containment
+-- operations (which treat arrays as sets).
+data ServiceTimingMetrics 
+  = ServiceTimingMetrics
+  { collectionTag        :: Int
+    -- ^ This is set to a new unique value when the counters reset (e.g. because of a restart)
+  , serviceTimingMetrics :: [ServiceTimingMetric]
+  } 
+  deriving (Show, Generic, Eq)
+data ServiceTimingMetric 
+  = ServiceTimingMetric
+  { dimensions :: RequestDimensions
+  , bucket   :: RunningTimeBucket
+  , metrics  :: RequestTimingsCount
+  }
+  deriving (Show, Generic, Eq)
+
+
+$(A.deriveJSON (A.aesonDrop 5 A.snakeCase) ''RequestTimingsCount) 
+$(A.deriveJSON (A.aesonDrop 5 A.snakeCase) ''RequestDimensions) 
+
+instance A.ToJSON ServiceTimingMetric
+instance A.FromJSON ServiceTimingMetric
+instance A.ToJSON ServiceTimingMetrics
+instance A.FromJSON ServiceTimingMetrics
+
+dumpServiceTimingMetrics :: MonadIO m=> m ServiceTimingMetrics
+dumpServiceTimingMetrics = liftIO $ do
+  cs <- readIORef requestCounters
+  let serviceTimingMetrics = flip map (HM.toList cs) $
+        \((dimensions, bucket), metrics)-> ServiceTimingMetric{..}
+      collectionTag = round approxStartTime
+  return ServiceTimingMetrics{..}
+
+

--- a/server/src-lib/Hasura/Server/Utils.hs
+++ b/server/src-lib/Hasura/Server/Utils.hs
@@ -4,7 +4,6 @@ module Hasura.Server.Utils where
 import           Data.Aeson
 import           Data.Char
 import           Data.List                  (find)
-import           Data.Time.Clock
 import           Language.Haskell.TH.Syntax (Lift)
 import           System.Environment
 import           System.Exit
@@ -117,13 +116,6 @@ fmapL :: (a -> a') -> Either a b -> Either a' b
 fmapL fn (Left e) = Left (fn e)
 fmapL _ (Right x) = pure x
 
--- diff time to micro seconds
-diffTimeToMicro :: NominalDiffTime -> Int
-diffTimeToMicro diff =
-  floor (realToFrac diff :: Double) * aSecond
-  where
-    aSecond = 1000 * 1000
-
 generateFingerprint :: IO Text
 generateFingerprint = UUID.toText <$> UUID.nextRandom
 
@@ -223,10 +215,3 @@ makeReasonMessage errors showError =
     [singleError] -> "because " <> showError singleError
     _ -> "for the following reasons:\n" <> T.unlines
          (map (("  • " <>) . showError) errors)
-
-withElapsedTime :: MonadIO m => m a -> m (NominalDiffTime, a)
-withElapsedTime ma = do
-  t1 <- liftIO getCurrentTime
-  a <- ma
-  t2 <- liftIO getCurrentTime
-  return (diffUTCTime t2 t1, a)

--- a/server/src-test/Data/TimeSpec.hs
+++ b/server/src-test/Data/TimeSpec.hs
@@ -1,0 +1,44 @@
+module Data.TimeSpec (spec) where
+-- | Time-related properties we care about.
+
+import Prelude
+import Data.Time.Clock.Units
+import Data.Time
+import Data.Aeson
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  timeUnitsSpec
+  diffTimeSpec
+
+timeUnitsSpec :: Spec
+timeUnitsSpec =
+  describe "time units" $ do
+    it "converts correctly" $ do
+      seconds 123 `shouldBe` 123
+      milliseconds 123 `shouldBe` 0.123
+      microseconds 123 `shouldBe` 0.000123
+      nanoseconds 123 `shouldBe` 0.000000123
+
+    it "has a correct Read instance" $ do
+      seconds (read "123") `shouldBe` 123
+      milliseconds (read "123") `shouldBe` 0.123
+      microseconds (read "123") `shouldBe` 0.000123
+      nanoseconds (read "123") `shouldBe` 0.000000123
+
+    it "JSON serializes as proper units" $ do
+      toJSON (1 :: Seconds) `shouldBe` Number 1
+      decode "1.0" `shouldBe` Just (1 :: Seconds)
+
+    it "converts with fromUnits" $ do
+      fromUnits (2 :: Minutes) `shouldBe` (120 :: NominalDiffTime)
+      fromUnits (60 :: Seconds) `shouldBe` (1 :: Minutes)
+
+diffTimeSpec :: Spec
+diffTimeSpec =
+  describe "DiffTime" $ do
+    it "JSON serializes as seconds" $ do
+    -- although we would prefer to use Seconds instead...
+      toJSON (1 :: DiffTime) `shouldBe` Number 1
+      decode "1.0" `shouldBe` Just (1 :: DiffTime)

--- a/server/src-test/Hasura/Server/TelemetrySpec.hs
+++ b/server/src-test/Hasura/Server/TelemetrySpec.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+module Hasura.Server.TelemetrySpec (spec) where
+
+import           Hasura.Prelude
+
+import qualified Data.Aeson                       as A
+import           Hasura.Server.Telemetry.Counters
+import           Test.Hspec
+
+spec :: Spec
+spec = do
+  telemetryCountersTests
+
+-- NOTE: this test is effectful/stateful; if we need to we can implement an
+-- operation to clear metric store.
+telemetryCountersTests :: Spec
+telemetryCountersTests = do
+  describe "request timing counters" $ do
+    it "is at first empty" $ do
+      fmap serviceTimingMetrics dumpServiceTimingMetrics `shouldReturn` []
+
+    -- excercise accumulating and buckets:
+    let expected =
+          -- NOTE: ordering is arbitrary here (and hence fragile)
+          [ServiceTimingMetric {
+              dimensions = RequestDimensions Hit Mutation Local HTTP
+            , bucket = RunningTimeBucket {bucketGreaterThan =        0}
+            , metrics = RequestTimingsCount {telemTimeIO = 2, telemTimeTot = 200, telemCount = 2}},
+          ServiceTimingMetric {
+              dimensions = RequestDimensions Miss Mutation Local HTTP
+            , bucket = RunningTimeBucket {bucketGreaterThan      = 1000}
+            , metrics = RequestTimingsCount {telemTimeIO = 2, telemTimeTot = 2002, telemCount = 2}},
+          ServiceTimingMetric {
+              dimensions = RequestDimensions Hit Query Remote WebSocket
+            , bucket = RunningTimeBucket {bucketGreaterThan      = 100000}
+            , metrics = RequestTimingsCount {telemTimeIO = 1, telemTimeTot = 100001, telemCount = 1}}]
+
+    it "accumulates as expected" $ do
+      recordTimingMetric (RequestDimensions Hit  Mutation Local  HTTP) (RequestTimings 1 100)
+      recordTimingMetric (RequestDimensions Hit  Mutation Local  HTTP) (RequestTimings 1 100)
+      recordTimingMetric (RequestDimensions Miss Mutation Local  HTTP) (RequestTimings 1 1001)
+      recordTimingMetric (RequestDimensions Miss Mutation Local  HTTP) (RequestTimings 1 1001)
+      recordTimingMetric (RequestDimensions Hit  Query    Remote WebSocket) (RequestTimings 1 100001)
+      fmap serviceTimingMetrics dumpServiceTimingMetrics `shouldReturn` expected
+
+    it "serializes and deserializes properly" $ do
+      fmap (fmap serviceTimingMetrics . A.eitherDecode . A.encode) dumpServiceTimingMetrics
+        `shouldReturn` Right expected

--- a/server/src-test/Main.hs
+++ b/server/src-test/Main.hs
@@ -20,8 +20,9 @@ import qualified Test.Hspec.Runner            as Hspec
 import           Hasura.Db                    (PGExecCtx (..))
 import           Hasura.RQL.Types             (SQLGenCtx (..), adminUserInfo)
 import           Hasura.RQL.Types.Run
-import           Hasura.Server.Init           (RawConnInfo, mkConnInfo, mkRawConnInfo,
-                                               parseRawConnInfo, runWithEnv)
+import           Hasura.Server.Init          (RawConnInfo, mkConnInfo,
+                                              mkRawConnInfo, parseRawConnInfo,
+                                              runWithEnv)
 import           Hasura.Server.Migrate
 import           Hasura.Server.Version
 
@@ -29,6 +30,8 @@ import qualified Data.Parser.CacheControlSpec as CacheControlParser
 import qualified Hasura.IncrementalSpec       as IncrementalSpec
 import qualified Hasura.RQL.MetadataSpec      as MetadataSpec
 import qualified Hasura.Server.MigrateSpec    as MigrateSpec
+import qualified Data.TimeSpec               as TimeSpec
+import qualified Hasura.Server.TelemetrySpec as TelemetrySpec
 
 data TestSuites
   = AllSuites !RawConnInfo
@@ -55,6 +58,8 @@ unitSpecs = do
   describe "Data.Parser.CacheControl" CacheControlParser.spec
   describe "Hasura.Incremental" IncrementalSpec.spec
   describe "Hasura.RQL.Metadata" MetadataSpec.spec
+  describe "Data.Time" TimeSpec.spec
+  describe "Hasura.Server.Telemetry" TelemetrySpec.spec
 
 buildPostgresSpecs :: (HasVersion) => RawConnInfo -> IO Spec
 buildPostgresSpecs pgConnOptions = do


### PR DESCRIPTION
We upload a set of accumulating timers and counters to track service
time for different types of operations, across several dimensions (e.g.
did we hit the plan cache, was a remote involved, etc.)

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [x] Tests

### Related Issues
#3552 although metrics should hopefully give us general visibility into performance

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
run tests

### Limitations, known bugs & workarounds
- marked an unsafe forked thread as `TODO immortal`, but we should fix all of these together (see #3768 )
- I didn't document changes in `telemetry.rst`; that doc is already stale. It would be nice if we could generate it from tests

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://docs.hasura.io/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
