### PR TITLE
cli(fix): execute down migration in the correct order

### DIFF
--- a/cli/migrate/migrate.go
+++ b/cli/migrate/migrate.go
@@ -803,7 +803,7 @@ func (m *Migrate) read(version uint64, direction string, ret chan<- interface{})
 		prev, err := m.sourceDrv.Prev(version)
 		if os.IsNotExist(err) {
 			// apply nil migration
-			migr, err := m.newMigration(version, -1)
+			migr, err := m.metanewMigration(version, -1)
 			if err != nil {
 				ret <- err
 				return
@@ -811,7 +811,7 @@ func (m *Migrate) read(version uint64, direction string, ret chan<- interface{})
 			ret <- migr
 			go migr.Buffer()
 
-			migr, err = m.metanewMigration(version, -1)
+			migr, err = m.newMigration(version, -1)
 			if err != nil {
 				ret <- err
 				return
@@ -824,7 +824,7 @@ func (m *Migrate) read(version uint64, direction string, ret chan<- interface{})
 			return
 		}
 
-		migr, err := m.newMigration(version, int64(prev))
+		migr, err := m.metanewMigration(version, int64(prev))
 		if err != nil {
 			ret <- err
 			return
@@ -833,7 +833,7 @@ func (m *Migrate) read(version uint64, direction string, ret chan<- interface{})
 		ret <- migr
 		go migr.Buffer()
 
-		migr, err = m.metanewMigration(version, int64(prev))
+		migr, err = m.newMigration(version, int64(prev))
 		if err != nil {
 			ret <- err
 			return


### PR DESCRIPTION
### Description
CLI doesn't execute migration in the correct order for `--version` flag.
This PR fixes the execution order for down migration.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [x] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
#3621 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [ ] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://docs.hasura.io/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [ ] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [ ] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [ ] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
