### PR TITLE
Add text type suggestion in column edits for all data types in console (close #2583)

### DIFF
--- a/console/src/components/Services/Data/TableModify/utils.js
+++ b/console/src/components/Services/Data/TableModify/utils.js
@@ -35,7 +35,20 @@ const getValidAlterOptions = (alterTypeOptions, colName) => {
       ...currentMap,
     };
   }
-
+  // adding text object
+  const text = {
+    value: 'text',
+    label: 'text',
+    key: 'item_0',
+    colIdentifier: 0,
+    description: 'variable-length string, no limit specified',
+  };
+  if (!allOptionsMap.hasOwnProperty('text')) {
+    allOptionsMap.text = text;
+  }
+  if (!allInfo.some(e => e.value === 'text')) {
+    allInfo.push(text);
+  }
   return {
     alterOptions: allInfo,
     alterOptionsValueMap: allOptionsMap,


### PR DESCRIPTION
### Description
This PR adds `text` type as a suggestion when editing columns on the console. Instead of doing
`alter table <table> alter column <column> type text;` as a raw sql query, the type can be chosen from the suggestion box itself. 

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Console

### Related Issues

#2583 

### Solution and Design
The way to make this `text` type available for all types was to insert the text object in the options array in the codebase and doing a conditional check before mutation to avoid duplication.

### Steps to test and verify
Go to the console and try to edit any column and search for text type in the suggestion box.