### PR TITLE
cli: fix version constraint for update check (close #3719)

### DIFF
--- a/cli/update/update.go
+++ b/cli/update/update.go
@@ -99,7 +99,7 @@ func HasUpdate(currentVersion *semver.Version, timeFile string) (bool, *semver.V
 		return false, nil, errors.Wrap(err, "get latest version")
 	}
 
-	c, err := semver.NewConstraint(fmt.Sprintf("> %s-0", currentVersion.String()))
+	c, err := semver.NewConstraint(fmt.Sprintf("> %s", currentVersion.String()))
 	if err != nil {
 		return false, nil, errors.Wrap(err, "semver constraint build")
 	}


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
https://github.com/hasura/graphql-engine/commit/f6a43fe3baeaeb91c96626f0cea3ccb5d0f2f5ec changed the semver check constraint that compares latest and current cli versions for update checks. If current version is `v1.0.0` and latest version is also `v1.0.0`, cli updates itself even though the versions are the same. This is because the constraint adds a `-0` and effectively `1.0.0-0` is behind `1.0.0`.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] CLI


### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
close #3719 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
The constraint is changed back to how it was. Since we don't publish pre-release versions via the API this won't cause any issues with update checks.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Build CLI with `v1.0.0` and execute `hasura update-cli`, earlier cli updates itself to v1.0.0 but now it says already at updated version.

