### PR TITLE
circleci: update workflow id

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -482,7 +482,7 @@ jobs:
 
 workflows:
   version: 2
-  workflow_v20190516:
+  workflow_v20200120:
     jobs:
     - check_build_worthiness: *filter_only_vtags
     - build_console:


### PR DESCRIPTION
### Description
To integrate changes introduced in https://github.com/hasura/graphql-engine/commit/1dd63a9386413cf070af40943b52f2fe2c5bf7ca with our internal CI/CD system, this PR updates the CircleCI workflow id to `workflow_v20200120`.