### PR TITLE
Store console headers in state instead of local storage

### DIFF
--- a/console/src/components/Services/ApiExplorer/ApiRequest/ApiRequest.js
+++ b/console/src/components/Services/ApiExplorer/ApiRequest/ApiRequest.js
@@ -67,6 +67,7 @@ class ApiRequest extends Component {
         error: null,
         serverResp: {},
       },
+      hasuraConsoleHeaders: {},
     };
 
     if (this.props.numberOfTables !== 0) {
@@ -81,9 +82,11 @@ class ApiRequest extends Component {
   }
 
   componentDidMount() {
+    const { hasuraConsoleHeaders } = this.state;
     const handleHeaderInit = () => {
       const graphiqlHeaders =
-        getPersistedGraphiQLHeaders() || getDefaultGraphiqlHeaders();
+        getPersistedGraphiQLHeaders(hasuraConsoleHeaders) ||
+        getDefaultGraphiqlHeaders();
 
       // if admin secret is set and admin secret header was ever added to headers, add admin secret header if not already present
       const adminSecret = getAdminSecret();
@@ -132,7 +135,7 @@ class ApiRequest extends Component {
       });
 
       // persist headers to local storage
-      persistGraphiQLHeaders(graphiqlHeaders);
+      persistGraphiQLHeaders(graphiqlHeaders, this.setConsoleHeaders);
 
       // set headers in redux
       this.props.dispatch(setHeadersBulk(graphiqlHeaders));
@@ -205,6 +208,10 @@ class ApiRequest extends Component {
         });
     }
   }
+
+  setConsoleHeaders = headers => {
+    this.setState({ hasuraConsoleHeaders: headers });
+  };
 
   render() {
     const { isAnalyzingToken, tokenInfo, analyzingHeaderRow } = this.state;
@@ -290,7 +297,7 @@ class ApiRequest extends Component {
           const index = parseInt(e.target.getAttribute('data-header-id'), 10);
           this.props
             .dispatch(removeRequestHeader(index))
-            .then(r => persistGraphiQLHeaders(r));
+            .then(r => persistGraphiQLHeaders(r, this.setConsoleHeaders));
         };
 
         const onHeaderValueChanged = e => {
@@ -299,7 +306,7 @@ class ApiRequest extends Component {
           const newValue = e.target.value;
           this.props
             .dispatch(changeRequestHeader(index, key, newValue, false))
-            .then(r => persistGraphiQLHeaders(r));
+            .then(r => persistGraphiQLHeaders(r, this.setConsoleHeaders));
         };
 
         const onShowAdminSecretClicked = () => {

--- a/console/src/components/Services/ApiExplorer/ApiRequest/utils.js
+++ b/console/src/components/Services/ApiExplorer/ApiRequest/utils.js
@@ -69,7 +69,7 @@ export const getPersistedAdminSecretHeaderWasAdded = () => {
   return lsValue ? lsValue === 'true' : false;
 };
 
-export const persistGraphiQLHeaders = headers => {
+export const persistGraphiQLHeaders = (headers, setHeaders) => {
   // filter empty headers
   const validHeaders = headers.filter(h => h.key);
 
@@ -84,16 +84,11 @@ export const persistGraphiQLHeaders = headers => {
     return maskedHeader;
   });
 
-  window.localStorage.setItem(
-    'HASURA_CONSOLE_GRAPHIQL_HEADERS',
-    JSON.stringify(maskedHeaders)
-  );
+  setHeaders(maskedHeaders);
 };
 
-export const getPersistedGraphiQLHeaders = () => {
-  const headersString = window.localStorage.getItem(
-    'HASURA_CONSOLE_GRAPHIQL_HEADERS'
-  );
+export const getPersistedGraphiQLHeaders = consoleHeaders => {
+  const headersString = consoleHeaders;
 
   let headers = null;
   if (headersString) {


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Change the way headers are stored and accessed by Explorer

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Console

### Related Issues


### Solution and Design
Store headers in ApiRequest state instead of local storage. 

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
This is mainly to avoid storing idToken for hasura pro in the local storage.

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [ ] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://docs.hasura.io/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [ ] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [ ] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [ ] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
