### PR TITLE
console: fixed create if not exists issue (fix #3766)

### DIFF
--- a/console/src/components/Services/Data/RawSQL/utils.js
+++ b/console/src/components/Services/Data/RawSQL/utils.js
@@ -1,7 +1,5 @@
 const createSQLRegex = /create\s*(?:|or\s*replace)\s*(view|table|function)\s*(?:\s*if*\s*not\s*exists\s*)?((\"?\w+\"?)\.(\"?\w+\"?)|(\"?\w+\"?))/; // eslint-disable-line
 
-const createSQLRegexNoFunction = /create\s*(?:|or\s*replace)\s*(view|table)\s*((\"?\w+\"?)\.(\"?\w+\"?)|(\"?\w+\"?))/; // eslint-disable-line
-
 const getSQLValue = value => {
   const quotedStringRegex = /^".*"$/;
 
@@ -54,6 +52,5 @@ const parseCreateSQL = sql => {
 
 export {
   createSQLRegex,
-  createSQLRegexNoFunction,
   parseCreateSQL
 };

--- a/console/src/components/Services/Data/RawSQL/utils.js
+++ b/console/src/components/Services/Data/RawSQL/utils.js
@@ -1,4 +1,4 @@
-const createSQLRegex = /create\s*(?:|or\s*replace)\s*(view|table|function)\s*((\"?\w+\"?)\.(\"?\w+\"?)|(\"?\w+\"?))/; // eslint-disable-line
+const createSQLRegex = /create\s*(?:|or\s*replace)\s*(view|table|function)\s*(?:\s*if*\s*not\s*exists\s*)?((\"?\w+\"?)\.(\"?\w+\"?)|(\"?\w+\"?))/; // eslint-disable-line
 
 const createSQLRegexNoFunction = /create\s*(?:|or\s*replace)\s*(view|table)\s*((\"?\w+\"?)\.(\"?\w+\"?)|(\"?\w+\"?))/; // eslint-disable-line
 
@@ -52,4 +52,8 @@ const parseCreateSQL = sql => {
   return _objects;
 };
 
-export { createSQLRegex, createSQLRegexNoFunction, parseCreateSQL };
+export {
+  createSQLRegex,
+  createSQLRegexNoFunction,
+  parseCreateSQL
+};


### PR DESCRIPTION
### Description
Raw SQL feature on console takes "IF" as the name of the create statement if "IF NOT EXISTS" was included in the query after the create type.

### Affected components
- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
#3766

### Solution and Design
Updated the [createSQLRegex](https://github.com/hasura/graphql-engine/blob/8a9901d417c1cde1e74744188779ad179c190120/console/src/components/Services/Data/RawSQL/utils.js#L1) to exclude "IF NOT EXISTS" while parseing create SQL

### Steps to test and verify

1. Go to Data > SQL
2. Attempt to create a table
```sql
CREATE TABLE IF NOT EXISTS Persons (
    PersonID int,
    LastName varchar(255),
    FirstName varchar(255),
    Address varchar(255),
    City varchar(255)
);
```
3. It won't try to take "IF" as the table name

<!--- ### Limitations, known bugs & workarounds -->