### PR TITLE
fix update event trigger & dropping triggers on `run_sql` (fix #3803, #3784)

### DIFF
--- a/server/src-lib/Hasura/App.hs
+++ b/server/src-lib/Hasura/App.hs
@@ -241,7 +241,7 @@ runHGEServer ServeOptions{..} InitCtx{..} initTime = do
                      $ Warp.defaultSettings
 
   maxEvThrds <- liftIO $ getFromEnv defaultMaxEventThreads "HASURA_GRAPHQL_EVENTS_HTTP_POOL_SIZE"
-  fetchI  <- fmap milliseconds $ liftIO $ 
+  fetchI  <- fmap milliseconds $ liftIO $
     getFromEnv defaultFetchIntervalMilliSec "HASURA_GRAPHQL_EVENTS_FETCH_INTERVAL"
   logEnvHeaders <- liftIO $ getFromEnv False "LOG_HEADERS_FROM_ENV"
 

--- a/server/src-lib/Hasura/RQL/DDL/EventTrigger.hs
+++ b/server/src-lib/Hasura/RQL/DDL/EventTrigger.hs
@@ -12,8 +12,9 @@ module Hasura.RQL.DDL.EventTrigger
   , subTableP2
   , subTableP2Setup
   , mkAllTriggersQ
+  , delTriggerQ
   , getEventTriggerDef
-  , updateEventTriggerDef
+  , updateEventTriggerInCatalog
   ) where
 
 import           Data.Aeson
@@ -143,22 +144,13 @@ delEventTriggerFromCatalog trn = do
   delTriggerQ trn
   archiveEvents trn
 
-archiveEvents:: TriggerName -> Q.TxE QErr ()
+archiveEvents :: TriggerName -> Q.TxE QErr ()
 archiveEvents trn = do
   Q.unitQE defaultTxErrorHandler [Q.sql|
            UPDATE hdb_catalog.event_log
            SET archived = 't'
            WHERE trigger_name = $1
                 |] (Identity trn) False
-
-updateEventTriggerToCatalog
-  :: EventTriggerConf
-  -> Q.TxE QErr ()
-updateEventTriggerToCatalog etc = do
-  updateEventTriggerDef name etc
-  delTriggerQ name
-  where
-    EventTriggerConf name _ _ _ _ _ = etc
 
 fetchEvent :: EventId -> Q.TxE QErr (EventId, Bool)
 fetchEvent eid = do
@@ -252,7 +244,7 @@ subTableP2
   :: (MonadTx m)
   => QualifiedTable -> Bool -> EventTriggerConf -> m ()
 subTableP2 qt replace etc = liftTx if replace
-  then updateEventTriggerToCatalog etc
+  then updateEventTriggerInCatalog etc
   else addEventTriggerToCatalog qt etc
 
 runCreateEventTriggerQuery
@@ -353,13 +345,12 @@ getEventTriggerDef triggerName = do
            |] (Identity triggerName) False
   return (QualifiedObject sn tn, etc)
 
-updateEventTriggerDef
-  :: TriggerName -> EventTriggerConf -> Q.TxE QErr ()
-updateEventTriggerDef trigName trigConf =
+updateEventTriggerInCatalog :: EventTriggerConf -> Q.TxE QErr ()
+updateEventTriggerInCatalog trigConf =
   Q.unitQE defaultTxErrorHandler
     [Q.sql|
       UPDATE hdb_catalog.event_triggers
       SET
       configuration = $1
       WHERE name = $2
-    |] (Q.AltJ $ toJSON trigConf, trigName) True
+    |] (Q.AltJ $ toJSON trigConf, etcName trigConf) True

--- a/server/src-lib/Hasura/RQL/DDL/Schema.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema.hs
@@ -85,7 +85,7 @@ instance ToJSON RunSQL where
           Q.ReadWrite -> False
       ]
 
-runRunSQL :: (MonadTx m, CacheRWM m) => RunSQL -> m EncJSON
+runRunSQL :: (MonadTx m, CacheRWM m, HasSQLGenCtx m) => RunSQL -> m EncJSON
 runRunSQL RunSQL {..} = do
   metadataCheckNeeded <- onNothing rCheckMetadataConsistency $ isAltrDropReplace rSql
   bool (execRawSQL rSql) (withMetadataCheck rCascade $ execRawSQL rSql) metadataCheckNeeded

--- a/server/src-lib/Hasura/RQL/DDL/Schema/Cache.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Cache.hs
@@ -264,7 +264,8 @@ buildSchemaCacheRule = proc inputs -> do
         recreateViewIfNeeded = Inc.cache $
           arrM \(tableName, tableColumns, triggerName, triggerDefinition) -> do
             buildReason <- ask
-            when (buildReason == CatalogUpdate) $
+            when (buildReason == CatalogUpdate) $ do
+              liftTx $ delTriggerQ triggerName -- executes DROP IF EXISTS.. sql
               mkAllTriggersQ triggerName tableName (M.elems tableColumns) triggerDefinition
 
     addRemoteSchema
@@ -289,7 +290,7 @@ buildSchemaCacheRule = proc inputs -> do
 -- | @'withMetadataCheck' cascade action@ runs @action@ and checks if the schema changed as a
 -- result. If it did, it checks to ensure the changes do not violate any integrity constraints, and
 -- if not, incorporates them into the schema cache.
-withMetadataCheck :: (MonadTx m, CacheRWM m) => Bool -> m a -> m a
+withMetadataCheck :: (MonadTx m, CacheRWM m, HasSQLGenCtx m) => Bool -> m a -> m a
 withMetadataCheck cascade action = do
   -- Drop hdb_views so no interference is caused to the sql query
   liftTx $ Q.catchE defaultTxErrorHandler clearHdbViews
@@ -346,7 +347,17 @@ withMetadataCheck cascade action = do
   processSchemaChanges schemaDiff
 
   buildSchemaCache
-  currentInconsistentObjs <- scInconsistentObjs <$> askSchemaCache
+  postSc <- askSchemaCache
+
+  -- Recreate event triggers in hdb_views
+  forM_ (M.elems $ scTables postSc) $ \(TableInfo coreInfo _ eventTriggers) -> do
+          let table = _tciName coreInfo
+              columns = getCols $ _tciFieldInfoMap coreInfo
+          forM_ (M.toList eventTriggers) $ \(triggerName, eti) -> do
+            let opsDefinition = etiOpsDef eti
+            mkAllTriggersQ triggerName table columns opsDefinition
+
+  let currentInconsistentObjs = scInconsistentObjs postSc
   checkNewInconsistentMeta existingInconsistentObjs currentInconsistentObjs
 
   return res

--- a/server/src-lib/Hasura/RQL/DDL/Schema/Rename.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Rename.hs
@@ -349,7 +349,7 @@ updateColInEventTriggerDef
   => TriggerName -> RenameCol -> m ()
 updateColInEventTriggerDef trigName rnCol = do
   (trigTab, trigDef) <- liftTx $ DS.getEventTriggerDef trigName
-  void $ liftTx $ DS.updateEventTriggerDef trigName $
+  void $ liftTx $ DS.updateEventTriggerInCatalog $
     rewriteEventTriggerConf trigTab trigDef
   where
     rewriteSubsCols trigTab = \case


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

This PR fixes the following issues:-

#3784 - Event triggers are lost on `run_sql` DDL queries.
#3803 - Event trigger is being wiped on recreating

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server


### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#3784 #3803 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

**3784**:- Recreate all event triggers at the end of a `run_sql` DDL query. 
**3803**:- Move delete trigger logic to build schema cache. If ops definition changes, the trigger is deleted (if exists) and created again with updated definition.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
- Performing a `run_sql` query with DDL statement shouldn't drop any trigger procedures in the `hdb_views` schema
- Updating the event trigger's webhook URL shouldn't drop the trigger procedure in the `hdb_views` schema.

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
