### PR TITLE
persist mix files only when coverage is enabled

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -41,9 +41,11 @@ ci-build:
 	echo '$(VERSION)' > '$(build_output)/version.txt'
 	shopt -s failglob globstar && cp $(executables_glob) '$(build_output)/'
 	# Copy the .mix files needed for `hpc` to generate code coverage reports into the build output
-	# directory.
-	mkdir -p '$(build_output)/mix/'
-	shopt -s failglob globstar && cp -R $(mix_dirs_glob) '$(build_output)/mix/'
+	# directory, only if coverage is enabled (the mix files aren't generated otherwise).
+	if [[ -n '$(enable_coverage)' ]]; then \
+	  mkdir -p '$(build_output)/mix/' && \
+	  shopt -s failglob globstar && cp -R $(mix_dirs_glob) '$(build_output)/mix/'; \
+	fi
 
 # assumes this is built in circleci
 ci-image:


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
Looks like we haven't tested a release after we switched to `cabal` from `stack`, this PR fixes an error that we encountered when tagging `v1.1.0-beta.3`. The [build log (](https://app.circleci.com/jobs/github/hasura/graphql-engine/83165)snipped):
```bash
/bin/bash: no match: dist-newstyle/**/hpc/vanilla/mix/**/graphql-engine-1.0.0/
Makefile:28: recipe for target 'ci-build' failed
make: *** [ci-build] Error 1
```

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [x] Build System
- [ ] Tests
- [ ] Other (list it)


