### PR TITLE
fix casting citext column type (fix #2818)

### DIFF
--- a/server/src-lib/Hasura/SQL/Types.hs
+++ b/server/src-lib/Hasura/SQL/Types.hs
@@ -451,17 +451,15 @@ pgTypeOid PGBoolean     = PTI.bool
 pgTypeOid PGChar        = PTI.char
 pgTypeOid PGVarchar     = PTI.varchar
 pgTypeOid PGText        = PTI.text
-pgTypeOid PGCitext      = PTI.text
+pgTypeOid PGCitext      = PTI.text -- Explict type cast to citext needed, See also Note [Type casting prepared params]
 pgTypeOid PGDate        = PTI.date
 pgTypeOid PGTimeStampTZ = PTI.timestamptz
 pgTypeOid PGTimeTZ      = PTI.timetz
 pgTypeOid PGJSON        = PTI.json
 pgTypeOid PGJSONB       = PTI.jsonb
--- we are using the ST_GeomFromGeoJSON($i) instead of $i
-pgTypeOid PGGeometry    = PTI.text
+pgTypeOid PGGeometry    = PTI.text -- we are using the ST_GeomFromGeoJSON($i) instead of $i
 pgTypeOid PGGeography   = PTI.text
--- we are using the ST_RastFromHexWKB($i) instead of $i
-pgTypeOid PGRaster      = PTI.text
+pgTypeOid PGRaster      = PTI.text -- we are using the ST_RastFromHexWKB($i) instead of $i
 pgTypeOid (PGUnknown _) = PTI.auto
 
 isIntegerType :: PGScalarType -> Bool

--- a/server/src-lib/Hasura/SQL/Types.hs
+++ b/server/src-lib/Hasura/SQL/Types.hs
@@ -333,6 +333,7 @@ data PGScalarType
   | PGChar
   | PGVarchar
   | PGText
+  | PGCitext
   | PGDate
   | PGTimeStampTZ
   | PGTimeTZ
@@ -361,6 +362,7 @@ instance ToSQL PGScalarType where
     PGChar        -> "character"
     PGVarchar     -> "varchar"
     PGText        -> "text"
+    PGCitext      -> "citext"
     PGDate        -> "date"
     PGTimeStampTZ -> "timestamptz"
     PGTimeTZ      -> "timetz"
@@ -412,7 +414,7 @@ textToPGScalarType t = case t of
   "character varying"        -> PGVarchar
 
   "text"                     -> PGText
-  "citext"                   -> PGText
+  "citext"                   -> PGCitext
 
   "date"                     -> PGDate
 
@@ -449,6 +451,7 @@ pgTypeOid PGBoolean     = PTI.bool
 pgTypeOid PGChar        = PTI.char
 pgTypeOid PGVarchar     = PTI.varchar
 pgTypeOid PGText        = PTI.text
+pgTypeOid PGCitext      = PTI.text
 pgTypeOid PGDate        = PTI.date
 pgTypeOid PGTimeStampTZ = PTI.timestamptz
 pgTypeOid PGTimeTZ      = PTI.timetz
@@ -474,7 +477,8 @@ isNumType PGNumeric = True
 isNumType ty        = isIntegerType ty
 
 stringTypes :: [PGScalarType]
-stringTypes = [PGVarchar, PGText]
+stringTypes = [PGVarchar, PGText, PGCitext]
+
 isStringType :: PGScalarType -> Bool
 isStringType = (`elem` stringTypes)
 

--- a/server/src-lib/Hasura/SQL/Value.hs
+++ b/server/src-lib/Hasura/SQL/Value.hs
@@ -63,6 +63,7 @@ data PGScalarValue
   | PGValChar !Char
   | PGValVarchar !T.Text
   | PGValText !T.Text
+  | PGValCitext !T.Text
   | PGValDate !Day
   | PGValTimeStampTZ !UTCTime
   | PGValTimeTZ !ZonedTimeOfDay
@@ -107,6 +108,7 @@ parsePGValue ty val = case (ty, val) of
       PGChar -> PGValChar <$> parseJSON val
       PGVarchar -> PGValVarchar <$> parseJSON val
       PGText -> PGValText <$> parseJSON val
+      PGCitext -> PGValCitext <$> parseJSON val
       PGDate -> PGValDate <$> parseJSON val
       PGTimeStampTZ -> PGValTimeStampTZ <$> parseJSON val
       PGTimeTZ -> PGValTimeTZ <$> parseJSON val
@@ -147,6 +149,7 @@ txtEncodedPGVal colVal = case colVal of
   PGValChar t     -> TELit $ T.pack $ show t
   PGValVarchar t  -> TELit t
   PGValText t     -> TELit t
+  PGValCitext t   -> TELit t
   PGValDate d     -> TELit $ T.pack $ showGregorian d
   PGValTimeStampTZ u ->
     TELit $ T.pack $ formatTime defaultTimeLocale "%FT%T%QZ" u
@@ -175,6 +178,7 @@ binEncoder colVal = case colVal of
   PGValChar t                      -> Q.toPrepVal t
   PGValVarchar t                   -> Q.toPrepVal t
   PGValText t                      -> Q.toPrepVal t
+  PGValCitext t                    -> Q.toPrepVal t
   PGValDate d                      -> Q.toPrepVal d
   PGValTimeStampTZ u               -> Q.toPrepVal u
   PGValTimeTZ (ZonedTimeOfDay t z) -> Q.toPrepValHelper PTI.timetz PE.timetz_int (t, z)
@@ -191,7 +195,8 @@ txtEncoder colVal = case txtEncodedPGVal colVal of
   TELit t -> S.SELit t
 
 toPrepParam :: Int -> PGScalarType -> S.SQLExp
-toPrepParam i ty = withConstructorFn ty $ S.SEPrep i
+toPrepParam i ty =
+  S.withTyAnn ty . withConstructorFn ty $ S.SEPrep i
 
 toBinaryValue :: WithScalarType PGScalarValue -> Q.PrepArg
 toBinaryValue = binEncoder . pstValue

--- a/server/src-lib/Hasura/SQL/Value.hs
+++ b/server/src-lib/Hasura/SQL/Value.hs
@@ -194,8 +194,18 @@ txtEncoder colVal = case txtEncodedPGVal colVal of
   TENull  -> S.SENull
   TELit t -> S.SELit t
 
+{- Note [Type casting prepared params]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Prepared values are passed to Postgres via text encoding. Explicit type cast for prepared params
+is needed to distinguish the column types. For example, the parameter for citext column type is
+generated as ($i)::citext where 'i' is parameter position (integer).
+
+Also see https://github.com/hasura/graphql-engine/issues/2818
+-}
+
 toPrepParam :: Int -> PGScalarType -> S.SQLExp
 toPrepParam i ty =
+  -- See Note [Type casting prepared params] above
   S.withTyAnn ty . withConstructorFn ty $ S.SEPrep i
 
 toBinaryValue :: WithScalarType PGScalarValue -> Q.PrepArg

--- a/server/tests-py/queries/graphql_query/basic/select_query_person_citext.yaml
+++ b/server/tests-py/queries/graphql_query/basic/select_query_person_citext.yaml
@@ -1,0 +1,19 @@
+# Test for https://github.com/hasura/graphql-engine/issues/2818
+description: Query data using citext column in where clause
+url: /v1/graphql
+status: 200
+response:
+  data:
+    person:
+    - id: 2
+      name: Clarke
+    - id: 3
+      name: clarke
+query:
+  query: |
+    query {
+      person(where: {name: {_eq: "clarke"}}){
+        id
+        name
+      }
+    }

--- a/server/tests-py/queries/graphql_query/basic/setup.yaml
+++ b/server/tests-py/queries/graphql_query/basic/setup.yaml
@@ -274,9 +274,10 @@ args:
 - type: run_sql
   args:
     sql: |
+      create extension if not exists citext;
       create table person (
           id serial primary key,
-          name text
+          name citext
       );
 - type: track_table
   args:
@@ -287,6 +288,8 @@ args:
     table: person
     objects:
     - name: "John\\"
+    - name: "Clarke"
+    - name: "clarke"
 
 #Set timezone
 - type: run_sql

--- a/server/tests-py/test_graphql_queries.py
+++ b/server/tests-py/test_graphql_queries.py
@@ -60,6 +60,9 @@ class TestGraphQLQueryBasic(DefaultTestSelectQueries):
         transport = 'http'
         check_query_f(hge_ctx, self.dir() + "/select_query_invalid_escape_sequence.yaml", transport)
 
+    def test_select_query_person_citext(self, hge_ctx, transport):
+        check_query_f(hge_ctx, self.dir() + "/select_query_person_citext.yaml", transport)
+
     def test_select_query_batching(self, hge_ctx, transport):
         transport = 'http'
         check_query_f(hge_ctx, self.dir() + "/select_query_batching.yaml", transport)


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

This PR fixes incorrect casting of `citext` column type to `text`. See issue #2818 for more details.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [x] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
Fix #2818 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
- Add `PGCitext` constructor to `PGScalarType` data type
- Add `PGValCitext` constructor to `PGScalarValue` data type
- Type cast prepared parameters to corresponding column types

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes

#### GraphQL
- [ ] No new GraphQL schema is generated
- [x] New GraphQL schema is being generated:
   - [x] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

Generates a new `citext_comparison_exp` input object for boolean expressions of any table having `citext` column.

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes
<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
