### PR TITLE
handle invalid keys in permission builder

### DIFF
--- a/console/src/components/Services/Data/TablePermissions/PermissionBuilder/PermissionBuilder.js
+++ b/console/src/components/Services/Data/TablePermissions/PermissionBuilder/PermissionBuilder.js
@@ -101,9 +101,13 @@ class PermissionBuilder extends React.Component {
         _missingSchemas = findMissingSchemas(newPath, currTable);
       } else if (isExistOperator(operator)) {
         const existTableDef = getQualifiedTableDef(value[TABLE_KEY]);
-        const existTableSchema = existTableDef.schema;
 
-        const existWhere = value[WHERE_KEY];
+        let existTableSchema;
+        if (existTableDef) {
+          existTableSchema = existTableDef.schema;
+        }
+
+        const existWhere = value[WHERE_KEY] || '';
 
         if (existTableSchema) {
           const { allTableSchemas } = this.props;
@@ -443,12 +447,12 @@ class PermissionBuilder extends React.Component {
         );
       });
 
-      const selectedValue = addToPrefix(prefix, value);
+      const selectedValue = addToPrefix(prefix, value || '--');
 
       return (
         <select
           value={selectedValue}
-          name={value}
+          name={prefix}
           onChange={dispatchSelect}
           className={styles.qb_select}
           data-test="qb-select"
@@ -820,7 +824,7 @@ class PermissionBuilder extends React.Component {
       };
 
       const unselectedElements = [];
-      if (!existsOpTable.name) {
+      if (!existsOpTable || !existsOpTable.name) {
         unselectedElements.push(WHERE_KEY);
       }
 

--- a/console/src/components/Services/Data/TablePermissions/PermissionBuilder/PermissionBuilder.js
+++ b/console/src/components/Services/Data/TablePermissions/PermissionBuilder/PermissionBuilder.js
@@ -42,6 +42,7 @@ import {
   isJsonString,
   getAllJsonPaths,
   isObject,
+  isArray,
 } from '../../../../Common/utils/jsUtils';
 
 class PermissionBuilder extends React.Component {
@@ -845,6 +846,8 @@ class PermissionBuilder extends React.Component {
       prefix
     ) => {
       const _boolExpArray = [];
+
+      expressions = isArray(expressions) ? expressions : [];
 
       expressions.concat([{}]).forEach((expression, i) => {
         const _boolExp = renderBoolExp(

--- a/console/src/components/Services/Data/TablePermissions/PermissionBuilder/PermissionBuilder.js
+++ b/console/src/components/Services/Data/TablePermissions/PermissionBuilder/PermissionBuilder.js
@@ -720,7 +720,9 @@ class PermissionBuilder extends React.Component {
         let columnType = '';
         if (tableSchema && columnName) {
           const column = getTableColumn(tableSchema, columnName);
-          columnType = getColumnType(column);
+          if (column) {
+            columnType = getColumnType(column);
+          }
         }
 
         _columnExp = renderOperatorExp(


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Permission builer breaks when:
-  column name is manually edited to a non-existent value
- _where / _table keys are changed under _exists operator
- object is passed to _or/_and operators

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#3848

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->
