### PR TITLE
Refactor initialisation and relax tx isolation levels where possible

### DIFF
--- a/server/src-exec/Main.hs
+++ b/server/src-exec/Main.hs
@@ -29,12 +29,12 @@ runApp (HGEOptionsG rci hgeCmd) =
       runHGEServer serveOptions initCtx initTime
     HCExport -> do
       (initCtx, _) <- initialiseCtx hgeCmd rci
-      res <- runTx' initCtx fetchMetadata
+      res <- runTx' initCtx fetchMetadata Q.ReadCommitted
       either printErrJExit printJSON res
 
     HCClean -> do
       (initCtx, _) <- initialiseCtx hgeCmd rci
-      res <- runTx' initCtx dropCatalog
+      res <- runTx' initCtx dropCatalog Q.ReadCommitted
       either printErrJExit (const cleanSuccess) res
 
     HCExecute -> do
@@ -58,7 +58,7 @@ runApp (HGEOptionsG rci hgeCmd) =
 
     HCVersion -> liftIO $ putStrLn $ "Hasura GraphQL Engine: " ++ convertText currentVersion
   where
-    runTx' initCtx tx =
-      liftIO $ runExceptT $ Q.runTx (_icPgPool initCtx) (Q.Serializable, Nothing) tx
+    runTx' initCtx tx txIso =
+      liftIO $ runExceptT $ Q.runTx (_icPgPool initCtx) (txIso, Nothing) tx
 
     cleanSuccess = liftIO $ putStrLn "successfully cleaned graphql-engine related data"

--- a/server/src-lib/Hasura/App.hs
+++ b/server/src-lib/Hasura/App.hs
@@ -301,7 +301,7 @@ runHGEServer ServeOptions{..} InitCtx{..} initTime = do
   where
     prepareEvents pool (Logger logger) = do
       liftIO $ logger $ mkGenericStrLog LevelInfo "event_triggers" "preparing data"
-      res <- runTx pool unlockAllEvents
+      res <- runUnlockTx pool unlockAllEvents
       either printErrJExit return res
 
     getFromEnv :: (Read a) => a -> String -> IO a
@@ -313,8 +313,8 @@ runHGEServer ServeOptions{..} InitCtx{..} initTime = do
           eRes = maybe (Left $ "Wrong expected type for environment variable: " <> env) Right mRes
       either printErrExit return eRes
 
-    runTx pool tx =
-      liftIO $ runExceptT $ Q.runTx pool (Q.Serializable, Nothing) tx
+    runUnlockTx pool tx =
+      liftIO $ runExceptT $ Q.runTx pool (Q.ReadCommitted, Nothing) tx
 
     -- | Catches the SIGTERM signal and initiates a graceful shutdown. Graceful shutdown for regular HTTP
     -- requests is already implemented in Warp, and is triggered by invoking the 'closeSocket' callback.

--- a/server/src-lib/Hasura/Server/App.hs
+++ b/server/src-lib/Hasura/Server/App.hs
@@ -474,9 +474,9 @@ mkWaiApp isoLevel logger sqlGenCtx enableAL pool ci httpManager mode corsCfg ena
         runCtx = RunCtx adminUserInfo httpManager sqlGenCtx
 
     (cacheRef, cacheBuiltTime) <- do
-      pgResp <- runExceptT $ peelRun runCtx pgExecCtxReadComm Q.ReadWrite $
-        (,) <$> pure schemaCache <*> liftTx fetchLastUpdate
-      (schemaCache, event) <- liftIO $ either initErrExit return pgResp
+      eventE <- runExceptT $ peelRun runCtx pgExecCtxReadComm Q.ReadWrite $
+        liftTx fetchLastUpdate
+      event <- liftIO $ either initErrExit return eventE
       scRef <- liftIO $ newIORef (schemaCache, initSchemaCacheVer)
       return (scRef, view _2 <$> event)
 

--- a/server/src-lib/Hasura/Server/App.hs
+++ b/server/src-lib/Hasura/Server/App.hs
@@ -12,7 +12,7 @@ import           Data.Aeson                             hiding (json)
 import           Data.Either                            (isRight)
 import           Data.Int                               (Int64)
 import           Data.IORef
-import           Data.Time.Clock                        (UTCTime)
+import           Data.Time.Clock                        (UTCTime, getCurrentTime)
 import           Data.Time.Clock.POSIX                  (getPOSIXTime)
 import           Network.Mime                           (defaultMimeLookup)
 import           System.Exit                            (exitFailure)
@@ -49,6 +49,7 @@ import           Hasura.Server.Cors
 import           Hasura.Server.Init
 import           Hasura.Server.Logging
 import           Hasura.Server.Middleware               (corsMiddleware)
+import           Hasura.Server.Migrate                  (migrateCatalog)
 import           Hasura.Server.Query
 import           Hasura.Server.Utils
 import           Hasura.Server.Version
@@ -464,36 +465,22 @@ mkWaiApp
   -> S.HashSet API
   -> EL.LiveQueriesOptions
   -> E.PlanCacheOptions
-  -> (RebuildableSchemaCache Run)
   -> m HasuraApp
 mkWaiApp isoLevel logger sqlGenCtx enableAL pool ci httpManager mode corsCfg enableConsole consoleAssetsDir
-         enableTelemetry instanceId apis lqOpts planCacheOptions schemaCache = do
+         enableTelemetry instanceId apis lqOpts planCacheOptions = do
 
-    let pgExecCtx = PGExecCtx pool isoLevel
-        pgExecCtxReadComm = PGExecCtx pool Q.ReadCommitted
-        runCtx = RunCtx adminUserInfo httpManager sqlGenCtx
-
-    (cacheRef, cacheBuiltTime) <- do
-      eventE <- runExceptT $ peelRun runCtx pgExecCtxReadComm Q.ReadWrite $
-        liftTx fetchLastUpdate
-      event <- liftIO $ either initErrExit return eventE
-      scRef <- liftIO $ newIORef (schemaCache, initSchemaCacheVer)
-      return (scRef, view _2 <$> event)
-
-    cacheLock <- liftIO $ newMVar ()
-    planCache <- liftIO $ E.initPlanCache planCacheOptions
+    (planCache, schemaCacheRef, cacheBuiltTime) <- initialiseSchemaCache
+    let getSchemaCache = first lastBuiltSchemaCache <$> readIORef (_scrCache schemaCacheRef)
 
     let corsPolicy = mkDefaultCorsPolicy corsCfg
-        getSchemaCache = first lastBuiltSchemaCache <$> readIORef cacheRef
-
+        pgExecCtx = PGExecCtx pool isoLevel
     lqState <- liftIO $ EL.initLiveQueriesState lqOpts pgExecCtx
     wsServerEnv <- WS.createWSServerEnv logger pgExecCtx lqState getSchemaCache httpManager
                                         corsPolicy sqlGenCtx enableAL planCache
 
     ekgStore <- liftIO EKG.newStore
 
-    let schemaCacheRef = SchemaCacheRef cacheLock cacheRef (E.clearPlanCache planCache)
-        serverCtx = ServerCtx
+    let serverCtx = ServerCtx
                     { scPGExecCtx       =  pgExecCtx
                     , scConnInfo        =  ci
                     , scLogger          =  logger
@@ -527,6 +514,30 @@ mkWaiApp isoLevel logger sqlGenCtx enableAL pool ci httpManager mode corsCfg ena
     getTimeMs :: IO Int64
     getTimeMs = (round . (* 1000)) `fmap` getPOSIXTime
 
+    initialiseSchemaCache :: m (E.PlanCache, SchemaCacheRef, Maybe UTCTime)
+    initialiseSchemaCache = do
+      let pgExecCtx = PGExecCtx pool Q.Serializable
+          adminRunCtx = RunCtx adminUserInfo httpManager sqlGenCtx
+      currentTime <- liftIO getCurrentTime
+      initialiseResult <- runExceptT $ peelRun adminRunCtx pgExecCtx Q.ReadWrite do
+        (,) <$> migrateCatalog currentTime <*> liftTx fetchLastUpdate
+
+      ((migrationResult, schemaCache), lastUpdateEvent) <-
+        initialiseResult `onLeft` \err -> do
+          L.unLogger logger StartupLog
+            { slLogLevel = L.LevelError
+            , slKind = "db_migrate"
+            , slInfo = toJSON err
+            }
+          liftIO exitFailure
+      L.unLogger logger migrationResult
+
+      cacheLock <- liftIO $ newMVar ()
+      cacheCell <- liftIO $ newIORef (schemaCache, initSchemaCacheVer)
+      planCache <- liftIO $ E.initPlanCache planCacheOptions
+      let cacheRef = SchemaCacheRef cacheLock cacheCell (E.clearPlanCache planCache)
+
+      pure (planCache, cacheRef, view _2 <$> lastUpdateEvent)
 
 httpApp
   :: (HasVersion, MonadIO m, MonadBaseControl IO m, ConsoleRenderer m, HttpLog m, UserAuthentication m, MetadataApiAuthorization m)

--- a/server/src-lib/Hasura/Server/App.hs
+++ b/server/src-lib/Hasura/Server/App.hs
@@ -469,7 +469,7 @@ mkWaiApp
 mkWaiApp isoLevel logger sqlGenCtx enableAL pool ci httpManager mode corsCfg enableConsole consoleAssetsDir
          enableTelemetry instanceId apis lqOpts planCacheOptions = do
 
-    (planCache, schemaCacheRef, cacheBuiltTime) <- initialiseSchemaCache
+    (planCache, schemaCacheRef, cacheBuiltTime) <- migrateAndInitialiseSchemaCache
     let getSchemaCache = first lastBuiltSchemaCache <$> readIORef (_scrCache schemaCacheRef)
 
     let corsPolicy = mkDefaultCorsPolicy corsCfg
@@ -514,8 +514,8 @@ mkWaiApp isoLevel logger sqlGenCtx enableAL pool ci httpManager mode corsCfg ena
     getTimeMs :: IO Int64
     getTimeMs = (round . (* 1000)) `fmap` getPOSIXTime
 
-    initialiseSchemaCache :: m (E.PlanCache, SchemaCacheRef, Maybe UTCTime)
-    initialiseSchemaCache = do
+    migrateAndInitialiseSchemaCache :: m (E.PlanCache, SchemaCacheRef, Maybe UTCTime)
+    migrateAndInitialiseSchemaCache = do
       let pgExecCtx = PGExecCtx pool Q.Serializable
           adminRunCtx = RunCtx adminUserInfo httpManager sqlGenCtx
       currentTime <- liftIO getCurrentTime


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

Currently, we are using `Serializable` tx isolation levels for all system processes. This is not required as most (one exception is catalog migration) of the system processes are either single statement read or write i.e (no repeated reads). Reducing the tx isolation level of such processes is generally good. 

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

https://github.com/hasura/graphql-engine/issues/660