### PR TITLE
Add POSTGRES_PASSWORD environment variable fix #3894 #3893

### DIFF
--- a/install-manifests/docker-compose-https/docker-compose.yaml
+++ b/install-manifests/docker-compose-https/docker-compose.yaml
@@ -5,6 +5,8 @@ services:
     restart: always
     volumes:
     - db_data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: "hasura"
   graphql-engine:
     image: hasura/graphql-engine:v1.0.0
     depends_on:
@@ -12,7 +14,7 @@ services:
     restart: always
     environment:
       # database url to connect
-      HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:@postgres:5432/postgres
+      HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:hasura@postgres:5432/postgres
       # enable the console served by server
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true" # set "false" to disable console
       ## uncomment next line to set an admin secret key

--- a/install-manifests/docker-compose-pgadmin/docker-compose.yaml
+++ b/install-manifests/docker-compose-pgadmin/docker-compose.yaml
@@ -5,6 +5,8 @@ services:
     restart: always
     volumes:
     - db_data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: "hasura"
   pgadmin:
     image: dpage/pgadmin4
     restart: always
@@ -24,7 +26,7 @@ services:
     - "postgres"
     restart: always
     environment:
-      HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:@postgres:5432/postgres
+      HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:hasura@postgres:5432/postgres
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true" # set to "false" to disable console
       ## uncomment next line to set an admin secret
       # HASURA_GRAPHQL_ADMIN_SECRET: myadminsecretkey

--- a/install-manifests/docker-compose/docker-compose.yaml
+++ b/install-manifests/docker-compose/docker-compose.yaml
@@ -5,6 +5,8 @@ services:
     restart: always
     volumes:
     - db_data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: "hasura"
   graphql-engine:
     image: hasura/graphql-engine:v1.0.0
     ports:
@@ -13,7 +15,7 @@ services:
     - "postgres"
     restart: always
     environment:
-      HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:@postgres:5432/postgres
+      HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:hasura@postgres:5432/postgres
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true" # set to "false" to disable console
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
       ## uncomment next line to set an admin secret


### PR DESCRIPTION
### Description
A recent change to the official PostgresQL Docker images means that `POSTGRES_PASSWORD` is now required to be set https://github.com/docker-library/postgres/issues/681

This PR adds this variable where required. It's set to `"hasura"`.

### Affected components
- [ ] Other (list it)

Example docker-compose configs.

### Related Issues
#3894
#3893

### Solution and Design
* Add the environment variable and add the password to the connection string

### Steps to test and verify
* run `docker-compose up` for one of the affected comose files. 

### Limitations, known bugs & workarounds

### Server checklist

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x ] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://docs.hasura.io/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x ] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [ x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
