### PR TITLE
Reserved keywords in column references break parser (fix #3597)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes and improvements
 
 - docs: add One-Click Render deployment guide (close #3683) (#4209)
+- server: reserved keywords in column references break parser (fix #3597) #3927
 
 ## `v1.2.0-beta.3`
 

--- a/server/cabal.project
+++ b/server/cabal.project
@@ -33,9 +33,8 @@ source-repository-package
 
 source-repository-package
   type: git
-  -- location: TODO: /Users/lyndon/hasura/graphql-parser-hs
-  https://github.com/hasura/graphql-parser-hs.git
-  tag: 088acdf9120c4bea11f6185dfb587bd04ee2cb54
+  location: https://github.com/hasura/graphql-parser-hs.git
+  tag: 1380495a7b3269b70a7ab3081d745a5f54171a9c
 
 source-repository-package
   type: git

--- a/server/cabal.project
+++ b/server/cabal.project
@@ -33,7 +33,8 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/hasura/graphql-parser-hs.git
+  -- location: TODO: /Users/lyndon/hasura/graphql-parser-hs
+  https://github.com/hasura/graphql-parser-hs.git
   tag: 088acdf9120c4bea11f6185dfb587bd04ee2cb54
 
 source-repository-package

--- a/server/tests-py/queries/graphql_mutation/insert/nullprefixcolumn/null_prefixed_column_ok.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/nullprefixcolumn/null_prefixed_column_ok.yaml
@@ -1,0 +1,19 @@
+description: |
+  Using "null" prefixed columns in on_conflict clause should behave normally.
+  Regression test for #3597.
+
+url: /v1/graphql
+status: 200
+query:
+  query: |
+    mutation {
+      insert_nullPrefixTestTable(objects: [{nullName: "2"}]
+      on_conflict:{constraint:nullPrefixTestTable_pkey, update_columns:[nullName]}){
+        affected_rows
+      }
+    }
+
+response:
+  data:
+    insert_nullPrefixTestTable:
+      affected_rows: 1

--- a/server/tests-py/queries/graphql_mutation/insert/nullprefixcolumn/setup.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/nullprefixcolumn/setup.yaml
@@ -1,0 +1,16 @@
+type: bulk
+args:
+
+#Test table
+- type: run_sql
+  args:
+    sql: |
+      create table "nullPrefixTestTable"(
+          id serial primary key,
+          "nullName" text
+      );
+- type: track_table
+  args:
+    schema: public
+    name: "nullPrefixTestTable"
+

--- a/server/tests-py/queries/graphql_mutation/insert/nullprefixcolumn/teardown.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/nullprefixcolumn/teardown.yaml
@@ -1,0 +1,7 @@
+type: bulk
+args:
+
+- type: run_sql
+  args:
+    sql: |
+      drop table "nullPrefixTestTable"

--- a/server/tests-py/test_graphql_mutations.py
+++ b/server/tests-py/test_graphql_mutations.py
@@ -188,6 +188,18 @@ class TestGraphqlInsertConstraints:
 
 
 @pytest.mark.parametrize("transport", ['http', 'websocket'])
+@usefixtures('per_class_tests_db_state')
+class TestGraphqlInsertNullPrefixedColumnOnConflict:
+
+    def test_address_not_null_constraint_err(self, hge_ctx, transport):
+        check_query_f(hge_ctx, self.dir() + "/null_prefixed_column_ok.yaml")
+
+    @classmethod
+    def dir(cls):
+        return "queries/graphql_mutation/insert/nullprefixcolumn"
+
+
+@pytest.mark.parametrize("transport", ['http', 'websocket'])
 @use_mutation_fixtures
 class TestGraphqlInsertGeoJson:
 


### PR DESCRIPTION
### Description

This pull-request is intended to fix issues related to #3597 "Field naming starting with reserved keywords breaks updates ".

The bug is located in the parser, therefore the fix is as follows:

* [x] Fix bug in parser
* [x] Add tests to engine
* [x] Update project.cabal to reference new version of the parser

```
source-repository-package
  type: git
  location: https://github.com/hasura/graphql-parser-hs.git
  tag: 1380495a7b3269b70a7ab3081d745a5f54171a9c
```

### Affected components

- [x] Server
- [x] Tests

### Related Issues

* #3597

### Solution and Design

The solution was to add more nuance to the parser as can be seen in the related parser pull request: https://github.com/hasura/graphql-parser-hs/pull/21

This is however only a temporary fix as the parser should probably be split into lexer/parser phases to much more effectively express the tokenisation of such identities as caused the problem here. Also this would make the code a lot more readable as it was quite difficult to narrow down the bug for a new contributor to the codebase (me!).

### Steps to test and verify

Run `pytest` against the new and old versions to see the fix addressed:

> pytest ... -vv test_graphql_mutations.py::TestGraphqlInsertNullPrefixedColumnOnConflict

You can also reproduce manually in the console if preferred.

#### Catalog upgrade

Does this PR change Hasura Catalog version?

- [x] No

#### Metadata

Does this PR add a new Metadata feature?
- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No Breaking changes

