### PR TITLE
Update Init.hs for newer tags

### DIFF
--- a/server/src-lib/Hasura/Server/Init.hs
+++ b/server/src-lib/Hasura/Server/Init.hs
@@ -1098,6 +1098,8 @@ downgradeShortcuts =
   , ("v1.0.0", "28")
   , ("v1.1.0-beta.1", "29")
   , ("v1.1.0-beta.2", "30")
+  , ("v1.1.0-beta.3", "31")
+  , ("v1.1.0", "31")
   ]
 
 downgradeOptionsParser :: Parser DowngradeOptions


### PR DESCRIPTION
This should fix the errors we're seeing on PRs against master, but we need to find a way to update these when we tag new releases.