### PR TITLE
fix regression on tag release script 

### DIFF
--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -38,13 +38,14 @@ find "$ROOT/install-manifests" \
      's#(hasura/graphql-engine:)v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(.*)*$#\1'"${TAG}"'\9#' {} \;
 
 # add the latest tag to the catalog_versions file
-[ -n "$(tail -c1 "$ROOT/src-rsr/catalog_versions.txt")" ] && echo >> "$ROOT/src-rsr/catalog_versions.txt"
-echo $TAG $(cat "$ROOT/src-rsr/catalog_version.txt") >> "$ROOT/src-rsr/catalog_versions.txt"
+[ -n "$(tail -c1 "$ROOT/server/src-rsr/catalog_versions.txt")" ] && echo >> "$ROOT/server/src-rsr/catalog_versions.txt"
+echo $TAG $(cat "$ROOT/server/src-rsr/catalog_version.txt") >> "$ROOT/server/src-rsr/catalog_versions.txt"
 
 git add "$ROOT/install-manifests" \
-        "$ROOT/scripts/cli-migrations"
+        "$ROOT/scripts/cli-migrations" \
+        "$ROOT/server/src-rsr"
 
-git commit -m "update manifests to $TAG"
+git commit -m "tag release $TAG"
 
 git tag -a "$TAG" -m "$MESSAGE"
 


### PR DESCRIPTION
This PR fixes regression introduced in https://github.com/hasura/graphql-engine/pull/3933 to the release tagging script.

Need not go into the public changelog.