### PR TITLE
WIP: Resolving caching error on non-null variables (fix #3773)

### DIFF
--- a/server/tests-py/queries/graphql_query/caching/defaulted_mandatory_variables.yaml
+++ b/server/tests-py/queries/graphql_query/caching/defaulted_mandatory_variables.yaml
@@ -1,0 +1,32 @@
+- description: "Regression test for issue 3773 - Ensure that caching doesn't break on defaulted mandatory fields."
+  url: /v1/graphql
+  status: 200
+  response:
+    data:
+      users:
+      - name: Alyssa
+  query:
+    query: |
+      query ($id: Int! = 1) {
+        users(where: {id: {_eq: $id}}) {
+          name
+        }
+      }
+    variables: {}
+
+- description: "This test breaks as of 048c1de"
+  url: /v1/graphql
+  status: 200
+  response:
+    data:
+      users:
+      - name: Ben
+  query:
+    query: |
+      query ($id: Int! = 1) {
+        users(where: {id: {_eq: $id}}) {
+          name
+        }
+      }
+    variables: {}
+

--- a/server/tests-py/test_graphql_queries.py
+++ b/server/tests-py/test_graphql_queries.py
@@ -604,3 +604,6 @@ class TestGraphQLQueryCaching:
 
     def test_include_directive(self, hge_ctx, transport):
         check_query_f(hge_ctx, self.dir() + '/include_directive.yaml', transport)
+
+    def test_defaulted_mandatory_variables(self, hge_ctx, transport):
+        check_query_f(hge_ctx, self.dir() + '/defaulted_mandatory_variables.yaml', transport)


### PR DESCRIPTION
### Description

Resolving issue: https://github.com/hasura/graphql-engine/issues/3773

Further description of the mechanics here: https://gist.github.com/0x777/a9fed2c4782b2776e09d4dde50c1a463

Manually test with:

```GraphQL
query ($aid: Int! = 1) {
  author(where: {id: {_eq: $aid}}) {
    name
  }
}
```

With variables `{}`.

Hit the same capability twice and you should trigger an error like:

```json
{  "errors": [
    {
      "extensions": {
        "path": "$.variableValues.aid",
        "code": "validation-failed"
      },
      "message": "expected a value for non-nullable variable"
    }
  ]
}
```

Test with:

> pytest --hge-urls http://localhost:8080 --pg-urls=postgres://hasura-test\@localhost:5432/testnull  -vv test_graphql_queries.py::TestGraphQLQueryCaching

### Affected components

- [x] Server
- [x] Tests

### Related Issues

* https://github.com/hasura/graphql-engine/issues/3773

### Solution and Design

Solution is a WIP. TODO!

### Steps to test and verify

> pytest ... test_graphql_queries.py::TestGraphQLQueryCaching

### Limitations, known bugs & workarounds

TODO

#### Metadata

Does this PR add a new Metadata feature?
- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No Breaking changes
