### PR TITLE
cli: bug fixes related to actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,7 +356,7 @@ jobs:
   
   test_and_build_cli_ext:
     docker:
-    - image: hasura/graphql-engine-extension-cli-builder:20200220
+    - image: hasura/graphql-engine-extension-cli-builder:20200225
     working_directory: ~/graphql-engine
     steps:
     - attach_workspace:

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -109,7 +109,7 @@ deploy_cli_ext() {
     cp ${DIST_PATH}/manifest.yaml ./plugins/cli-ext.yaml
     git add .
     git commit -m "update cli-ext manifest to ${LATEST_TAG}"
-    git push -q https://${GITHUB_TOKEN}@github.com/hasura/plugins-index.git cli-ext-${LATEST_TAG}
+    git push -q https://${GITHUB_TOKEN}@github.com/hasura/cli-plugins-index.git cli-ext-${LATEST_TAG}
     hub pull-request -F- <<<"Update cli-ext manifest to ${LATEST_TAG}" -r ${REVIEWERS} -a ${REVIEWERS}
 
     unset VERSION

--- a/.circleci/extension-cli-builder.dockerfile
+++ b/.circleci/extension-cli-builder.dockerfile
@@ -1,27 +1,18 @@
 FROM node:12
 
-ARG gcloud_version="207.0.0"
+ARG upx_version="3.94"
 
 # install dependencies
 RUN apt-get update && apt-get install -y \
-    netcat \
-    libpq5 \
-    libgtk2.0-0 \
-    libnotify-dev \
-    libgconf-2-4 \
-    libnss3 \
-    libxss1 \
-    libasound2 \
     zip \
     xvfb \
-    && curl -Lo /tmp/gcloud-${gcloud_version}.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${gcloud_version}-linux-x86_64.tar.gz \
-    && tar -xzf /tmp/gcloud-${gcloud_version}.tar.gz -C /usr/local \
-    && /usr/local/google-cloud-sdk/install.sh \
+    && curl -Lo /tmp/upx-${upx_version}.tar.xz https://github.com/upx/upx/releases/download/v${upx_version}/upx-${upx_version}-amd64_linux.tar.xz \
+    && xz -d -c /tmp/upx-${upx_version}.tar.xz \
+        | tar -xOf - upx-${upx_version}-amd64_linux/upx > /bin/upx \
+    && chmod a+x /bin/upx \
     && apt-get -y auto-remove \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /usr/share/doc/ \
     && rm -rf /usr/share/man/ \
     && rm -rf /usr/share/locale/
-
-ENV PATH "/usr/local/google-cloud-sdk/bin:$PATH"

--- a/cli-ext/Makefile
+++ b/cli-ext/Makefile
@@ -11,6 +11,7 @@ ci-copy-assets:
 	mkdir -p /build/_cli_ext_output
 	cp $(BUILDDIR)/* /build/_cli_ext_output/
 
+# Not supported: Refer https://github.com/zeit/pkg/issues/50
 upx-compress: $(BUILDDIR)
 	ls $(BUILDDIR)/cli-ext-hasura-* | xargs upx
 
@@ -30,7 +31,7 @@ upx-compress: $(BUILDDIR)
 	shasum -a 256 $< > $@
 
 .PHONY: deploy
-deploy: upx-compress $(CHECKSUMS)
+deploy: $(CHECKSUMS)
 	./scripts/generate-manifest.sh && \
 	$(RM) $(BUILDDIR)/tmp.yaml
 

--- a/cli-ext/Makefile
+++ b/cli-ext/Makefile
@@ -11,6 +11,9 @@ ci-copy-assets:
 	mkdir -p /build/_cli_ext_output
 	cp $(BUILDDIR)/* /build/_cli_ext_output/
 
+upx-compress: $(BUILDDIR)
+	ls $(BUILDDIR)/cli-ext-hasura-* | xargs upx
+
 .PRECIOUS: %.zip
 %.zip: %.exe
 	cd $(BUILDDIR) && \
@@ -27,7 +30,7 @@ ci-copy-assets:
 	shasum -a 256 $< > $@
 
 .PHONY: deploy
-deploy: $(CHECKSUMS)
+deploy: upx-compress $(CHECKSUMS)
 	./scripts/generate-manifest.sh && \
 	$(RM) $(BUILDDIR)/tmp.yaml
 

--- a/cli-ext/Makefile
+++ b/cli-ext/Makefile
@@ -1,5 +1,5 @@
 BUILDDIR   := bin
-ASSETS     := $(BUILDDIR)/command-macos.tar.gz $(BUILDDIR)/command-linux.tar.gz $(BUILDDIR)/command-win.zip
+ASSETS     := $(BUILDDIR)/cli-ext-hasura-macos.tar.gz $(BUILDDIR)/cli-ext-hasura-linux.tar.gz $(BUILDDIR)/cli-ext-hasura-win.zip
 CHECKSUMS  := $(patsubst %,%.sha256,$(ASSETS))
 
 COMPRESS := gzip --best -k -c

--- a/cli-ext/package.json
+++ b/cli-ext/package.json
@@ -8,7 +8,7 @@
     "pretranspile": "npm run get-shared-modules",
     "transpile": "rm -rf build/* && babel ./src ./tests --out-dir build",
     "prebuild": "npm run transpile",
-    "build": "rm -rf ./bin/* && pkg ./build/command.js --out-path ./bin",
+    "build": "rm -rf ./bin/* && pkg ./build/command.js --output ./bin/cli-ext-hasura -t node8-linux-x64,node8-macos-x64,node8-win-x64",
     "pretest": "npm run transpile && babel ./tests --out-dir _tmptests",
     "posttest": "rm -rf _tmptests",
     "test": "node ./_tmptests/index.js"

--- a/cli-ext/scripts/generate-manifest.sh
+++ b/cli-ext/scripts/generate-manifest.sh
@@ -6,9 +6,9 @@ ROOT="$(readlink -f ${BASH_SOURCE[0]%/*}/../../)"
 
 export VERSION=$(${ROOT}/scripts/get-version.sh)
 export BUCKET_URL=https://github.com/hasura/graphql-engine/releases/download/${VERSION}
-export LINUX_SHA256=$(cat ${ROOT}/cli-ext/bin/command-linux.tar.gz.sha256 | cut -f1 -d' ')
-export MACOS_SHA256=$(cat ${ROOT}/cli-ext/bin/command-macos.tar.gz.sha256 | cut -f1 -d' ')
-export WINDOWS_SHA256=$(cat ${ROOT}/cli-ext/bin/command-win.zip.sha256 | cut -f1 -d' ')
+export LINUX_SHA256=$(cat ${ROOT}/cli-ext/bin/cli-ext-hasura-linux.tar.gz.sha256 | cut -f1 -d' ')
+export MACOS_SHA256=$(cat ${ROOT}/cli-ext/bin/cli-ext-hasura-macos.tar.gz.sha256 | cut -f1 -d' ')
+export WINDOWS_SHA256=$(cat ${ROOT}/cli-ext/bin/cli-ext-hasura-win.zip.sha256 | cut -f1 -d' ')
 
 ( echo "cat <<EOF >${ROOT}/cli-ext/bin/manifest.yaml";
   cat ${ROOT}/cli-ext/scripts/manifest.yaml;

--- a/cli-ext/scripts/manifest.yaml
+++ b/cli-ext/scripts/manifest.yaml
@@ -4,24 +4,24 @@ shortDescription: "Hasura CLI extension"
 homepage: https://github.com/hasura/graphql-engine
 hidden: true
 platforms:
-  - uri: "${BUCKET_URL}/command-linux.tar.gz"
+  - uri: "${BUCKET_URL}/cli-ext-hasura-linux.tar.gz"
     sha256: "${LINUX_SHA256}"
-    bin: command-linux
+    bin: cli-ext-hasura-linux
     files:
-      - from: ./command-linux
-        to: command-linux
+      - from: ./cli-ext-hasura-linux
+        to: cli-ext-hasura-linux
     selector: linux-amd64
-  - uri: "${BUCKET_URL}/command-macos.tar.gz"
+  - uri: "${BUCKET_URL}/cli-ext-hasura-macos.tar.gz"
     sha256: "${MACOS_SHA256}"
-    bin: command-macos
+    bin: cli-ext-hasura-macos
     files:
-      - from: ./command-macos
-        to: command-macos
+      - from: ./cli-ext-hasura-macos
+        to: cli-ext-hasura-macos
     selector: darwin-amd64
-  - uri: "${BUCKET_URL}/command-win.zip"
+  - uri: "${BUCKET_URL}/cli-ext-hasura-win.zip"
     sha256: "${WINDOWS_SHA256}"
-    bin: command-win.exe
+    bin: cli-ext-hasura-win.exe
     files:
-      - from: ./command-win.exe
-        to: command-win.exe
+      - from: ./cli-ext-hasura-win.exe
+        to: cli-ext-hasura-win.exe
     selector: windows-amd64

--- a/cli/metadata/actions/actions.go
+++ b/cli/metadata/actions/actions.go
@@ -437,8 +437,8 @@ func (a *ActionConfig) Build(metadata *yaml.MapSlice) error {
 		for newTypeObjIndex, newTypeObj := range sdlFromResp.Types.Scalars {
 			if customType.Name == newTypeObj.Name {
 				isFound = true
-				sdlFromResp.Types.Objects[newTypeObjIndex].Description = oldAction.CustomTypes.Objects[customTypeIndex].Description
-				sdlFromResp.Types.Objects[newTypeObjIndex].Relationships = oldAction.CustomTypes.Objects[customTypeIndex].Relationships
+				sdlFromResp.Types.Scalars[newTypeObjIndex].Description = oldAction.CustomTypes.Scalars[customTypeIndex].Description
+				sdlFromResp.Types.Scalars[newTypeObjIndex].Relationships = oldAction.CustomTypes.Scalars[customTypeIndex].Relationships
 				break
 			}
 		}

--- a/cli/metadata/allowlist/allow_list.go
+++ b/cli/metadata/allowlist/allow_list.go
@@ -51,7 +51,7 @@ func (a *AllowListConfig) Build(metadata *yaml.MapSlice) error {
 	item := yaml.MapItem{
 		Key: "allowlist",
 	}
-	var obj yaml.MapSlice
+	var obj []yaml.MapSlice
 	err = yaml.Unmarshal(data, &obj)
 	if err != nil {
 		return err

--- a/cli/metadata/functions/functions.go
+++ b/cli/metadata/functions/functions.go
@@ -51,7 +51,7 @@ func (f *FunctionConfig) Build(metadata *yaml.MapSlice) error {
 	item := yaml.MapItem{
 		Key: "functions",
 	}
-	var obj yaml.MapSlice
+	var obj []yaml.MapSlice
 	err = yaml.Unmarshal(data, &obj)
 	if err != nil {
 		return err

--- a/cli/metadata/querycollections/query_collections.go
+++ b/cli/metadata/querycollections/query_collections.go
@@ -52,7 +52,7 @@ func (q *QueryCollectionConfig) Build(metadata *yaml.MapSlice) error {
 	item := yaml.MapItem{
 		Key: "query_collections",
 	}
-	var obj yaml.MapSlice
+	var obj []yaml.MapSlice
 	err = yaml.Unmarshal(data, &obj)
 	if err != nil {
 		return err

--- a/cli/metadata/remoteschemas/remote_schemas.go
+++ b/cli/metadata/remoteschemas/remote_schemas.go
@@ -51,7 +51,7 @@ func (r *RemoteSchemaConfig) Build(metadata *yaml.MapSlice) error {
 	item := yaml.MapItem{
 		Key: "remote_schemas",
 	}
-	var obj yaml.MapSlice
+	var obj []yaml.MapSlice
 	err = yaml.Unmarshal(data, &obj)
 	if err != nil {
 		return err

--- a/cli/metadata/tables/tables.go
+++ b/cli/metadata/tables/tables.go
@@ -51,7 +51,7 @@ func (t *TableConfig) Build(metadata *yaml.MapSlice) error {
 	}
 	item := yaml.MapItem{
 		Key:   "tables",
-		Value: yaml.MapSlice{},
+		Value: []yaml.MapSlice{},
 	}
 	err = yaml.Unmarshal(data, &item.Value)
 	if err != nil {


### PR DESCRIPTION
### Description
This PR fixes issue with `metadata apply` unable to unmarshal `functions,query_collections` in metadata.

Other Fixes:
- Change `cli-ext` binary name
- Add upx in `cli-ext` docker image. (But upx is not yet support with [pkg](https://github.com/zeit/pkg/issues/50) )

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [x] CLI
- [ ] Docs
- [ ] Community Content
- [x] Build System
- [ ] Tests
- [ ] Other (list it)