### PR TITLE
add base path for docs to fix 404 pages

### DIFF
--- a/docs/_theme/djangodocs/basic/layout.html
+++ b/docs/_theme/djangodocs/basic/layout.html
@@ -125,7 +125,7 @@
     {%- endif %}
     {{- metatags }}
     {%- if pagename == "404" %}
-    <base href="/{{ version }}/{{ pagename }}">
+    <base href="/docs/{{ version }}/{{ pagename }}">
     {% endif %}
     {%- block htmltitle %}
     <title>{{ title|striptags|e }}{{ titlesuffix }}</title>


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
This PR adds base path `/docs` for 404 page template so that assets get loaded correctly.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Docs

