### PR TITLE
cli: fix flags in actions, migrate and metadata cmd (fix #3982)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Hasura GraphQL Engine Changelog
 
-## `v1.2.0-beta.2`
-
-- CLI: fix flags in actions, migrate and metadata commands (close #3982)
-
 ## `v1.2.0-beta.1`
 
 - Introducing Actions: https://docs.hasura.io/1.0/graphql/manual/actions/index.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hasura GraphQL Engine Changelog
 
+## `v1.2.0-beta.2`
+
+- CLI: fix flags in actions, migrate and metadata commands (close #3982)
+
 ## `v1.2.0-beta.1`
 
 - Introducing Actions: https://docs.hasura.io/1.0/graphql/manual/actions/index.html

--- a/cli/commands/actions.go
+++ b/cli/commands/actions.go
@@ -15,12 +15,12 @@ import (
 // NewActionsCmd returns the actions command
 func NewActionsCmd(ec *cli.ExecutionContext) *cobra.Command {
 	v := viper.New()
-	ec.Viper = v
 	actionsCmd := &cobra.Command{
 		Use:          "actions",
 		Short:        "Manage actions on hasura",
 		SilenceUsage: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			ec.Viper = v
 			err := ec.Prepare()
 			if err != nil {
 				return err

--- a/cli/commands/metadata.go
+++ b/cli/commands/metadata.go
@@ -11,12 +11,12 @@ import (
 // NewMetadataCmd returns the metadata command
 func NewMetadataCmd(ec *cli.ExecutionContext) *cobra.Command {
 	v := viper.New()
-	ec.Viper = v
 	metadataCmd := &cobra.Command{
 		Use:     "metadata",
 		Aliases: []string{"md"},
 		Short:   "Manage Hasura GraphQL Engine metadata saved in the database",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			ec.Viper = v
 			err := ec.Prepare()
 			if err != nil {
 				return err

--- a/cli/commands/migrate.go
+++ b/cli/commands/migrate.go
@@ -31,12 +31,12 @@ import (
 // NewMigrateCmd returns the migrate command
 func NewMigrateCmd(ec *cli.ExecutionContext) *cobra.Command {
 	v := viper.New()
-	ec.Viper = v
 	migrateCmd := &cobra.Command{
 		Use:          "migrate",
 		Short:        "Manage migrations on the database",
 		SilenceUsage: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			ec.Viper = v
 			err := ec.Prepare()
 			if err != nil {
 				return err


### PR DESCRIPTION
### Description
This PR fixes the flags which were not working in `actions, migrate and metadata` commands.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [x] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
#3982 

### Solution and Design
Assign `viper` object in PreRun.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->
