### PR TITLE
fix syntax error in codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 /docs/       @marionschleifer
 /cli/        @shahidhk
 /console/    @beerose
-CHANGELOG.md @marionschleifer,@shahidhk
+CHANGELOG.md @marionschleifer @shahidhk


### PR DESCRIPTION
This PR fixes the syntax error that was introduced in https://github.com/hasura/graphql-engine/pull/3946