### PR TITLE
cli: fix typo in cli example for squash (fix #4047)

### DIFF
--- a/cli/commands/migrate_squash.go
+++ b/cli/commands/migrate_squash.go
@@ -39,7 +39,7 @@ func newMigrateSquashCmd(ec *cli.ExecutionContext) *cobra.Command {
 	}
 
 	f := migrateSquashCmd.Flags()
-	f.Uint64Var(&opts.from, "from", 0, "start squashing form this version")
+	f.Uint64Var(&opts.from, "from", 0, "start squashing from this version")
 	f.StringVar(&opts.name, "name", "squashed", "name for the new squashed migration")
 	f.BoolVar(&opts.deleteSource, "delete-source", false, "delete the source files after squashing without any confirmation")
 

--- a/docs/graphql/manual/hasura-cli/hasura_migrate_squash.rst
+++ b/docs/graphql/manual/hasura-cli/hasura_migrate_squash.rst
@@ -38,7 +38,7 @@ Options
 ::
 
       --delete-source   delete the source files after squashing without any confirmation
-      --from uint       start squashing form this version
+      --from uint       start squashing from this version
   -h, --help            help for squash
       --name string     name for the new squashed migration (default "squashed")
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

Fix #4047 

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Affected components
<!-- Remove non-affected components from the list -->

- [x] CLI
- [x] Docs

### Related Issues
#4047
