### PR TITLE
remove spaces from templated url

### DIFF
--- a/docs/graphql/manual/actions/create.rst
+++ b/docs/graphql/manual/actions/create.rst
@@ -183,7 +183,7 @@ Now, set the handler for the action:
   To manage handler endpoints across environments it is possible to template
   the endpoints using ENV variables.
 
-  e.g. ``https://my-handler-endpoint/addNumbers`` can be templated to ``{{ ACTION_BASE_ENDPOINT }}/addNumbers``
+  e.g. ``https://my-handler-endpoint/addNumbers`` can be templated to ``{{ACTION_BASE_ENDPOINT}}/addNumbers``
   where ``ACTION_BASE_ENDPOINT`` is an ENV variable whose value is set to ``https://my-handler-endpoint``
 
 Step 3: Finish action creation


### PR DESCRIPTION
### Description

There is a typo in the docs for URL templating in actions.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [ ] CLI
- [x] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

