### PR TITLE
exclude pro from release channel

### DIFF
--- a/cli/version/console.go
+++ b/cli/version/console.go
@@ -48,7 +48,7 @@ func (v *Version) GetConsoleAssetsVersion() (av string) {
 				// Get the correct channel from the prerelease tag
 				var re = regexp.MustCompile(`^[a-z]+`)
 				tag := re.FindString(preRelease)
-				if tag != "" {
+				if tag != "" && tag != "pro" {
 					channel = tag
 				}
 			}

--- a/scripts/get-console-assets-version.sh
+++ b/scripts/get-console-assets-version.sh
@@ -16,7 +16,7 @@ if [[ "$LATEST_TAG" =~ $SEMVER_REGEX ]]; then
     major=${BASH_REMATCH[1]}
     minor=${BASH_REMATCH[2]}
     release=${BASH_REMATCH[5]}
-    if [[ "$release" =~ $CHANNEL_REGEX ]]; then
+    if [[ "$release" =~ $CHANNEL_REGEX ]] && [[ "${BASH_REMATCH[0]}" != "pro" ]]; then
         channel="${BASH_REMATCH[0]}"
     fi
     VERSION="channel/$channel/v$major$minor"

--- a/server/src-lib/Hasura/Server/Version.hs
+++ b/server/src-lib/Hasura/Server/Version.hs
@@ -17,7 +17,7 @@ import qualified Data.SemVer                as V
 import qualified Data.Text                  as T
 import qualified Language.Haskell.TH.Syntax as TH
 
-import           Text.Regex.TDFA           ((=~~))
+import           Text.Regex.TDFA            ((=~~))
 import           Control.Lens               ((^.), (^?))
 import           Data.Aeson                 (FromJSON (..), ToJSON (..))
 import           Data.Text.Conversions      (FromText (..), ToText (..))
@@ -88,7 +88,9 @@ consoleAssetsVersion = case currentVersion of
         Nothing -> Nothing
         Just r  -> if
           | T.null r   -> Nothing
-          | otherwise  -> T.pack <$> (getChannelFromPreRelease $ T.unpack r)
+          | otherwise  -> T.pack <$> (getChannelFromPreRelease $ T.unpack r) >>= \pr -> if
+                            | pr == "pro" -> Just "stable"
+                            | otherwise   -> Just pr
 
     getChannelFromPreRelease :: String -> Maybe String
     getChannelFromPreRelease sv = sv =~~ ("^([a-z]+)"::String)


### PR DESCRIPTION
### Description
This PR excludes `pro` from release channel which enables to load console assets from `stable` channel.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [ ] Console
- [x] CLI
- [ ] Docs
- [ ] Community Content
- [x] Build System
- [ ] Tests
- [ ] Other (list it)

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->
