### PR TITLE
ci: fix ciignore script to ignore certain directories

### DIFF
--- a/.circleci/ciignore.sh
+++ b/.circleci/ciignore.sh
@@ -49,10 +49,10 @@ echo "Changes in this build:"
 echo $changes
 echo
 
-if [[ ${#changes[@]} -gt 0 ]]; then
-	  # If there's still changes left, then we have stuff to build, leave the commit alone.
+if [[ ! -z "$changes" ]]; then
+	# If there's still changes left, then we have stuff to build, leave the commit alone.
     echo "Files that are not ignored present in commits, need to build, succeed the job"
-	  exit
+	exit
 fi
 
 echo "Only ignored files are present in commits, build is not required, write the skip_job file"


### PR DESCRIPTION
### Description
This PR fixes an issue with `ciignore.sh` script to ignore blacklist directories.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [x] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->
