### PR TITLE
cli: fix parse error returned on console api (close #4126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   
 ### Other changes
 
+- cli: fix parse error returned on console api (close #4126)
 - console and cli-ext: fix parsing of wrapped types in SDL
 - cli: fix typo in cli example for squash (fix #4047) (#4049)
 - console: fix run_sql migration modal messaging (close #4020) (#4060)

--- a/cli/migrate/database/hasuradb/metadata.go
+++ b/cli/migrate/database/hasuradb/metadata.go
@@ -31,14 +31,8 @@ func (h *HasuraDB) ExportMetadata() (map[string][]byte, error) {
 	}
 	h.logger.Debug("response: ", string(body))
 
-	var horror HasuraError
 	if resp.StatusCode != http.StatusOK {
-		err = json.Unmarshal(body, &horror)
-		if err != nil {
-			h.logger.Debug(err)
-			return nil, fmt.Errorf("failed parsing json: %v; response from API: %s", err, string(body))
-		}
-		return nil, horror.Error(h.config.isCMD)
+		return nil, NewHasuraError(body, h.config.isCMD)
 	}
 
 	var c yaml.MapSlice
@@ -74,14 +68,8 @@ func (h *HasuraDB) ResetMetadata() error {
 	}
 	h.logger.Debug("response: ", string(body))
 
-	var horror HasuraError
 	if resp.StatusCode != http.StatusOK {
-		err = json.Unmarshal(body, &horror)
-		if err != nil {
-			h.logger.Debug(err)
-			return fmt.Errorf("failed parsing json: %v; response from API: %s", err, string(body))
-		}
-		return horror.Error(h.config.isCMD)
+		return NewHasuraError(body, h.config.isCMD)
 	}
 	return nil
 }
@@ -100,14 +88,8 @@ func (h *HasuraDB) ReloadMetadata() error {
 	}
 	h.logger.Debug("response: ", string(body))
 
-	var horror HasuraError
 	if resp.StatusCode != http.StatusOK {
-		err = json.Unmarshal(body, &horror)
-		if err != nil {
-			h.logger.Debug(err)
-			return fmt.Errorf("failed parsing json: %v; response from API: %s", err, string(body))
-		}
-		return horror.Error(h.config.isCMD)
+		return NewHasuraError(body, h.config.isCMD)
 	}
 	return nil
 }
@@ -125,14 +107,8 @@ func (h *HasuraDB) GetInconsistentMetadata() (bool, []database.InconsistentMetad
 	}
 	h.logger.Debug("response: ", string(body))
 
-	var horror HasuraError
 	if resp.StatusCode != http.StatusOK {
-		err = json.Unmarshal(body, &horror)
-		if err != nil {
-			h.logger.Debug(err)
-			return false, nil, err
-		}
-		return false, nil, horror.Error(h.config.isCMD)
+		return false, nil, NewHasuraError(body, h.config.isCMD)
 	}
 
 	var inMet InconsistentMetadata
@@ -160,14 +136,8 @@ func (h *HasuraDB) DropInconsistentMetadata() error {
 	}
 	h.logger.Debug("response: ", string(body))
 
-	var horror HasuraError
 	if resp.StatusCode != http.StatusOK {
-		err = json.Unmarshal(body, &horror)
-		if err != nil {
-			h.logger.Debug(err)
-			return err
-		}
-		return horror.Error(h.config.isCMD)
+		return NewHasuraError(body, h.config.isCMD)
 	}
 	return nil
 }
@@ -221,34 +191,32 @@ func (h *HasuraDB) ApplyMetadata() error {
 	}
 	h.logger.Debug("response: ", string(body))
 
-	var horror HasuraError
 	if resp.StatusCode != http.StatusOK {
-		err = json.Unmarshal(body, &horror)
-		if err != nil {
-			h.logger.Debug(err)
-			return fmt.Errorf("failed parsing json: %v; response from API: %s", err, string(body))
-		}
-
-		if horror.Path != "" {
-			jsonData, err := json.Marshal(query)
-			if err != nil {
-				return err
-			}
-			var metadataQuery interface{}
-			err = json.Unmarshal(jsonData, &metadataQuery)
-			if err != nil {
-				return err
-			}
-			lookup, err := jsonpath.JsonPathLookup(metadataQuery, horror.Path)
-			if err == nil {
-				queryData, err := json.MarshalIndent(lookup, "", "  ")
+		switch herror := NewHasuraError(body, h.config.isCMD).(type) {
+		case HasuraError:
+			if herror.Path != "" {
+				jsonData, err := json.Marshal(query)
 				if err != nil {
 					return err
 				}
-				horror.migrationQuery = "offending object: \n\r\n\r" + string(queryData)
+				var metadataQuery interface{}
+				err = json.Unmarshal(jsonData, &metadataQuery)
+				if err != nil {
+					return err
+				}
+				lookup, err := jsonpath.JsonPathLookup(metadataQuery, herror.Path)
+				if err == nil {
+					queryData, err := json.MarshalIndent(lookup, "", "  ")
+					if err != nil {
+						return err
+					}
+					herror.migrationQuery = "offending object: \n\r\n\r" + string(queryData)
+				}
 			}
+			return herror
+		default:
+			return herror
 		}
-		return horror.Error(h.config.isCMD)
 	}
 	return nil
 }
@@ -266,14 +234,8 @@ func (h *HasuraDB) Query(data interface{}) error {
 	}
 	h.logger.Debug("response: ", string(body))
 
-	var horror HasuraError
 	if resp.StatusCode != http.StatusOK {
-		err = json.Unmarshal(body, &horror)
-		if err != nil {
-			h.logger.Debug(err)
-			return fmt.Errorf("failed parsing json: %v; response from API: %s", err, string(body))
-		}
-		return horror.Error(h.config.isCMD)
+		return NewHasuraError(body, h.config.isCMD)
 	}
 	return nil
 }

--- a/cli/migrate/database/hasuradb/schema_dump.go
+++ b/cli/migrate/database/hasuradb/schema_dump.go
@@ -1,7 +1,6 @@
 package hasuradb
 
 import (
-	"encoding/json"
 	"net/http"
 )
 
@@ -22,14 +21,8 @@ func (h *HasuraDB) ExportSchemaDump(schemaNames []string) ([]byte, error) {
 	}
 	h.logger.Debug("response: ", string(body))
 
-	var horror HasuraError
 	if resp.StatusCode != http.StatusOK {
-		err = json.Unmarshal(body, &horror)
-		if err != nil {
-			h.logger.Debug(err)
-			return nil, err
-		}
-		return nil, horror.Error(h.config.isCMD)
+		return nil, NewHasuraError(body, h.config.isCMD)
 	}
 
 	return body, nil

--- a/cli/migrate/database/hasuradb/settings.go
+++ b/cli/migrate/database/hasuradb/settings.go
@@ -26,14 +26,8 @@ func (h *HasuraDB) ensureSettingsTable() error {
 	}
 	h.logger.Debug("response: ", string(body))
 
-	var horror HasuraError
 	if resp.StatusCode != http.StatusOK {
-		err = json.Unmarshal(body, &horror)
-		if err != nil {
-			h.logger.Debug(err)
-			return fmt.Errorf("failed parsing json: %v; response from API: %s", err, string(body))
-		}
-		return horror.Error(h.config.isCMD)
+		return NewHasuraError(body, h.config.isCMD)
 	}
 
 	var hres HasuraSQLRes
@@ -67,12 +61,7 @@ func (h *HasuraDB) ensureSettingsTable() error {
 	h.logger.Debug("response: ", string(body))
 
 	if resp.StatusCode != http.StatusOK {
-		err = json.Unmarshal(body, &horror)
-		if err != nil {
-			return fmt.Errorf("failed parsing json: %v; response from API: %s", err, string(body))
-		}
-
-		return horror.Error(h.config.isCMD)
+		return NewHasuraError(body, h.config.isCMD)
 	}
 
 	err = json.Unmarshal(body, &hres)
@@ -110,14 +99,8 @@ func (h *HasuraDB) setDefaultSettings() error {
 		return err
 	}
 
-	var horror HasuraError
 	if resp.StatusCode != http.StatusOK {
-		err = json.Unmarshal(body, &horror)
-		if err != nil {
-			h.logger.Debug(err)
-			return fmt.Errorf("failed parsing json: %v; response from API: %s", err, string(body))
-		}
-		return horror.Error(h.config.isCMD)
+		return NewHasuraError(body, h.config.isCMD)
 	}
 
 	return nil
@@ -138,16 +121,9 @@ func (h *HasuraDB) GetSetting(name string) (value string, err error) {
 	}
 	h.logger.Debug("response: ", string(body))
 
-	var horror HasuraError
-
 	// If status != 200 return error
 	if resp.StatusCode != http.StatusOK {
-		err = json.Unmarshal(body, &horror)
-		if err != nil {
-			return value, fmt.Errorf("failed parsing json: %v; response from API: %s", err, string(body))
-		}
-
-		return value, horror.Error(h.config.isCMD)
+		return value, NewHasuraError(body, h.config.isCMD)
 	}
 
 	var hres HasuraSQLRes
@@ -187,16 +163,9 @@ func (h *HasuraDB) UpdateSetting(name string, value string) error {
 	}
 	h.logger.Debug("response: ", string(body))
 
-	var horror HasuraError
-
 	// If status != 200 return error
 	if resp.StatusCode != http.StatusOK {
-		err = json.Unmarshal(body, &horror)
-		if err != nil {
-			return fmt.Errorf("failed parsing json: %v; response from API: %s", err, string(body))
-		}
-
-		return horror.Error(h.config.isCMD)
+		return NewHasuraError(body, h.config.isCMD)
 	}
 
 	var hres HasuraSQLRes

--- a/cli/migrate/database/hasuradb/types.go
+++ b/cli/migrate/database/hasuradb/types.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hasura/graphql-engine/cli/migrate/database"
 
 	"github.com/qor/transition"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -203,7 +202,7 @@ type SchemaDump struct {
 	CleanOutput bool     `json:"clean_output"`
 }
 
-func (h *HasuraError) CMDError() error {
+func (h HasuraError) Error() string {
 	var errorStrings []string
 	errorStrings = append(errorStrings, fmt.Sprintf("[%s] %s (%s)", h.Code, h.ErrorMessage, h.Path))
 	if h.migrationFile != "" {
@@ -222,27 +221,22 @@ func (h *HasuraError) CMDError() error {
 			errorStrings = append(errorStrings, fmt.Sprintf("Hint: %s", h.Internal.Error.Hint))
 		}
 	}
-	return fmt.Errorf(strings.Join(errorStrings, "\r\n"))
+	return strings.Join(errorStrings, "\r\n")
 }
 
-func (h *HasuraError) APIError() error {
-	data, err := json.Marshal(&h)
-	if err != nil {
-		return err
-	}
-	return fmt.Errorf("Data Error: %s", string(data))
-}
-
-func (h *HasuraError) Error(isCMD bool) error {
-	var err error
-	switch isCMD {
+// NewHasuraError - returns error based on data and isCmd
+func NewHasuraError(data []byte, isCmd bool) error {
+	switch isCmd {
 	case true:
-		err = h.CMDError()
-	case false:
-		err = h.APIError()
+		var herror HasuraError
+		err := json.Unmarshal(data, &herror)
+		if err != nil {
+			return fmt.Errorf("failed parsing json: %v; response from API: %s", err, string(data))
+		}
+		return herror
+	default:
+		return fmt.Errorf("Data Error: %s", string(data))
 	}
-	log.Debug(err)
-	return err
 }
 
 type HasuraSQLRes struct {


### PR DESCRIPTION
### Description
This PR fixes the parse error that is returned on console api by not unmarshaling the data api error into `HasuraError`

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [x] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
#4126 

### Solution and Design
Previously, cli tries to parse the data api error into `HasuraError` for console API which results in parse error if the types were not defined correctly.

Instead, this PR fixes the above issue by not unmarshaling the data api error message into `HasuraError`

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->