### PR TITLE
server: fix all EWKT warnings in python tests

### DIFF
--- a/server/tests-py/queries/graphql_query/boolexp/postgis/setup.yaml
+++ b/server/tests-py/queries/graphql_query/boolexp/postgis/setup.yaml
@@ -64,11 +64,11 @@ args:
     sql: |
       INSERT INTO geom_table (type, geom_col)
       VALUES
-      ('point', ST_GeomFromText('SRID=4326;POINT(1 2)')),
-      ('linestring', ST_GeomFromText('SRID=4326;LINESTRING(0 0, 0.5 1, 1 2, 1.5 3)')),
-      ('linestring', ST_GeomFromText('SRID=4326;LINESTRING(1 0, 0.5 0.5, 0 1)')),
-      ('polygon', ST_GeomFromText('SRID=4326;POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))')),
-      ('polygon', ST_GeomFromText('SRID=4326;POLYGON((2 0, 2 1, 3 1, 3 0, 2 0))'))
+      ('point', ST_GeomFromEWKT('SRID=4326;POINT(1 2)')),
+      ('linestring', ST_GeomFromEWKT('SRID=4326;LINESTRING(0 0, 0.5 1, 1 2, 1.5 3)')),
+      ('linestring', ST_GeomFromEWKT('SRID=4326;LINESTRING(1 0, 0.5 0.5, 0 1)')),
+      ('polygon', ST_GeomFromEWKT('SRID=4326;POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))')),
+      ('polygon', ST_GeomFromEWKT('SRID=4326;POLYGON((2 0, 2 1, 3 1, 3 0, 2 0))'))
       ;
 - type: run_sql
   args:
@@ -86,7 +86,7 @@ args:
     sql: |
       INSERT INTO geog_as_geom_table (name, geom_col)
       VALUES
-      ('London', ST_GeomFromText('SRID=4326;POINT(0.1278 51.5074)')),
-      ('Paris',  ST_GeomFromText('SRID=4326;POINT(2.3522 48.8566)')),
-      ('Moscow', ST_GeomFromText('SRID=4326;POINT(37.6173 55.7558)')),
-      ('New York', ST_GeomFromText('SRID=4326;POINT(-74.0060 40.7128)'));
+      ('London', ST_GeomFromEWKT('SRID=4326;POINT(0.1278 51.5074)')),
+      ('Paris',  ST_GeomFromEWKT('SRID=4326;POINT(2.3522 48.8566)')),
+      ('Moscow', ST_GeomFromEWKT('SRID=4326;POINT(37.6173 55.7558)')),
+      ('New York', ST_GeomFromEWKT('SRID=4326;POINT(-74.0060 40.7128)'));

--- a/server/tests-py/queries/graphql_query/boolexp/raster/setup.yaml
+++ b/server/tests-py/queries/graphql_query/boolexp/raster/setup.yaml
@@ -19,8 +19,8 @@ args:
         rast raster
       );
       INSERT INTO dummy_rast (rast) values
-        (ST_AsRaster(ST_Buffer(ST_GeomFromText('SRID=4326;POINT(1 2)'),2), 5, 5))
-      , (ST_AsRaster(ST_Buffer(ST_GeomFromText('SRID=4326;LINESTRING(0 0, 0.5 1, 1 2, 1.5 3)'), 2), 5, 5))
+        (ST_AsRaster(ST_Buffer(ST_GeomFromEWKT('SRID=4326;POINT(1 2)'),2), 5, 5))
+      , (ST_AsRaster(ST_Buffer(ST_GeomFromEWKT('SRID=4326;LINESTRING(0 0, 0.5 1, 1 2, 1.5 3)'), 2), 5, 5))
       ;
 - type: track_table
   args:

--- a/server/tests-py/queries/graphql_query/permissions/setup.yaml
+++ b/server/tests-py/queries/graphql_query/permissions/setup.yaml
@@ -370,11 +370,11 @@ args:
     sql: |
       INSERT INTO geom_table (type, geom_col)
       VALUES
-      ('point', ST_GeomFromText('SRID=4326;POINT(1 2)')),
-      ('linestring', ST_GeomFromText('SRID=4326;LINESTRING(0 0, 0.5 1, 1 2, 1.5 3)')),
-      ('linestring', ST_GeomFromText('SRID=4326;LINESTRING(1 0, 0.5 0.5, 0 1)')),
-      ('polygon', ST_GeomFromText('SRID=4326;POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))')),
-      ('polygon', ST_GeomFromText('SRID=4326;POLYGON((2 0, 2 1, 3 1, 3 0, 2 0))'))
+      ('point', ST_GeomFromEWKT('SRID=4326;POINT(1 2)')),
+      ('linestring', ST_GeomFromEWKT('SRID=4326;LINESTRING(0 0, 0.5 1, 1 2, 1.5 3)')),
+      ('linestring', ST_GeomFromEWKT('SRID=4326;LINESTRING(1 0, 0.5 0.5, 0 1)')),
+      ('polygon', ST_GeomFromEWKT('SRID=4326;POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))')),
+      ('polygon', ST_GeomFromEWKT('SRID=4326;POLYGON((2 0, 2 1, 3 1, 3 0, 2 0))'))
       ;
 
 

--- a/server/tests-py/queries/v1/select/boolexp/postgis/setup.yaml
+++ b/server/tests-py/queries/v1/select/boolexp/postgis/setup.yaml
@@ -66,11 +66,11 @@ args:
     sql: |
       INSERT INTO geom_table (type, geom_col)
       VALUES
-      ('point', ST_GeomFromText('SRID=4326;POINT(1 2)')),
-      ('linestring', ST_GeomFromText('SRID=4326;LINESTRING(0 0, 0.5 1, 1 2, 1.5 3)')),
-      ('linestring', ST_GeomFromText('SRID=4326;LINESTRING(1 0, 0.5 0.5, 0 1)')),
-      ('polygon', ST_GeomFromText('SRID=4326;POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))')),
-      ('polygon', ST_GeomFromText('SRID=4326;POLYGON((2 0, 2 1, 3 1, 3 0, 2 0))'))
+      ('point', ST_GeomFromEWKT('SRID=4326;POINT(1 2)')),
+      ('linestring', ST_GeomFromEWKT('SRID=4326;LINESTRING(0 0, 0.5 1, 1 2, 1.5 3)')),
+      ('linestring', ST_GeomFromEWKT('SRID=4326;LINESTRING(1 0, 0.5 0.5, 0 1)')),
+      ('polygon', ST_GeomFromEWKT('SRID=4326;POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))')),
+      ('polygon', ST_GeomFromEWKT('SRID=4326;POLYGON((2 0, 2 1, 3 1, 3 0, 2 0))'))
       ;
 - type: run_sql
   args:
@@ -88,7 +88,7 @@ args:
     sql: |
       INSERT INTO geog_as_geom_table (name, geom_col)
       VALUES
-      ('London', ST_GeomFromText('SRID=4326;POINT(0.1278 51.5074)')),
-      ('Paris',  ST_GeomFromText('SRID=4326;POINT(2.3522 48.8566)')),
-      ('Moscow', ST_GeomFromText('SRID=4326;POINT(37.6173 55.7558)')),
-      ('New York', ST_GeomFromText('SRID=4326;POINT(-74.0060 40.7128)'));
+      ('London', ST_GeomFromEWKT('SRID=4326;POINT(0.1278 51.5074)')),
+      ('Paris',  ST_GeomFromEWKT('SRID=4326;POINT(2.3522 48.8566)')),
+      ('Moscow', ST_GeomFromEWKT('SRID=4326;POINT(37.6173 55.7558)')),
+      ('New York', ST_GeomFromEWKT('SRID=4326;POINT(-74.0060 40.7128)'));

--- a/server/tests-py/queries/v1/select/permissions/setup.yaml
+++ b/server/tests-py/queries/v1/select/permissions/setup.yaml
@@ -256,11 +256,11 @@ args:
     sql: |
       INSERT INTO geom_table (type, geom_col)
       VALUES
-      ('point', ST_GeomFromText('SRID=4326;POINT(1 2)')),
-      ('linestring', ST_GeomFromText('SRID=4326;LINESTRING(0 0, 0.5 1, 1 2, 1.5 3)')),
-      ('linestring', ST_GeomFromText('SRID=4326;LINESTRING(1 0, 0.5 0.5, 0 1)')),
-      ('polygon', ST_GeomFromText('SRID=4326;POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))')),
-      ('polygon', ST_GeomFromText('SRID=4326;POLYGON((2 0, 2 1, 3 1, 3 0, 2 0))'))
+      ('point', ST_GeomFromEWKT('SRID=4326;POINT(1 2)')),
+      ('linestring', ST_GeomFromEWKT('SRID=4326;LINESTRING(0 0, 0.5 1, 1 2, 1.5 3)')),
+      ('linestring', ST_GeomFromEWKT('SRID=4326;LINESTRING(1 0, 0.5 0.5, 0 1)')),
+      ('polygon', ST_GeomFromEWKT('SRID=4326;POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))')),
+      ('polygon', ST_GeomFromEWKT('SRID=4326;POLYGON((2 0, 2 1, 3 1, 3 0, 2 0))'))
       ;
 
 #Permission based on Geography columns


### PR DESCRIPTION
### Description
The setup in several tests was using `ST_GeomFromText`, which expects data in the OGC WKT format, but was providing the SRID in the text itself, which is part of the EWKT format. The result was: a lot of warnings at test time.

The fix was simply to replace all calls to `ST_GeomFromText` to `ST_GeomFromEWKT`.

### Affected components
- [ ] Tests