### PR TITLE
server: add tests for track_table of a materialized view

### DIFF
--- a/server/tests-py/queries/v1/track_table/setup.yaml
+++ b/server/tests-py/queries/v1/track_table/setup.yaml
@@ -30,13 +30,26 @@ args:
         age INTEGER NOT NULL
       );
 
+
       INSERT INTO author (name) VALUES
         ('Author 1'),
         ('Author 2');
 
+      INSERT INTO article (title, author_id) VALUES
+        ('Lorem ipsum dolor sit amet',  1),
+        ('lolcats: an anthology',       2),
+        ('consectetur adipiscing elit', 1);
+
       INSERT INTO hge_tests.resident (name, age) VALUES
         ('Resident 1', 23),
         ('Resident 2', 31);
+
+
+      CREATE MATERIALIZED VIEW articles AS
+          SELECT article.title, author.name
+          FROM article
+          LEFT JOIN author ON author.id = article.author_id
+      ;
 
       CREATE OR REPLACE FUNCTION test1()
       RETURNS SETOF test2 AS $$

--- a/server/tests-py/queries/v1/track_table/teardown.yaml
+++ b/server/tests-py/queries/v1/track_table/teardown.yaml
@@ -4,6 +4,7 @@ args:
 - type: run_sql
   args:
     sql: |
+      DROP MATERIALIZED VIEW articles;
       DROP TABLE hge_tests.resident;
       DROP TABLE article;
       DROP TABLE author;

--- a/server/tests-py/queries/v1/track_table/track_untrack_materialized_view.yaml
+++ b/server/tests-py/queries/v1/track_table/track_untrack_materialized_view.yaml
@@ -1,4 +1,4 @@
-- description: Track matview
+- description: Track materialized view
   url: /v1/query
   status: 200
   response:
@@ -8,7 +8,7 @@
     args:
       name: articles
 
-- description: Track already untracked matview
+- description: Track already untracked materialized view
   url: /v1/query
   status: 400
   response:
@@ -38,8 +38,7 @@
         - title
         - name
 
-#Untrack matview
-- description: Untrack matview
+- description: Untrack materialized view
   url: /v1/query
   status: 200
   response:
@@ -50,8 +49,7 @@
       table: articles
 
 
-#Untrack matview
-- description: Untrack matview
+- description: Untrack materialized view
   url: /v1/query
   status: 400
   response:
@@ -63,7 +61,6 @@
     args:
       table: articles
 
-#Run a select query: error
 - description: Select query error
   url: /v1/query
   status: 400

--- a/server/tests-py/queries/v1/track_table/track_untrack_matview.yaml
+++ b/server/tests-py/queries/v1/track_table/track_untrack_matview.yaml
@@ -1,0 +1,80 @@
+- description: Track matview
+  url: /v1/query
+  status: 200
+  response:
+    message: success
+  query:
+    type: track_table
+    args:
+      name: articles
+
+- description: Track already untracked matview
+  url: /v1/query
+  status: 400
+  response:
+    path: $.args
+    error: 'view/table already tracked : "articles"'
+    code: already-tracked
+  query:
+    type: track_table
+    args:
+      name: articles
+
+- description: Select query
+  url: /v1/query
+  status: 200
+  response:
+  - title: "Lorem ipsum dolor sit amet"
+    name: Author 1
+  - title: "lolcats: an anthology"
+    name: Author 2
+  - title: "consectetur adipiscing elit"
+    name: Author 1
+  query:
+    type: select
+    args:
+      table: articles
+      columns:
+        - title
+        - name
+
+#Untrack matview
+- description: Untrack matview
+  url: /v1/query
+  status: 200
+  response:
+    message: success
+  query:
+    type: untrack_table
+    args:
+      table: articles
+
+
+#Untrack matview
+- description: Untrack matview
+  url: /v1/query
+  status: 400
+  response:
+    path: $.args
+    error: 'view/table already untracked : "articles"'
+    code: already-untracked
+  query:
+    type: untrack_table
+    args:
+      table: articles
+
+#Run a select query: error
+- description: Select query error
+  url: /v1/query
+  status: 400
+  response:
+    path: $.args.table
+    error: table "articles" does not exist
+    code: not-exists
+  query:
+    type: select
+    args:
+      table: articles
+      columns:
+        - title
+        - name

--- a/server/tests-py/test_v1_queries.py
+++ b/server/tests-py/test_v1_queries.py
@@ -629,8 +629,8 @@ class TestTrackTables:
         check_query_f(hge_ctx, self.dir() + '/track_untrack_table.yaml')
         hge_ctx.may_skip_test_teardown = True
 
-    def test_track_untrack_matview(self, hge_ctx):
-        check_query_f(hge_ctx, self.dir() + '/track_untrack_matview.yaml')
+    def test_track_untrack_materialized_view(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + '/track_untrack_materialized_view.yaml')
         hge_ctx.may_skip_test_teardown = True
 
     def test_track_untrack_table_with_deps(self, hge_ctx):

--- a/server/tests-py/test_v1_queries.py
+++ b/server/tests-py/test_v1_queries.py
@@ -629,6 +629,10 @@ class TestTrackTables:
         check_query_f(hge_ctx, self.dir() + '/track_untrack_table.yaml')
         hge_ctx.may_skip_test_teardown = True
 
+    def test_track_untrack_matview(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + '/track_untrack_matview.yaml')
+        hge_ctx.may_skip_test_teardown = True
+
     def test_track_untrack_table_with_deps(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + '/track_untrack_table_deps.yaml')
         hge_ctx.may_skip_test_teardown = True


### PR DESCRIPTION
### Description
In the context of #91, we discovered that materialized views were already "automagically" supported; to ensure we don't regress on this accidental but welcome change, this patch adds simple tests.

This is basically just a copy of `track_untrack_table`, but for materialized views.

### Affected components
- [ ] Tests