### PR TITLE
console shared modules: fix parsing of wrapped types in SDL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   
 ### Other changes
 
+- console and cli-ext: fix parsing of wrapped types in SDL
 - cli: fix typo in cli example for squash (fix #4047) (#4049)
 - console: fix run_sql migration modal messaging (close #4020) (#4060)
 - docs: add note on pg versions for actions (#4034)

--- a/console/src/shared/utils/wrappingTypeUtils.js
+++ b/console/src/shared/utils/wrappingTypeUtils.js
@@ -35,7 +35,7 @@ export const unwrapType = wrappedTypename => {
 };
 
 export const getAstTypeMetadata = type => {
-  let _t = { type };
+  let _t = { ...type };
   const typewraps = [];
   while (_t.kind !== 'NamedType') {
     if (_t.kind === 'ListType') {
@@ -74,7 +74,7 @@ export const getSchemaTypeMetadata = type => {
 
 export const wrapTypename = (name, wrapperStack) => {
   let wrappedTypename = name;
-  wrapperStack.forEach(w => {
+  wrapperStack.reverse().forEach(w => {
     if (w === 'l') {
       wrappedTypename = `[${wrappedTypename}]`;
     }


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
If the the type is wrapped with a combination of arrays and non-nullables in SDL (ex: `[String!]!`), console reverses the order currently.

This PR fixes it.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#4099 

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Try writing arbitrary types in SDL format in actions. Ex: `[[Int]!]!`. Hit save, the order must be maintained.
