### PR TITLE
console: fix passing default value to JsonInput

### DIFF
--- a/console/src/components/Services/Data/Common/Components/TypedInput.js
+++ b/console/src/components/Services/Data/Common/Components/TypedInput.js
@@ -89,10 +89,12 @@ export const TypedInput = ({
     case JSONDTYPE:
       return (
         <JsonInput
-          {...standardInputProps}
-          defaultValue={
-            prevValue ? JSON.stringify(prevValue) : getDefaultValue()
-          }
+          standardProps={{
+            ...standardInputProps,
+            defaultValue: prevValue
+              ? JSON.stringify(prevValue)
+              : getDefaultValue(),
+          }}
           placeholderProp={placeHolder}
         />
       );


### PR DESCRIPTION
### Description

Props weren't appropriately passed to the JsonInput component causing a runtime error. 

### How to reproduce

1. Create a table with JSONB field. 
2. Go to `insert row`.

Before: runtime error.
After: no runtime error. 

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components

- [x] Console