### PR TITLE
tests: fix stringify function

### DIFF
--- a/server/tests-py/validate.py
+++ b/server/tests-py/validate.py
@@ -407,6 +407,7 @@ def collapse_order_not_selset(result_inp, query):
 # Use this since jsondiff seems to produce object/dict structures that can't
 # always be serialized to json.
 def stringify_keys(d):
+    """Recursively convert a dict's keys to strings."""
     if not isinstance(d, dict): return d
 
     def decode(k):
@@ -414,9 +415,6 @@ def stringify_keys(d):
         try:
             return k.decode("utf-8")
         except Exception:
-            try:
-                return repr(k)
-            except Exception:
-                raise
+            return repr(k)
 
     return { decode(k): stringify_keys(v) for k, v in d.items() }

--- a/server/tests-py/validate.py
+++ b/server/tests-py/validate.py
@@ -406,26 +406,17 @@ def collapse_order_not_selset(result_inp, query):
 
 # Use this since jsondiff seems to produce object/dict structures that can't
 # always be serialized to json.
-# Copy-pasta from: https://stackoverflow.com/q/12734517/176841
 def stringify_keys(d):
- """Convert a dict's keys to strings if they are not."""
- if isinstance(d, dict):
-   for key in d.keys():
-     # check inner dict
-     if isinstance(d[key], dict):
-         value = stringify_keys(d[key])
-     else:
-         value = d[key]
-     # convert nonstring to string if needed
-     if not isinstance(key, str):
-         try:
-             d[key.decode("utf-8")] = value
-         except Exception:
-             try:
-                 d[repr(key)] = value
-             except Exception:
-                 raise
+    if not isinstance(d, dict): return d
 
-         # delete old key
-         del d[key]
- return d
+    def decode(k):
+        if isinstance(k, str): return k
+        try:
+            return k.decode("utf-8")
+        except Exception:
+            try:
+                return repr(k)
+            except Exception:
+                raise
+
+    return { decode(k): stringify_keys(v) for k, v in d.items() }


### PR DESCRIPTION
### Description

The stackoverflow answer this was copied from has a glaring problem: python really dislikes a dictionary being modified while it is being iterated on. I rewrote the function to instead return a modified copy.

Interestingly, this only surfaced when some tests were failing, which is probably why it remained undetected. 

### Affected components
- [ ] Tests