### PR TITLE
Fix bulk deleting roles without permissions close #4178

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,3 +102,4 @@
 - console: add design system base components (#3866)
 - docs: add docs for redeliver_event API
 - option to reload remote schemas in 'reload_metadata' API (fix #3792, #4117)
+- console: fix bulk deleting roles without permissions (#4195)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,4 +102,4 @@
 - console: add design system base components (#3866)
 - docs: add docs for redeliver_event API
 - option to reload remote schemas in 'reload_metadata' API (fix #3792, #4117)
-- console: fix bulk deleting roles without permissions (#4195)
+- console: disable selecting roles without permissions for bulk actions (close #4178) (#4195)

--- a/console/src/components/Common/Permissions/TableRow.js
+++ b/console/src/components/Common/Permissions/TableRow.js
@@ -52,7 +52,8 @@ const TableRow = ({
             className={styles.cursorPointer}
             checked={bulkSection.checked}
             data-role={bulkSection.role}
-            title="Select for bulk actions"
+            disabled={bulkSection.disableCheckbox}
+            title={bulkSection.title}
             type="checkbox"
           />
           {/*{deleteIcon}*/}

--- a/console/src/components/Services/Data/TablePermissions/Permissions.js
+++ b/console/src/components/Services/Data/TablePermissions/Permissions.js
@@ -286,6 +286,8 @@ class Permissions extends Component {
       };
 
       const getPermissionsTableBody = () => {
+        const rolePermissions = getTablePermissionsByRoles(tableSchema);
+
         const getBulkCheckbox = (role, isNewRole) => {
           const dispatchBulkSelect = e => {
             const isChecked = e.target.checked;
@@ -293,8 +295,12 @@ class Permissions extends Component {
             dispatch(permSetBulkSelect(isChecked, selectedRole));
           };
 
+          const disableCheckbox = !Object.keys(rolePermissions).includes(role);
+
           return {
             showCheckbox: !(role === 'admin' || isNewRole),
+            disableCheckbox,
+            title: disableCheckbox ? 'No permissions exist' : 'Select for bulk actions',
             bulkSelect: permissionsState.bulkSelect,
             onChange: dispatchBulkSelect,
             role,
@@ -334,8 +340,6 @@ class Permissions extends Component {
 
           const getRoleQueryPermission = queryType => {
             let _permission;
-
-            const rolePermissions = getTablePermissionsByRoles(tableSchema);
 
             if (role === 'admin') {
               _permission = permissionsSymbols.fullAccess;


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Roles without any permissions can't be bulk deleted and throws an error as described in #4178.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#4178 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
Do not render the checkbox for roles without any permission. That way, the user can't select it.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Try to mark and bulk delete a role without any permissions configured in a table, watch the inspector before doing it.

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->
N/A

### Server checklist
<!-- A checklist for server code -->
N/A

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
