### PR TITLE
console: support materialized views

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -483,6 +483,8 @@ jobs:
     - run:
         name: test console
         command: .circleci/test-console.sh
+    - store_artifacts:
+        path: /build/_console_output/server.log
 
   # test server upgrade from last version to current build
   test_server_upgrade:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+help:
+	@echo "available commands:"
+	@echo "  build:   builds console and server"
+	@echo "  console: builds console"
+	@echo "  server:  builds server"
+
+build: console server
+
+server:
+	cd server && cabal new-install && cabal new-build
+
+console:
+	cd console && npm ci && npm run server-build
+
+
+hs-tests:
+	cd server && cabal new-run -- 'test:graphql-engine-tests' --database-url='postgres://localhost:4200/hasura-tests'
+
+py-tests:
+	./run-py-tests.sh
+
+.PHONY: help build server console hs-tests py-tests

--- a/console/src/components/Services/Data/utils.js
+++ b/console/src/components/Services/Data/utils.js
@@ -417,113 +417,48 @@ FROM (
     ON pga.attrelid = pgc.oid
   LEFT OUTER JOIN (
     SELECT
-      current_database()::information_schema.sql_identifier AS table_catalog,
-      nc.nspname::information_schema.sql_identifier         AS table_schema,
-      c.relname::information_schema.sql_identifier          AS table_name,
-      a.attname::information_schema.sql_identifier          AS column_name,
-      a.attnum::information_schema.cardinal_number          AS ordinal_position,
-      CASE
-          WHEN a.attgenerated = ''::char THEN pg_get_expr(ad.adbin, ad.adrelid)
-          ELSE NULL::text
-      END::information_schema.character_data AS column_default,
-      CASE
-          WHEN a.attnotnull OR t.typtype = 'd'::char AND t.typnotnull THEN 'NO'::text
-          ELSE 'YES'::text
-      END::information_schema.yes_or_no AS is_nullable,
-      CASE
-          WHEN t.typtype = 'd'::char THEN
-          CASE
-              WHEN bt.typelem <> 0::oid AND bt.typlen = '-1'::integer THEN 'ARRAY'::text
-              WHEN nbt.nspname = 'pg_catalog'::name THEN format_type(t.typbasetype, NULL::integer)
-              ELSE 'USER-DEFINED'::text
-          END
-          ELSE
-          CASE
-              WHEN t.typelem <> 0::oid AND t.typlen = '-1'::integer THEN 'ARRAY'::text
-              WHEN nt.nspname = 'pg_catalog'::name THEN format_type(a.atttypid, NULL::integer)
-              ELSE 'USER-DEFINED'::text
-          END
-      END::information_schema.character_data AS data_type,
-      information_schema._pg_char_max_length(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS character_maximum_length,
-      information_schema._pg_char_octet_length(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS character_octet_length,
-      information_schema._pg_numeric_precision(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS numeric_precision,
-      information_schema._pg_numeric_precision_radix(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS numeric_precision_radix,
-      information_schema._pg_numeric_scale(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS numeric_scale,
-      information_schema._pg_datetime_precision(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS datetime_precision,
-      information_schema._pg_interval_type(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.character_data AS interval_type,
-      NULL::integer::information_schema.cardinal_number AS interval_precision,
-      NULL::name::information_schema.sql_identifier AS character_set_catalog,
-      NULL::name::information_schema.sql_identifier AS character_set_schema,
-      NULL::name::information_schema.sql_identifier AS character_set_name,
-      CASE
-          WHEN nco.nspname IS NOT NULL THEN current_database()
-          ELSE NULL::name
-      END::information_schema.sql_identifier AS collation_catalog,
-      nco.nspname::information_schema.sql_identifier AS collation_schema,
-      co.collname::information_schema.sql_identifier AS collation_name,
-      CASE
-          WHEN t.typtype = 'd'::char THEN current_database()
-          ELSE NULL::name
-      END::information_schema.sql_identifier AS domain_catalog,
-      CASE
-          WHEN t.typtype = 'd'::char THEN nt.nspname
-          ELSE NULL::name
-      END::information_schema.sql_identifier AS domain_schema,
-      CASE
-          WHEN t.typtype = 'd'::char THEN t.typname
-          ELSE NULL::name
-      END::information_schema.sql_identifier AS domain_name,
-      current_database()::information_schema.sql_identifier AS udt_catalog,
-      COALESCE(nbt.nspname, nt.nspname)::information_schema.sql_identifier AS udt_schema,
-      COALESCE(bt.typname, t.typname)::information_schema.sql_identifier AS udt_name,
-      NULL::name::information_schema.sql_identifier AS scope_catalog,
-      NULL::name::information_schema.sql_identifier AS scope_schema,
-      NULL::name::information_schema.sql_identifier AS scope_name,
-      NULL::integer::information_schema.cardinal_number AS maximum_cardinality,
-      a.attnum::information_schema.sql_identifier AS dtd_identifier,
-      'NO'::character varying::information_schema.yes_or_no AS is_self_referencing,
-      CASE
-          WHEN a.attidentity = ANY (ARRAY['a'::char, 'd'::char]) THEN 'YES'::text
-          ELSE 'NO'::text
-      END::information_schema.yes_or_no AS is_identity,
-      CASE a.attidentity
-          WHEN 'a'::char THEN 'ALWAYS'::text
-          WHEN 'd'::char THEN 'BY DEFAULT'::text
-          ELSE NULL::text
-      END::information_schema.character_data AS identity_generation,
-      seq.seqstart::information_schema.character_data AS identity_start,
-      seq.seqincrement::information_schema.character_data AS identity_increment,
-      seq.seqmax::information_schema.character_data AS identity_maximum,
-      seq.seqmin::information_schema.character_data AS identity_minimum,
-      CASE
-          WHEN seq.seqcycle THEN 'YES'::text
-          ELSE 'NO'::text
-      END::information_schema.yes_or_no AS identity_cycle,
-      CASE
-          WHEN a.attgenerated <> ''::char THEN 'ALWAYS'::text
-          ELSE 'NEVER'::text
-      END::information_schema.character_data AS is_generated,
-      CASE
-          WHEN a.attgenerated <> ''::char THEN pg_get_expr(ad.adbin, ad.adrelid)
-          ELSE NULL::text
-      END::information_schema.character_data AS generation_expression,
-      CASE
-          WHEN (c.relkind = ANY (ARRAY['r'::char, 'p'::char])) OR (c.relkind = ANY (ARRAY['v'::char, 'f'::char])) AND pg_column_is_updatable(c.oid::regclass, a.attnum, false) THEN 'YES'::text
-          ELSE 'NO'::text
-      END::information_schema.yes_or_no AS is_updatable
-   FROM pg_attribute a
-     LEFT JOIN pg_attrdef ad ON a.attrelid = ad.adrelid AND a.attnum = ad.adnum
-     JOIN (pg_class c
-     JOIN pg_namespace nc ON c.relnamespace = nc.oid) ON a.attrelid = c.oid
-     JOIN (pg_type t
-     JOIN pg_namespace nt ON t.typnamespace = nt.oid) ON a.atttypid = t.oid
-     LEFT JOIN (pg_type bt
-     JOIN pg_namespace nbt ON bt.typnamespace = nbt.oid) ON t.typtype = 'd'::char AND t.typbasetype = bt.oid
-     LEFT JOIN (pg_collation co
-     JOIN pg_namespace nco ON co.collnamespace = nco.oid) ON a.attcollation = co.oid AND (nco.nspname <> 'pg_catalog'::name OR co.collname <> 'default'::name)
-     LEFT JOIN (pg_depend dep
-     JOIN pg_sequence seq ON dep.classid = 'pg_class'::regclass::oid AND dep.objid = seq.seqrelid AND dep.deptype = 'i'::char) ON dep.refclassid = 'pg_class'::regclass::oid AND dep.refobjid = c.oid AND dep.refobjsubid = a.attnum
-   WHERE NOT pg_is_other_temp_schema(nc.oid) AND a.attnum > 0 AND NOT a.attisdropped AND (c.relkind = ANY (ARRAY['r'::char, 'v'::char, 'm'::char])) AND (pg_has_role(c.relowner, 'USAGE'::text) OR has_column_privilege(c.oid, a.attnum, 'SELECT, INSERT, UPDATE, REFERENCES'::text))
+      current_database() AS table_catalog,
+      nc.nspname         AS table_schema,
+      c.relname          AS table_name,
+      a.attname          AS column_name,
+      a.attnum           AS ordinal_position,
+      pg_get_expr(ad.adbin, ad.adrelid) AS column_default,
+      CASE WHEN a.attnotnull OR (t.typtype = 'd' AND t.typnotnull) THEN 'NO' ELSE 'YES' END AS is_nullable,
+      CASE WHEN t.typtype = 'd' THEN
+        CASE WHEN bt.typelem <> 0 AND bt.typlen = -1 THEN 'ARRAY'
+             WHEN nbt.nspname = 'pg_catalog' THEN format_type(t.typbasetype, null)
+             ELSE 'USER-DEFINED' END
+      ELSE
+        CASE WHEN t.typelem <> 0 AND t.typlen = -1 THEN 'ARRAY'
+             WHEN nt.nspname = 'pg_catalog' THEN format_type(a.atttypid, null)
+             ELSE 'USER-DEFINED' END
+      END AS data_type,
+      CASE WHEN nco.nspname IS NOT NULL THEN current_database() END AS collation_catalog,
+      nco.nspname AS collation_schema,
+      co.collname AS collation_name,
+      CASE WHEN t.typtype = 'd' THEN current_database() ELSE null END AS domain_catalog,
+      CASE WHEN t.typtype = 'd' THEN nt.nspname ELSE null END AS domain_schema,
+      CASE WHEN t.typtype = 'd' THEN t.typname ELSE null END AS domain_name,
+      current_database() AS udt_catalog,
+      coalesce(nbt.nspname, nt.nspname) AS udt_schema,
+      coalesce(bt.typname, t.typname) AS udt_name,
+      a.attnum AS dtd_identifier,
+      CASE WHEN c.relkind = 'r' OR
+                     (c.relkind IN ('v', 'f') AND
+                      pg_column_is_updatable(c.oid, a.attnum, false))
+           THEN 'YES' ELSE 'NO' END AS is_updatable
+    FROM (pg_attribute a LEFT JOIN pg_attrdef ad ON attrelid = adrelid AND attnum = adnum)
+      JOIN (pg_class c JOIN pg_namespace nc ON (c.relnamespace = nc.oid)) ON a.attrelid = c.oid
+      JOIN (pg_type t JOIN pg_namespace nt ON (t.typnamespace = nt.oid)) ON a.atttypid = t.oid
+      LEFT JOIN (pg_type bt JOIN pg_namespace nbt ON (bt.typnamespace = nbt.oid))
+        ON (t.typtype = 'd' AND t.typbasetype = bt.oid)
+      LEFT JOIN (pg_collation co JOIN pg_namespace nco ON (co.collnamespace = nco.oid))
+        ON a.attcollation = co.oid AND (nco.nspname, co.collname) <> ('pg_catalog', 'default')
+    WHERE (NOT pg_is_other_temp_schema(nc.oid))
+      AND a.attnum > 0 AND NOT a.attisdropped AND c.relkind in ('r', 'v', 'm')
+      AND (pg_has_role(c.relowner, 'USAGE')
+           OR has_column_privilege(c.oid, a.attnum,
+                                   'SELECT, INSERT, UPDATE, REFERENCES'))
   ) AS isc
     ON  isc.table_schema = pgn.nspname
     AND isc.table_name   = pgc.relname

--- a/console/src/components/Services/Data/utils.js
+++ b/console/src/components/Services/Data/utils.js
@@ -281,25 +281,28 @@ export const fetchTrackedTableListQuery = options => {
   return query;
 };
 
-const generateWhereClause = options => {
+const generateWhereClause = (options,
+                             tableName = 'ist.table_name',
+                             schemaName = 'ist.table_schema',
+                             clausePrefix = 'where') => {
   let whereClause = '';
 
   const whereCondtions = [];
   if (options.schemas) {
     options.schemas.forEach(schemaName => {
-      whereCondtions.push(`(ist.table_schema='${schemaName}')`);
+      whereCondtions.push(`(${schemaField}='${schemaName}')`);
     });
   }
   if (options.tables) {
     options.tables.forEach(tableInfo => {
       whereCondtions.push(
-        `(ist.table_schema='${tableInfo.table_schema}' and ist.table_name='${tableInfo.table_name}')`
+        `(${schemaName}='${tableInfo.table_schema}' and ${tableName}='${tableInfo.table_name}')`
       );
     });
   }
 
   if (whereCondtions.length > 0) {
-    whereClause = 'where';
+      whereClause = clausePrefix;
   }
 
   whereCondtions.forEach((whereInfo, index) => {
@@ -315,23 +318,23 @@ const generateWhereClause = options => {
 export const fetchTrackedTableFkQuery = options => {
   const whereQuery = generateWhereClause(options);
 
-  const runSql = `select 
+  const runSql = `select
   COALESCE(
     json_agg(
       row_to_json(info)
-    ), 
+    ),
     '[]' :: JSON
-  ) AS tables 
-FROM 
+  ) AS tables
+FROM
   (
     select
-      hdb_fkc.*, 
-      fk_ref_table.table_name IS NOT NULL AS is_ref_table_tracked 
-    from 
-      hdb_catalog.hdb_table AS ist 
-      JOIN hdb_catalog.hdb_foreign_key_constraint AS hdb_fkc ON hdb_fkc.table_schema = ist.table_schema 
-      and hdb_fkc.table_name = ist.table_name 
-      LEFT OUTER JOIN hdb_catalog.hdb_table AS fk_ref_table ON fk_ref_table.table_schema = hdb_fkc.ref_table_table_schema 
+      hdb_fkc.*,
+      fk_ref_table.table_name IS NOT NULL AS is_ref_table_tracked
+    from
+      hdb_catalog.hdb_table AS ist
+      JOIN hdb_catalog.hdb_foreign_key_constraint AS hdb_fkc ON hdb_fkc.table_schema = ist.table_schema
+      and hdb_fkc.table_name = ist.table_name
+      LEFT OUTER JOIN hdb_catalog.hdb_table AS fk_ref_table ON fk_ref_table.table_schema = hdb_fkc.ref_table_table_schema
       and fk_ref_table.table_name = hdb_fkc.ref_table
     ${whereQuery}
   ) as info
@@ -346,24 +349,24 @@ FROM
 export const fetchTrackedTableReferencedFkQuery = options => {
   const whereQuery = generateWhereClause(options);
 
-  const runSql = `select 
+  const runSql = `select
   COALESCE(
     json_agg(
       row_to_json(info)
-    ), 
+    ),
     '[]' :: JSON
-  ) AS tables 
-FROM 
+  ) AS tables
+FROM
   (
     select DISTINCT ON (hdb_fkc.constraint_oid)
-      hdb_fkc.*, 
+      hdb_fkc.*,
       fk_ref_table.table_name IS NOT NULL AS is_table_tracked,
       hdb_uc.constraint_name IS NOT NULL AS is_unique
-    from 
-      hdb_catalog.hdb_table AS ist 
-      JOIN hdb_catalog.hdb_foreign_key_constraint AS hdb_fkc ON hdb_fkc.ref_table_table_schema = ist.table_schema 
-      and hdb_fkc.ref_table = ist.table_name 
-      LEFT OUTER JOIN hdb_catalog.hdb_table AS fk_ref_table ON fk_ref_table.table_schema = hdb_fkc.table_schema 
+    from
+      hdb_catalog.hdb_table AS ist
+      JOIN hdb_catalog.hdb_foreign_key_constraint AS hdb_fkc ON hdb_fkc.ref_table_table_schema = ist.table_schema
+      and hdb_fkc.ref_table = ist.table_name
+      LEFT OUTER JOIN hdb_catalog.hdb_table AS fk_ref_table ON fk_ref_table.table_schema = hdb_fkc.table_schema
       and fk_ref_table.table_name = hdb_fkc.table_name
       LEFT OUTER JOIN hdb_catalog.hdb_unique_constraint AS hdb_uc ON hdb_uc.table_schema = hdb_fkc.table_schema
       and hdb_uc.table_name = hdb_fkc.table_name and ARRAY(select json_array_elements_text(hdb_uc.columns) ORDER BY json_array_elements_text) = ARRAY(select json_object_keys(hdb_fkc.column_mapping) ORDER BY json_object_keys)
@@ -378,74 +381,60 @@ FROM
 };
 
 export const fetchTableListQuery = options => {
-  const whereQuery = generateWhereClause(options);
+  const whereQuery = generateWhereClause(
+    options,
+    tableName = 'pgc.relname',
+    schemaName = 'pgn.nspname',
+    clausePrefix = 'and'
+  );
 
   // TODO: optimise this. Multiple OUTER JOINS causes data bloating
   const runSql = `
-select 
-  COALESCE(
-    json_agg(
-      row_to_json(info)
-    ), 
-    '[]' :: JSON
-  ) AS tables 
-FROM 
-  (
-    select 
-      ist.table_schema, 
-      ist.table_name,
-      ist.table_type,
-      obj_description(
-        (
-          quote_ident(ist.table_schema) || '.' || quote_ident(ist.table_name)
-        ):: regclass, 
-        'pg_class'
-      ) AS comment, 
-      COALESCE(json_agg(
-        DISTINCT row_to_json(is_columns) :: JSONB || jsonb_build_object(
-          'comment',
-          (
-            SELECT 
-              pg_catalog.col_description(
-                c.oid, is_columns.ordinal_position :: int
-              ) 
-            FROM 
-              pg_catalog.pg_class c 
-            WHERE 
-              c.oid = (quote_ident(ist.table_schema) || '.' || quote_ident(ist.table_name)):: regclass :: oid
-              AND c.relname = is_columns.table_name
-          )
-        )
-      ) FILTER (WHERE is_columns.column_name IS NOT NULL), '[]' :: JSON) AS columns,
-      COALESCE(json_agg(
-        DISTINCT row_to_json(is_triggers) :: JSONB || jsonb_build_object(
-          'comment',
-          (
-            SELECT description FROM pg_description JOIN pg_trigger ON pg_description.objoid = pg_trigger.oid 
-            WHERE 
-              tgname = is_triggers.trigger_name 
-              AND tgrelid = (quote_ident(is_triggers.event_object_schema) || '.' || quote_ident(is_triggers.event_object_table)):: regclass :: oid
-          )
-        )
-      ) FILTER (WHERE is_triggers.trigger_name IS NOT NULL), '[]' :: JSON) AS triggers,
-      row_to_json(is_views) AS view_info
-    FROM 
-      information_schema.tables AS ist 
-      LEFT OUTER JOIN information_schema.columns AS is_columns ON 
-        is_columns.table_schema = ist.table_schema 
-        AND is_columns.table_name = ist.table_name 
-      LEFT OUTER JOIN information_schema.views AS is_views ON is_views.table_schema = ist.table_schema
-        AND is_views.table_name = ist.table_name
-      LEFT OUTER JOIN information_schema.triggers AS is_triggers ON 
-        is_triggers.event_object_schema = ist.table_schema AND 
-        is_triggers.event_object_table = ist.table_name
-    ${whereQuery} 
-    GROUP BY 
-      ist.table_schema, 
-      ist.table_name,
-      ist.table_type,
-      is_views.*
-  ) AS info
+SELECT
+  COALESCE(Json_agg(Row_to_json(info)), '[]' :: json) AS tables
+FROM (
+  SELECT
+    pgn.nspname as table_schema,
+    pgc.relname as table_name,
+    case
+      when pgc.relkind = 'r' then 'BASE TABLE'
+      when pgc.relkind = 'v' then 'VIEW'
+      when pgc.relkind = 'm' then 'MATERIALIZED VIEW'
+    end as table_type,
+    obj_description(pgc.oid) AS comment,
+    COALESCE(json_agg(DISTINCT row_to_json(isc) :: jsonb || jsonb_build_object('comment', col_description(pga.attrelid, pga.attnum))) filter (WHERE isc.column_name IS NOT NULL), '[]' :: json) AS columns,
+    COALESCE(json_agg(DISTINCT row_to_json(ist) :: jsonb || jsonb_build_object('comment', obj_description(pgt.tgrelid))) filter (WHERE ist.trigger_name IS NOT NULL), '[]' :: json) AS triggers,
+    row_to_json(isv) AS view_info
+
+  FROM pg_class as pgc
+  INNER JOIN pg_namespace as pgn
+    ON pgc.relnamespace = pgn.oid
+
+  /* columns */
+  LEFT OUTER JOIN pg_attribute AS pga
+    ON pga.attrelid = pgc.oid
+  LEFT OUTER JOIN information_schema.columns AS isc
+    ON  isc.table_schema = pgn.nspname
+    AND isc.table_name   = pgc.relname
+    AND isc.column_name  = pga.attname
+
+  /* triggers */
+  LEFT OUTER JOIN pg_trigger AS pgt
+    ON pgt.tgrelid = pgc.oid
+  LEFT OUTER JOIN information_schema.triggers AS ist
+    ON  ist.event_object_schema = pgn.nspname
+    AND ist.event_object_table  = pgc.relname
+    AND ist.trigger_name        = pgt.tgname
+
+  /* views */
+  LEFT OUTER JOIN information_schema.views AS isv
+    ON  isv.table_schema = pgn.nspname
+    AND isv.table_name   = pgc.relname
+  WHERE
+    pgc.relkind IN ('r', 'v', 'm')
+    ${whereQuery}
+  GROUP BY pgc.oid, pgn.nspname, pgc.relname, table_type, isv.*
+) AS info;
 `;
   return getRunSqlQuery(
     runSql,
@@ -617,7 +606,7 @@ export const commonDataTypes = [
  * Filter types whose typename is unknown and type category is not 'Pseudo' and it is valid and available to be used
  * */
 export const fetchColumnTypesQuery = `
-SELECT 
+SELECT
   string_agg(t.typname, ',') as "Type Name",
   string_agg(pg_catalog.format_type(t.oid, NULL), ',') as "Display Name",
   string_agg(coalesce(pg_catalog.obj_description(t.oid, 'pg_type'), ''), ':') as "Descriptions",

--- a/console/src/components/Services/Data/utils.js
+++ b/console/src/components/Services/Data/utils.js
@@ -281,28 +281,30 @@ export const fetchTrackedTableListQuery = options => {
   return query;
 };
 
-const generateWhereClause = (options,
-                             tableName = 'ist.table_name',
-                             schemaName = 'ist.table_schema',
-                             clausePrefix = 'where') => {
+const generateWhereClause = (
+  options,
+  sqlTableName = 'ist.table_name',
+  sqlSchemaName = 'ist.table_schema',
+  clausePrefix = 'where'
+) => {
   let whereClause = '';
 
   const whereCondtions = [];
   if (options.schemas) {
     options.schemas.forEach(schemaName => {
-      whereCondtions.push(`(${schemaField}='${schemaName}')`);
+      whereCondtions.push(`(${sqlSchemaName}='${schemaName}')`);
     });
   }
   if (options.tables) {
     options.tables.forEach(tableInfo => {
       whereCondtions.push(
-        `(${schemaName}='${tableInfo.table_schema}' and ${tableName}='${tableInfo.table_name}')`
+        `(${sqlSchemaName}='${tableInfo.table_schema}' and ${sqlTableName}='${tableInfo.table_name}')`
       );
     });
   }
 
   if (whereCondtions.length > 0) {
-      whereClause = clausePrefix;
+    whereClause = clausePrefix;
   }
 
   whereCondtions.forEach((whereInfo, index) => {
@@ -383,9 +385,9 @@ FROM
 export const fetchTableListQuery = options => {
   const whereQuery = generateWhereClause(
     options,
-    tableName = 'pgc.relname',
-    schemaName = 'pgn.nspname',
-    clausePrefix = 'and'
+    'pgc.relname',
+    'pgn.nspname',
+    'and'
   );
 
   // TODO: optimise this. Multiple OUTER JOINS causes data bloating
@@ -413,7 +415,116 @@ FROM (
   /* columns */
   LEFT OUTER JOIN pg_attribute AS pga
     ON pga.attrelid = pgc.oid
-  LEFT OUTER JOIN information_schema.columns AS isc
+  LEFT OUTER JOIN (
+    SELECT
+      current_database()::information_schema.sql_identifier AS table_catalog,
+      nc.nspname::information_schema.sql_identifier         AS table_schema,
+      c.relname::information_schema.sql_identifier          AS table_name,
+      a.attname::information_schema.sql_identifier          AS column_name,
+      a.attnum::information_schema.cardinal_number          AS ordinal_position,
+      CASE
+          WHEN a.attgenerated = ''::char THEN pg_get_expr(ad.adbin, ad.adrelid)
+          ELSE NULL::text
+      END::information_schema.character_data AS column_default,
+      CASE
+          WHEN a.attnotnull OR t.typtype = 'd'::char AND t.typnotnull THEN 'NO'::text
+          ELSE 'YES'::text
+      END::information_schema.yes_or_no AS is_nullable,
+      CASE
+          WHEN t.typtype = 'd'::char THEN
+          CASE
+              WHEN bt.typelem <> 0::oid AND bt.typlen = '-1'::integer THEN 'ARRAY'::text
+              WHEN nbt.nspname = 'pg_catalog'::name THEN format_type(t.typbasetype, NULL::integer)
+              ELSE 'USER-DEFINED'::text
+          END
+          ELSE
+          CASE
+              WHEN t.typelem <> 0::oid AND t.typlen = '-1'::integer THEN 'ARRAY'::text
+              WHEN nt.nspname = 'pg_catalog'::name THEN format_type(a.atttypid, NULL::integer)
+              ELSE 'USER-DEFINED'::text
+          END
+      END::information_schema.character_data AS data_type,
+      information_schema._pg_char_max_length(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS character_maximum_length,
+      information_schema._pg_char_octet_length(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS character_octet_length,
+      information_schema._pg_numeric_precision(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS numeric_precision,
+      information_schema._pg_numeric_precision_radix(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS numeric_precision_radix,
+      information_schema._pg_numeric_scale(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS numeric_scale,
+      information_schema._pg_datetime_precision(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS datetime_precision,
+      information_schema._pg_interval_type(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.character_data AS interval_type,
+      NULL::integer::information_schema.cardinal_number AS interval_precision,
+      NULL::name::information_schema.sql_identifier AS character_set_catalog,
+      NULL::name::information_schema.sql_identifier AS character_set_schema,
+      NULL::name::information_schema.sql_identifier AS character_set_name,
+      CASE
+          WHEN nco.nspname IS NOT NULL THEN current_database()
+          ELSE NULL::name
+      END::information_schema.sql_identifier AS collation_catalog,
+      nco.nspname::information_schema.sql_identifier AS collation_schema,
+      co.collname::information_schema.sql_identifier AS collation_name,
+      CASE
+          WHEN t.typtype = 'd'::char THEN current_database()
+          ELSE NULL::name
+      END::information_schema.sql_identifier AS domain_catalog,
+      CASE
+          WHEN t.typtype = 'd'::char THEN nt.nspname
+          ELSE NULL::name
+      END::information_schema.sql_identifier AS domain_schema,
+      CASE
+          WHEN t.typtype = 'd'::char THEN t.typname
+          ELSE NULL::name
+      END::information_schema.sql_identifier AS domain_name,
+      current_database()::information_schema.sql_identifier AS udt_catalog,
+      COALESCE(nbt.nspname, nt.nspname)::information_schema.sql_identifier AS udt_schema,
+      COALESCE(bt.typname, t.typname)::information_schema.sql_identifier AS udt_name,
+      NULL::name::information_schema.sql_identifier AS scope_catalog,
+      NULL::name::information_schema.sql_identifier AS scope_schema,
+      NULL::name::information_schema.sql_identifier AS scope_name,
+      NULL::integer::information_schema.cardinal_number AS maximum_cardinality,
+      a.attnum::information_schema.sql_identifier AS dtd_identifier,
+      'NO'::character varying::information_schema.yes_or_no AS is_self_referencing,
+      CASE
+          WHEN a.attidentity = ANY (ARRAY['a'::char, 'd'::char]) THEN 'YES'::text
+          ELSE 'NO'::text
+      END::information_schema.yes_or_no AS is_identity,
+      CASE a.attidentity
+          WHEN 'a'::char THEN 'ALWAYS'::text
+          WHEN 'd'::char THEN 'BY DEFAULT'::text
+          ELSE NULL::text
+      END::information_schema.character_data AS identity_generation,
+      seq.seqstart::information_schema.character_data AS identity_start,
+      seq.seqincrement::information_schema.character_data AS identity_increment,
+      seq.seqmax::information_schema.character_data AS identity_maximum,
+      seq.seqmin::information_schema.character_data AS identity_minimum,
+      CASE
+          WHEN seq.seqcycle THEN 'YES'::text
+          ELSE 'NO'::text
+      END::information_schema.yes_or_no AS identity_cycle,
+      CASE
+          WHEN a.attgenerated <> ''::char THEN 'ALWAYS'::text
+          ELSE 'NEVER'::text
+      END::information_schema.character_data AS is_generated,
+      CASE
+          WHEN a.attgenerated <> ''::char THEN pg_get_expr(ad.adbin, ad.adrelid)
+          ELSE NULL::text
+      END::information_schema.character_data AS generation_expression,
+      CASE
+          WHEN (c.relkind = ANY (ARRAY['r'::char, 'p'::char])) OR (c.relkind = ANY (ARRAY['v'::char, 'f'::char])) AND pg_column_is_updatable(c.oid::regclass, a.attnum, false) THEN 'YES'::text
+          ELSE 'NO'::text
+      END::information_schema.yes_or_no AS is_updatable
+   FROM pg_attribute a
+     LEFT JOIN pg_attrdef ad ON a.attrelid = ad.adrelid AND a.attnum = ad.adnum
+     JOIN (pg_class c
+     JOIN pg_namespace nc ON c.relnamespace = nc.oid) ON a.attrelid = c.oid
+     JOIN (pg_type t
+     JOIN pg_namespace nt ON t.typnamespace = nt.oid) ON a.atttypid = t.oid
+     LEFT JOIN (pg_type bt
+     JOIN pg_namespace nbt ON bt.typnamespace = nbt.oid) ON t.typtype = 'd'::char AND t.typbasetype = bt.oid
+     LEFT JOIN (pg_collation co
+     JOIN pg_namespace nco ON co.collnamespace = nco.oid) ON a.attcollation = co.oid AND (nco.nspname <> 'pg_catalog'::name OR co.collname <> 'default'::name)
+     LEFT JOIN (pg_depend dep
+     JOIN pg_sequence seq ON dep.classid = 'pg_class'::regclass::oid AND dep.objid = seq.seqrelid AND dep.deptype = 'i'::char) ON dep.refclassid = 'pg_class'::regclass::oid AND dep.refobjid = c.oid AND dep.refobjsubid = a.attnum
+   WHERE NOT pg_is_other_temp_schema(nc.oid) AND a.attnum > 0 AND NOT a.attisdropped AND (c.relkind = ANY (ARRAY['r'::char, 'v'::char, 'm'::char])) AND (pg_has_role(c.relowner, 'USAGE'::text) OR has_column_privilege(c.oid, a.attnum, 'SELECT, INSERT, UPDATE, REFERENCES'::text))
+  ) AS isc
     ON  isc.table_schema = pgn.nspname
     AND isc.table_name   = pgc.relname
     AND isc.column_name  = pga.attname

--- a/console/src/components/Services/Data/utils.js
+++ b/console/src/components/Services/Data/utils.js
@@ -405,7 +405,7 @@ FROM (
     end as table_type,
     obj_description(pgc.oid) AS comment,
     COALESCE(json_agg(DISTINCT row_to_json(isc) :: jsonb || jsonb_build_object('comment', col_description(pga.attrelid, pga.attnum))) filter (WHERE isc.column_name IS NOT NULL), '[]' :: json) AS columns,
-    COALESCE(json_agg(DISTINCT row_to_json(ist) :: jsonb || jsonb_build_object('comment', obj_description(pgt.tgrelid))) filter (WHERE ist.trigger_name IS NOT NULL), '[]' :: json) AS triggers,
+    COALESCE(json_agg(DISTINCT row_to_json(ist) :: jsonb || jsonb_build_object('comment', obj_description(pgt.oid))) filter (WHERE ist.trigger_name IS NOT NULL), '[]' :: json) AS triggers,
     row_to_json(isv) AS view_info
 
   FROM pg_class as pgc

--- a/run-hs-tests.sh
+++ b/run-hs-tests.sh
@@ -1,0 +1,11 @@
+set -euo pipefail
+
+DB_NAME='hasura-tests'
+POSTGRES="postgres://localhost:4200/$DB_NAME"
+
+cd $(dirname $(realpath "$0"))
+dropdb   -p 4200 ${DB_NAME} --if-exists
+createdb -p 4200 ${DB_NAME}
+
+cd server
+cabal new-run -- test:graphql-engine-tests --database-url="$POSTGRES"

--- a/run-py-tests.sh
+++ b/run-py-tests.sh
@@ -1,0 +1,25 @@
+set -euo pipefail
+
+DB_NAME='hasura-tests'
+POSTGRES="postgres://localhost:4200/$DB_NAME"
+
+cd $(dirname $(realpath "$0"))
+dropdb   -p 4200 ${DB_NAME} --if-exists
+createdb -p 4200 ${DB_NAME}
+
+cd server
+source .python-venv/bin/activate
+pip3 install -r tests-py/requirements.txt > /dev/null
+export EVENT_WEBHOOK_HEADER=MyEnvValue
+export WEBHOOK_FROM_ENV=http://localhost:5592/
+
+cabal new-run -- exe:graphql-engine \
+  --database-url=${POSTGRES}        \
+  serve                             \
+  --stringify-numeric-types         \
+  2>&1 > tests-py/hasura.log &
+sleep 10
+
+cd tests-py
+pytest --hge-urls http://localhost:8080 --pg-urls ${POSTGRES} "$@" || true
+ps | grep graphql | cut -d ' ' -f 2 | xargs kill

--- a/run-py-tests.sh
+++ b/run-py-tests.sh
@@ -13,6 +13,7 @@ pip3 install -r tests-py/requirements.txt > /dev/null
 export EVENT_WEBHOOK_HEADER=MyEnvValue
 export WEBHOOK_FROM_ENV=http://localhost:5592/
 
+cabal new-build
 cabal new-run -- exe:graphql-engine \
   --database-url=${POSTGRES}        \
   serve                             \

--- a/run-py-tests.sh
+++ b/run-py-tests.sh
@@ -1,17 +1,65 @@
 set -euo pipefail
 
+
+# parameters
+
 DB_NAME='hasura-tests'
 POSTGRES="postgres://localhost:4200/$DB_NAME"
 
-cd $(dirname $(realpath "$0"))
+
+# cleanup
+
+WH_PID=""
+
+function finish {
+    function terminate() {
+        pid="$1"
+        if [ -n "$pid" ] ; then
+            kill $pid || true
+            wait $pid || true
+        fi
+    }
+    ps | grep graphql | tr -s ' ' | cut -d ' ' -f 2 | xargs kill 2> /dev/null || true
+    terminate "$WH_PID"
+}
+trap finish EXIT
+
+
+# helpers
+
+wait_for_port() {
+    local service=$1
+    local port=$2
+    echo -n "Waiting for $service on port $port..."
+    for _ in $(seq 1 60);
+    do
+      nc -z localhost $port && echo " ready" && return
+      echo -n .
+      sleep 0.25
+    done
+    echo " timeout, aborting" && exit 1
+}
+
+
+# create db
+
+cd $(dirname $(realpath "$0"))/server
 dropdb   -p 4200 ${DB_NAME} --if-exists
 createdb -p 4200 ${DB_NAME}
 
-cd server
+
+# get python env
+
 source .python-venv/bin/activate
 pip3 install -r tests-py/requirements.txt > /dev/null
-export EVENT_WEBHOOK_HEADER=MyEnvValue
-export WEBHOOK_FROM_ENV=http://localhost:5592/
+
+
+# build and run graphql-engine
+
+export HASURA_GRAPHQL_ADMIN_SECRET="s3cr3t"
+export EVENT_WEBHOOK_HEADER="MyEnvValue"
+export WEBHOOK_FROM_ENV="http://localhost:5592/"
+export HASURA_GRAPHQL_AUTH_HOOK="https://localhost:9090/"
 
 cabal new-build
 cabal new-run -- exe:graphql-engine \
@@ -19,8 +67,56 @@ cabal new-run -- exe:graphql-engine \
   serve                             \
   --stringify-numeric-types         \
   2>&1 > tests-py/hasura.log &
-sleep 10
+wait_for_port 'graphql-engine' 8080
+
+
+# run webhook
 
 cd tests-py
-pytest --hge-urls http://localhost:8080 --pg-urls ${POSTGRES} "$@" || true
-ps | grep graphql | cut -d ' ' -f 2 | xargs kill
+
+if [ ! -f ssl/webhook-req.cnf ] ; then
+    echo "Warning: no SSL configuration found, creating new"
+    CNF_TEMPLATE='[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+
+[req_distinguished_name]
+
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost
+IP.1 = 127.0.0.1'
+
+    mkdir -p ssl
+    pushd ssl
+    echo "$CNF_TEMPLATE" > webhook-req.cnf
+
+    openssl genrsa -out ca-key.pem 2048
+    openssl req -x509 -new -nodes -key ca-key.pem -days 10 -out ca.pem -subj "/CN=webhook-ca"
+    openssl genrsa -out webhook-key.pem 2048
+    openssl req -new -key webhook-key.pem -out webhook.csr -subj "/CN=hge-webhook" -config webhook-req.cnf
+    openssl x509 -req -in webhook.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out webhook.pem -days 10 -extensions v3_req -extfile webhook-req.cnf
+
+    sudo cp ca.pem /etc/ssl/certs/webhook.crt
+    # arch / manjaro specific
+    sudo trust extract-compat # update-ca-certificates
+    popd
+fi
+
+python3 webhook.py 9090 ssl/webhook-key.pem ssl/webhook.pem > webhook.log 2>&1 &
+WH_PID=$!
+wait_for_port 'webhook' 9090
+
+
+# running tests
+
+pytest \
+    --hge-key "s3cr3t" \
+    --hge-urls http://localhost:8080/ \
+    --hge-webhook https://localhost:9090/ \
+    --pg-urls ${POSTGRES} \
+    "$@" || true

--- a/server/run-hlint.sh
+++ b/server/run-hlint.sh
@@ -1,0 +1,5 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+git diff --name-only master | sed 's%^server/%%' | egrep 'hs$' | xargs hlint

--- a/server/src-lib/Hasura/RQL/DDL/Schema.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema.hs
@@ -102,7 +102,7 @@ runRunSQL RunSQL {..} = do
     isAltrDropReplace = either throwErr return . matchRegex regex False
       where
         throwErr s = throw500 $ "compiling regex failed: " <> T.pack s
-        regex = "alter|drop|replace|create function|comment on"
+        regex = "\\balter\\b|\\bdrop\\b|\\breplace\\b|\\bcreate function\\b|\\bcomment on\\b"
 
 data RunSQLRes
   = RunSQLRes


### PR DESCRIPTION
### Description
This is the frontend part of #91. **WARNING**: it is an ugly workaround!

The problem is as follows: this query used `information_schema` to retrieve information about the underlying postgres database. Unfortunately, neither `information_schema.tables` nor `information_schema.columns` contain data about materialized views. What this PR does is to change the query to instead rely on postgres internals, such as `pg_class` and `pg_attribute`. It has a few upsides; notably, retrieving comments is much easier now, since we have access to the oid of each element, and we can just use `col_description` and `obj_description`.

However, the previous version of that query returned *every single column* of the `columns` view, unmodified. To emulate that behaviour, I had to recreate the entire `columns` view in the query, while fixing it so that it includes materialized views.

I obtained the definition of `columns` by running `psql -E` and running `\dS+ information_schema.columns`. The only change is as follows:

before: `c.relkind = ANY (ARRAY['r'::"char", 'v'::"char", 'f'::"char", 'p'::"char"])`
after: `c.relkind = ANY (ARRAY['r'::"char", 'v'::"char", 'm'::"char"])`

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Console

### Limitations, known bugs & workarounds

There are several things that are missing from this PR, in its current state:

- currently, the `view_info` part of the query is computed using the `information_schema.views` view, which... suffers from the exact same problem: not listing materialized views. I am not sure whether we actually want to treat them as views as far as the console is concerned, but that's something to check,
- I have **NOT** checked that the console properly supports this new `MATERIALIZED VIEW` table type everywhere; from my limited testing, it treats is as a view (the name is italicized for instance),
- I have **NOT** done regression testing beyond some very simple examples on my test database,
- I have **NOT** written new tests, nor done extensive tests in the console; I have simply tested, on one materialized view:
  - tracking it
  - untracking it
  - running a query against it in GraphiQL
  - checking that the data is correct (both rows and columns) in the Data tab

Ideally, this would be rewritten to call a backend function, and none of the postgres internals would be in the frontend. But in recent discussions we have agreed that it was preferable to do this workaround before doing the necessary server work.