### PR TITLE
console: fix handle long column names during update event trigger cre…

### DIFF
--- a/console/src/components/Common/Common.scss
+++ b/console/src/components/Common/Common.scss
@@ -1395,8 +1395,9 @@ code {
   width: 300px;
 }
 
-.wordBreakAll {
-  word-break: break-all;
+.columnListElement {
+  float: left;
+  margin-right: 50px !important;
 }
 
 /* container height subtracting top header and bottom scroll bar */

--- a/console/src/components/Common/Common.scss
+++ b/console/src/components/Common/Common.scss
@@ -1395,6 +1395,10 @@ code {
   width: 300px;
 }
 
+.wordBreakAll {
+  word-break: break-all;
+}
+
 /* container height subtracting top header and bottom scroll bar */
 $mainContainerHeight: calc(100vh - 50px - 25px);
 

--- a/console/src/components/Common/Permissions/PermissionStyles.scss
+++ b/console/src/components/Common/Permissions/PermissionStyles.scss
@@ -109,11 +109,6 @@ width: 85%;
     padding: 10px;
     word-wrap: break-word;
 
-    .columnListElement {
-      float: left;
-      margin-right: 50px;
-    }
-
     .form_permission_insert_set_wrapper {
       .permission_insert_set_wrapper {
         .configure_insert_set_checkbox {

--- a/console/src/components/Services/Data/TablePermissions/Permissions.scss
+++ b/console/src/components/Services/Data/TablePermissions/Permissions.scss
@@ -37,7 +37,7 @@
   // TODO: make common with Roles page
   .clickableCell {
     cursor: pointer;
-    
+
     .editPermsIcon {
       font-size: 12px;
       position: absolute;
@@ -116,11 +116,6 @@
     margin: 5px;
     padding: 10px;
     word-wrap: break-word;
-
-    .columnListElement {
-      float: left;
-      margin-right: 50px;
-    }
 
     .form_permission_insert_set_wrapper {
       .permission_insert_set_wrapper {

--- a/console/src/components/Services/EventTrigger/Add/AddTrigger.js
+++ b/console/src/components/Services/EventTrigger/Add/AddTrigger.js
@@ -249,7 +249,10 @@ class AddTrigger extends Component {
           />
         );
         return (
-          <div key={i} className={styles.padd_remove + ' col-md-4'}>
+          <div
+            key={i}
+            className={`${styles.padd_remove} ${styles.wordBreakAll} style col-md-4`}
+          >
             <div className={'checkbox '}>
               <label>
                 {inputHtml}

--- a/console/src/components/Services/EventTrigger/Add/AddTrigger.js
+++ b/console/src/components/Services/EventTrigger/Add/AddTrigger.js
@@ -251,7 +251,7 @@ class AddTrigger extends Component {
         return (
           <div
             key={i}
-            className={`${styles.padd_remove} ${styles.wordBreakAll} style col-md-4`}
+            className={`${styles.padd_remove} ${styles.columnListElement}`}
           >
             <div className={'checkbox '}>
               <label>

--- a/console/src/components/Services/EventTrigger/Modify/OperationEditor.js
+++ b/console/src/components/Services/EventTrigger/Modify/OperationEditor.js
@@ -99,9 +99,7 @@ class OperationEditor extends React.Component {
             {definition.update ? (
               allTableColumns.map((col, i) => (
                 <div
-                  className={`${styles.opsCheckboxWrapper} col-md-4 ${
-                    styles.padd_remove
-                  }`}
+                  className={`${styles.opsCheckboxWrapper} ${styles.columnListElement} ${styles.padd_remove}`}
                   key={i}
                 >
                   <input
@@ -139,9 +137,7 @@ class OperationEditor extends React.Component {
           <div className={'col-md-12 ' + styles.padd_remove}>
             {operationTypes.map((qt, i) => (
               <div
-                className={`${styles.opsCheckboxWrapper} col-md-2 ${
-                  styles.padd_remove
-                } ${styles.cursorPointer}`}
+                className={`${styles.opsCheckboxWrapper} col-md-2 ${styles.padd_remove} ${styles.cursorPointer}`}
                 key={i}
                 onClick={() => {
                   dispatch(
@@ -173,9 +169,7 @@ class OperationEditor extends React.Component {
             {modifyTrigger.definition.update ? (
               allTableColumns.map((col, i) => (
                 <div
-                  className={`${styles.opsCheckboxWrapper} col-md-4 ${
-                    styles.padd_remove
-                  } ${styles.cursorPointer}`}
+                  className={`${styles.opsCheckboxWrapper} ${styles.columnListElement} ${styles.padd_remove} ${styles.cursorPointer}`}
                   key={i}
                   onClick={() => dispatch(toggleColumn('update', col.name))}
                 >


### PR DESCRIPTION
### Description
Fixed handle long column names during update event trigger creation. ( #4123 )

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

 #4123

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

Apply word break style.

<img width="644" alt="スクリーンショット 2020-03-27 8 53 22" src="https://user-images.githubusercontent.com/11070996/77707450-7e588080-7008-11ea-90e9-af37712945e1.png">


### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

Create a table with long column names and check event trigger creation

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
