### PR TITLE
unlock event if event trigger info is not found in cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The order and collapsed state of columns is now persisted across page navigation
 - docs: add One-Click Render deployment guide (close #3683) (#4209)
 - server: reserved keywords in column references break parser (fix #3597) #3927
 - server: fix postgres specific error message that exposed database type on invalid query parameters (#4294)
+- server: unlock event and retry after 60s on schema cache errors in event triggers (#4213)
 
 ## `v1.2.0-beta.3`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The order and collapsed state of columns is now persisted across page navigation
 - docs: add One-Click Render deployment guide (close #3683) (#4209)
 - server: reserved keywords in column references break parser (fix #3597) #3927
 - server: fix postgres specific error message that exposed database type on invalid query parameters (#4294)
-- server: unlock event and retry after 60s on schema cache errors in event triggers (#4213)
+- server: fix an edge case where some events wouldn't be processed because of internal erorrs (#4213)
 
 ## `v1.2.0-beta.3`
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

In the unexpected scenario in which table or event trigger info is not found in schema cache for a event, we were logging an error. We also need to unlock the event so that it can be reprocessed.


### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

