### PR TITLE
console: wait more before expanding table in browse-rows test

### DIFF
--- a/console/cypress/integration/data/insert-browse/spec.js
+++ b/console/cypress/integration/data/insert-browse/spec.js
@@ -483,7 +483,7 @@ export const checkViewRelationship = () => {
     .contains('View')
     .first()
     .click();
-  cy.wait(1000);
+  cy.wait(5000);
   cy.get('a')
     .contains('Close')
     .first()


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
The tests on the `stable` branch are failing probably because it takes a while to open the relationships table on browse-rows.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [x] Tests
- [ ] Other (list it)
