### PR TITLE
Fix JSON(B) rendering in data browser (close #4201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,3 +105,4 @@
 - console: disable selecting roles without permissions for bulk actions (close #4178) (#4195)
 - console: show remote schema / event trigger intro sections always (#4044)
 - server: fix postgres query error when computed fields included in mutation response (fix #4035)
+- console: Fix JSON(B) rendering in data (close #4201) (#4221)

--- a/console/src/components/Services/Data/TableBrowseRows/ViewRows.js
+++ b/console/src/components/Services/Data/TableBrowseRows/ViewRows.js
@@ -581,7 +581,11 @@ const ViewRows = ({
           } else if (rowColumnValue === undefined) {
             cellValue = 'NULL';
             cellTitle = cellValue;
-          } else if (typeof rowColumnValue === 'object') {
+          } else if (
+            col.data_type === 'json' ||
+            col.data_type === 'jsonb' ||
+            rowColumnValue === 'object'
+          ) {
             cellValue = JSON.stringify(rowColumnValue, null, 4);
             cellTitle = cellValue;
           } else {
@@ -759,9 +763,7 @@ const ViewRows = ({
           <b className={styles.padd_small_right}>Selected:</b>
           {selectedRows.length}
           <button
-            className={`${styles.add_mar_right_small} btn btn-xs btn-default ${
-              styles.bulkDeleteButton
-            }`}
+            className={`${styles.add_mar_right_small} btn btn-xs btn-default ${styles.bulkDeleteButton}`}
             title="Delete selected rows"
             onClick={handleDeleteItems}
           >


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Hasura was rendering strings and objects as the same in browse rows, we couldn't differentiate one from another.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#4201

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
Checking if the column is a JSON or JSONB type instead of only if the value is an object fix the issue.

Before (You couldn't tell that one of the rows is a string by mistake):

![Screen Shot 2020-03-28 at 18 41 24](https://user-images.githubusercontent.com/26460/77834482-c4563700-7123-11ea-9784-385e21614c8b.png)

After (You can see the difference clearly):

![Screen Shot 2020-03-28 at 18 37 46](https://user-images.githubusercontent.com/26460/77834468-ac7eb300-7123-11ea-8b7e-b338f446d6e1.png)


### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Create one json and one jsonb columns, create two rows, one with both values as `{"object":true}` and another one with both values as `"{\"string\": \"true\"}"`.

You can't tell the difference in `Browse Rows` before and you should after this fix.

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->
None.

### Server checklist
<!-- A checklist for server code -->
None.

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
