### PR TITLE
ci: use hub instead of ghr for releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -517,7 +517,7 @@ jobs:
 
   deploy:
     docker:
-    - image: hasura/graphql-engine-deployer:v0.3
+    - image: hasura/graphql-engine-deployer:v0.4
     working_directory: ~/graphql-engine
     steps:
     - attach_workspace:

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -52,30 +52,21 @@ deploy_server_latest() {
 
 draft_github_release() {
     cd "$ROOT"
+    export GITHUB_REPOSITORY="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
     echo "drafting github release"
-    ghr -t "$GITHUB_TOKEN" \
-        -u "$CIRCLE_PROJECT_USERNAME" \
-        -r "$CIRCLE_PROJECT_REPONAME" \
-        -b "${RELEASE_BODY}" \
-        -draft \
+    hub release create \
+        --draft \
+        -a /build/_cli_output/binaries/cli-hasura-darwin-amd64 \
+        -a /build/_cli_output/binaries/cli-hasura-linux-amd64 \
+        -a /build/_cli_output/binaries/cli-hasura-windows-amd64.exe \
+        -a /build/_cli_ext_output/cli-ext-hasura-linux.tar.gz \
+        -a /build/_cli_ext_output/cli-ext-hasura-macos.tar.gz \
+        -a /build/_cli_ext_output/cli-ext-hasura-win.zip \
+        -m "$CIRCLE_TAG" \
+        -m "${RELEASE_BODY}" \
      "$CIRCLE_TAG"
-    echo "uploading cli assets"
-    ghr -t "$GITHUB_TOKEN" \
-        -u "$CIRCLE_PROJECT_USERNAME" \
-        -r "$CIRCLE_PROJECT_REPONAME" \
-        -draft \
-     "$CIRCLE_TAG" /build/_cli_output/binaries/
-    echo "uploading cli-ext assets"
-    ghr -t "$GITHUB_TOKEN" \
-        -u "$CIRCLE_PROJECT_USERNAME" \
-        -r "$CIRCLE_PROJECT_REPONAME" \
-        -draft \
-     "$CIRCLE_TAG" /build/_cli_ext_output/*.tar.gz
-    ghr -t "$GITHUB_TOKEN" \
-        -u "$CIRCLE_PROJECT_USERNAME" \
-        -r "$CIRCLE_PROJECT_REPONAME" \
-        -draft \
-     "$CIRCLE_TAG" /build/_cli_ext_output/*.zip
+
+    unset GITHUB_REPOSITORY
 }
 
 configure_git() {

--- a/.circleci/deployer.dockerfile
+++ b/.circleci/deployer.dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:16.04
 ARG docker_ver="17.09.0-ce"
 ARG upx_version="3.94"
 ARG gcloud_version="207.0.0"
-ARG ghr_version="0.10.0"
+ARG ghr_version="0.13.0"
 ARG hub_version="2.5.0"
 
 RUN apt-get -y update \

--- a/.circleci/deployer.dockerfile
+++ b/.circleci/deployer.dockerfile
@@ -3,8 +3,7 @@ FROM ubuntu:16.04
 ARG docker_ver="17.09.0-ce"
 ARG upx_version="3.94"
 ARG gcloud_version="207.0.0"
-ARG ghr_version="0.13.0"
-ARG hub_version="2.5.0"
+ARG hub_version="2.14.2"
 
 RUN apt-get -y update \
     && apt-get install -y curl make xz-utils git python \
@@ -15,9 +14,6 @@ RUN apt-get -y update \
     && xz -d -c /tmp/upx-${upx_version}.tar.xz \
        | tar -xOf - upx-${upx_version}-amd64_linux/upx > /bin/upx \
     && chmod a+x /bin/upx \
-    && curl -Lo /tmp/ghr-${ghr_version}.tar.gz https://github.com/tcnksm/ghr/releases/download/v${ghr_version}/ghr_v${ghr_version}_linux_amd64.tar.gz \
-    && tar -xz -C /tmp -f /tmp/ghr-${ghr_version}.tar.gz \
-    && mv /tmp/ghr_v${ghr_version}_linux_amd64/* /usr/bin \
     && curl -Lo /tmp/gcloud-${gcloud_version}.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${gcloud_version}-linux-x86_64.tar.gz \
     && tar -xzf /tmp/gcloud-${gcloud_version}.tar.gz -C /usr/local \
     && /usr/local/google-cloud-sdk/install.sh \


### PR DESCRIPTION
### Description
This PR replaces `ghr` with `hub` for github releases.

[hub](https://hub.github.com/hub.1.html)
[hub-release](https://hub.github.com/hub-release.1.html)

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [x] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->