### PR TITLE
console: fix computed field permission selection

### DIFF
--- a/console/src/components/Services/Data/TablePermissions/Actions.js
+++ b/console/src/components/Services/Data/TablePermissions/Actions.js
@@ -249,7 +249,9 @@ const toggleAllFields = (permissions, allFields, fieldType) => {
 
 // fieldType: columns / computed_fields
 const toggleField = (permissions, fieldName, fieldType) => {
-  const currFields = permissions ? permissions[fieldType] : [];
+  const currFields =
+    permissions && permissions[fieldType] ? permissions[fieldType] : [];
+
   let _newFields = currFields;
 
   const fieldIndex = currFields.indexOf(fieldName);


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

fix runtime error while selecting computed field in select permissions. 

this happens only in some particular cases where state ends up with null/undefined values of computed_fields key

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Console

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->
