### PR TITLE
ci: fix cli-migrations-v2 build process

### DIFF
--- a/scripts/cli-migrations/v2/Dockerfile
+++ b/scripts/cli-migrations/v2/Dockerfile
@@ -1,8 +1,13 @@
+FROM hasura/haskell-docker-packager:20190731 as packager
+WORKDIR /tmp
+RUN apt-get update && apt-get download libstdc++6
+
 FROM hasura/graphql-engine:v1.1.1
 
-RUN wget http://ftp.us.debian.org/debian/pool/main/g/gcc-10/libstdc++6_10-20200312-2_amd64.deb -O lib.deb \
-    && busybox dpkg-deb -x lib.deb / \
-    && rm lib.deb
+# install libstdc++6
+COPY --from=packager /tmp/libstdc++6* .
+RUN busybox dpkg-deb -x libstdc++6*.deb / \
+    && rm libstdc++6*.deb
 
 # set an env var to let the cli know that
 # it is running in server environment


### PR DESCRIPTION
### Description
This PR fixes an issue with `cli-migrations-v2` docker build process to install `libstdc++6`.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [x] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
Instead of downloading `libstdc++6.deb` file from the FTP server, this PR uses a multi-stage docker process to download the `libstdc++6` package using `apt-get` and then copy it to the install step.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->