### PR TITLE
cli: event trigger retry_conf support to squash (close #4296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The order and collapsed state of columns is now persisted across page navigation
 
 ### Bug fixes and improvements
 
+- cli: add retry_conf in event trigger for squashing migrations (close #4296) (#4324)
 - cli: add support for multiple versions of plugin (close #4105)
 - cli: template assets path in console HTML for unversioned builds
 - console: allow customising graphql field names for columns of views (close #3689) (#4255)

--- a/cli/migrate/database/hasuradb/squash.go
+++ b/cli/migrate/database/hasuradb/squash.go
@@ -40,14 +40,23 @@ func (q CustomQuery) MergeEventTriggers(squashList *database.CustomList) error {
 		prevElems := make([]*list.Element, 0)
 		for _, val := range g.Group {
 			element := val.(*list.Element)
-			switch element.Value.(type) {
-			case *trackTableInput:
+			switch obj := element.Value.(type) {
+			case *createEventTriggerInput:
+				if obj.Replace {
+					for _, e := range prevElems {
+						squashList.Remove(e)
+					}
+					err := eventTriggerTransition.Trigger("delete_event_trigger", &evCfg, nil)
+					if err != nil {
+						return err
+					}
+				}
 				err := eventTriggerTransition.Trigger("create_event_trigger", &evCfg, nil)
 				if err != nil {
 					return err
 				}
 				prevElems = append(prevElems, element)
-			case *unTrackTableInput:
+			case *deleteEventTriggerInput:
 				err := eventTriggerTransition.Trigger("delete_event_trigger", &evCfg, nil)
 				if err != nil {
 					return err

--- a/cli/migrate/database/hasuradb/types.go
+++ b/cli/migrate/database/hasuradb/types.go
@@ -475,8 +475,15 @@ type createEventTriggerInput struct {
 	Definition     *createEventTriggerOperationInput `json:"definition,omitempty" yaml:"definition,omitempty"`
 	Headers        interface{}                       `json:"headers" yaml:"headers"`
 	Replace        bool                              `json:"replace" yaml:"replace"`
+	RetryConf      *createEventTriggerRetryConfInput `json:"retry_conf" yaml:"retry_conf"`
 
 	createEventTriggerOperationInput
+}
+
+type createEventTriggerRetryConfInput struct {
+	IntervalSec int `json:"interval_sec" yaml:"interval_sec"`
+	NumRetries  int `json:"num_retries" yaml:"num_retries"`
+	TimeOutSec  int `json:"timeout_sec" yaml:"timeout_sec"`
 }
 
 type createEventTriggerOperationInput struct {
@@ -493,15 +500,16 @@ func (c *createEventTriggerInput) MarshalJSON() ([]byte, error) {
 		c.Definition = nil
 	}
 	return json.Marshal(&struct {
-		Name           string      `json:"name" yaml:"name"`
-		Table          tableSchema `json:"table" yaml:"table"`
-		Webhook        string      `json:"webhook,omitempty" yaml:"webhook,omitempty"`
-		WebhookFromEnv string      `json:"webhook_from_env,omitempty" yaml:"webhook_from_env,omitempty"`
-		Headers        interface{} `json:"headers" yaml:"headers"`
-		Replace        bool        `json:"replace" yaml:"replace"`
-		Insert         interface{} `json:"insert,omitempty" yaml:"insert,omitempty"`
-		Update         interface{} `json:"update,omitempty" yaml:"update,omitempty"`
-		Delete         interface{} `json:"delete,omitempty" yaml:"delete,omitempty"`
+		Name           string                            `json:"name" yaml:"name"`
+		Table          tableSchema                       `json:"table" yaml:"table"`
+		Webhook        string                            `json:"webhook,omitempty" yaml:"webhook,omitempty"`
+		WebhookFromEnv string                            `json:"webhook_from_env,omitempty" yaml:"webhook_from_env,omitempty"`
+		Headers        interface{}                       `json:"headers" yaml:"headers"`
+		Replace        bool                              `json:"replace" yaml:"replace"`
+		RetryConf      *createEventTriggerRetryConfInput `json:"retry_conf" yaml:"retry_conf"`
+		Insert         interface{}                       `json:"insert,omitempty" yaml:"insert,omitempty"`
+		Update         interface{}                       `json:"update,omitempty" yaml:"update,omitempty"`
+		Delete         interface{}                       `json:"delete,omitempty" yaml:"delete,omitempty"`
 	}{
 		Name:           c.Name,
 		Table:          c.Table,
@@ -509,6 +517,7 @@ func (c *createEventTriggerInput) MarshalJSON() ([]byte, error) {
 		WebhookFromEnv: c.WebhookFromEnv,
 		Headers:        c.Headers,
 		Replace:        c.Replace,
+		RetryConf:      c.RetryConf,
 		Insert:         c.Insert,
 		Update:         c.Update,
 		Delete:         c.Delete,


### PR DESCRIPTION
### Description
This PR adds `retry_conf` to `create_event_trigger` input.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [x] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
#4296 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->