### PR TITLE
cli: show env vars for the flags in command help (close #4263)

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -7,6 +7,9 @@ OUTPUT_DIR := _output
 # compile assets
 .PHONY: assets
 assets:
+ifndef HAS_PKGER
+	go get github.com/markbates/pkger/cmd/pkger
+endif
 	pkger -o pkg/console/templates/packed -include /pkg/console/templates/gohtml/
 
 HAS_GOX := $(shell command -v gox;)
@@ -18,9 +21,6 @@ deps:
 	go mod download
 ifndef HAS_GOX
 	go get github.com/mitchellh/gox
-endif
-ifndef HAS_PKGER
-	go get github.com/markbates/pkger/cmd/pkger
 endif
 
 # build cli locally, for all given platform/arch

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -433,8 +432,8 @@ func (ec *ExecutionContext) WriteConfig(config *Config) error {
 func (ec *ExecutionContext) readConfig() error {
 	// need to get existing viper because https://github.com/spf13/viper/issues/233
 	v := ec.Viper
-	v.SetEnvPrefix("HASURA_GRAPHQL")
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	v.SetEnvPrefix(util.ViperEnvPrefix)
+	v.SetEnvKeyReplacer(util.ViperEnvReplacer)
 	v.AutomaticEnv()
 	v.SetConfigName("config")
 	v.SetDefault("version", "1")

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v2"

--- a/cli/commands/actions.go
+++ b/cli/commands/actions.go
@@ -46,14 +46,16 @@ func NewActionsCmd(ec *cli.ExecutionContext) *cobra.Command {
 		newActionsUseCodegenCmd(ec),
 	)
 
-	actionsCmd.PersistentFlags().String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
-	actionsCmd.PersistentFlags().String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
-	actionsCmd.PersistentFlags().String("access-key", "", "access key for Hasura GraphQL Engine")
-	actionsCmd.PersistentFlags().MarkDeprecated("access-key", "use --admin-secret instead")
+	f := actionsCmd.PersistentFlags()
 
-	v.BindPFlag("endpoint", actionsCmd.PersistentFlags().Lookup("endpoint"))
-	v.BindPFlag("admin_secret", actionsCmd.PersistentFlags().Lookup("admin-secret"))
-	v.BindPFlag("access_key", actionsCmd.PersistentFlags().Lookup("access-key"))
+	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
+	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
+	f.String("access-key", "", "access key for Hasura GraphQL Engine")
+	f.MarkDeprecated("access-key", "use --admin-secret instead")
+
+	util.BindPFlag(v, "endpoint", f.Lookup("endpoint"))
+	util.BindPFlag(v, "admin_secret", f.Lookup("admin-secret"))
+	util.BindPFlag(v, "access_key", f.Lookup("access-key"))
 
 	return actionsCmd
 }

--- a/cli/commands/actions_create.go
+++ b/cli/commands/actions_create.go
@@ -49,8 +49,8 @@ func newActionsCreateCmd(ec *cli.ExecutionContext, v *viper.Viper) *cobra.Comman
 	f.String("webhook", "", "webhook to use in action")
 
 	// bind to viper
-	v.BindPFlag("actions.kind", f.Lookup("kind"))
-	v.BindPFlag("actions.handler_webhook_baseurl", f.Lookup("webhook"))
+	util.BindPFlag(v, "actions.kind", f.Lookup("kind"))
+	util.BindPFlag(v, "actions.handler_webhook_baseurl", f.Lookup("webhook"))
 
 	return actionsCreateCmd
 }

--- a/cli/commands/console.go
+++ b/cli/commands/console.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/hasura/graphql-engine/cli/migrate"
+	"github.com/hasura/graphql-engine/cli/util"
 
 	"github.com/gin-gonic/gin"
 	"github.com/hasura/graphql-engine/cli"
@@ -66,9 +67,10 @@ func NewConsoleCmd(ec *cli.ExecutionContext) *cobra.Command {
 	f.MarkDeprecated("access-key", "use --admin-secret instead")
 
 	// need to create a new viper because https://github.com/spf13/viper/issues/233
-	v.BindPFlag("endpoint", f.Lookup("endpoint"))
-	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
-	v.BindPFlag("access_key", f.Lookup("access-key"))
+	util.BindPFlag(v, "endpoint", f.Lookup("endpoint"))
+	util.BindPFlag(v, "admin_secret", f.Lookup("admin-secret"))
+	util.BindPFlag(v, "access_key", f.Lookup("access-key"))
+
 	return consoleCmd
 }
 
@@ -151,7 +153,7 @@ func (o *ConsoleOptions) Run() error {
 		Address:                 o.Address,
 		SignalChanConsoleServer: o.ConsoleServerInterruptSignal,
 		SignalChanAPIServer:     o.APIServerInterruptSignal,
-		WG: o.WG,
+		WG:                      o.WG,
 	}
 
 	return console.Serve(serveOpts)

--- a/cli/commands/metadata.go
+++ b/cli/commands/metadata.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"github.com/hasura/graphql-engine/cli"
 	"github.com/hasura/graphql-engine/cli/migrate"
+	"github.com/hasura/graphql-engine/cli/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -35,14 +36,16 @@ func NewMetadataCmd(ec *cli.ExecutionContext) *cobra.Command {
 		newMetadataInconsistencyCmd(ec),
 	)
 
-	metadataCmd.PersistentFlags().String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
-	metadataCmd.PersistentFlags().String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
-	metadataCmd.PersistentFlags().String("access-key", "", "access key for Hasura GraphQL Engine")
-	metadataCmd.PersistentFlags().MarkDeprecated("access-key", "use --admin-secret instead")
+	f := metadataCmd.PersistentFlags()
 
-	v.BindPFlag("endpoint", metadataCmd.PersistentFlags().Lookup("endpoint"))
-	v.BindPFlag("admin_secret", metadataCmd.PersistentFlags().Lookup("admin-secret"))
-	v.BindPFlag("access_key", metadataCmd.PersistentFlags().Lookup("access-key"))
+	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
+	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
+	f.String("access-key", "", "access key for Hasura GraphQL Engine")
+	f.MarkDeprecated("access-key", "use --admin-secret instead")
+
+	util.BindPFlag(v, "endpoint", f.Lookup("endpoint"))
+	util.BindPFlag(v, "admin_secret", f.Lookup("admin-secret"))
+	util.BindPFlag(v, "access_key", f.Lookup("access-key"))
 
 	return metadataCmd
 }

--- a/cli/commands/migrate.go
+++ b/cli/commands/migrate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hasura/graphql-engine/cli"
 	"github.com/hasura/graphql-engine/cli/migrate"
 	mig "github.com/hasura/graphql-engine/cli/migrate/cmd"
+	"github.com/hasura/graphql-engine/cli/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -37,14 +38,18 @@ func NewMigrateCmd(ec *cli.ExecutionContext) *cobra.Command {
 		newMigrateCreateCmd(ec),
 		newMigrateSquashCmd(ec),
 	)
-	migrateCmd.PersistentFlags().String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
-	migrateCmd.PersistentFlags().String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
-	migrateCmd.PersistentFlags().String("access-key", "", "access key for Hasura GraphQL Engine")
-	migrateCmd.PersistentFlags().MarkDeprecated("access-key", "use --admin-secret instead")
 
-	v.BindPFlag("endpoint", migrateCmd.PersistentFlags().Lookup("endpoint"))
-	v.BindPFlag("admin_secret", migrateCmd.PersistentFlags().Lookup("admin-secret"))
-	v.BindPFlag("access_key", migrateCmd.PersistentFlags().Lookup("access-key"))
+	f := migrateCmd.PersistentFlags()
+
+	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
+	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
+	f.String("access-key", "", "access key for Hasura GraphQL Engine")
+	f.MarkDeprecated("access-key", "use --admin-secret instead")
+
+	util.BindPFlag(v, "endpoint", f.Lookup("endpoint"))
+	util.BindPFlag(v, "admin_secret", f.Lookup("admin-secret"))
+	util.BindPFlag(v, "access_key", f.Lookup("access-key"))
+
 	return migrateCmd
 }
 

--- a/cli/commands/scripts_update_config_v2.go
+++ b/cli/commands/scripts_update_config_v2.go
@@ -330,17 +330,17 @@ func newScriptsUpdateConfigV2Cmd(ec *cli.ExecutionContext) *cobra.Command {
 	}
 
 	f := scriptsUpdateConfigV2Cmd.Flags()
-	f.StringVar(&metadataDir, "metadata-dir", "metadata", "")
 
+	f.StringVar(&metadataDir, "metadata-dir", "metadata", "")
 	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
 	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
 	f.String("access-key", "", "access key for Hasura GraphQL Engine")
 	f.MarkDeprecated("access-key", "use --admin-secret instead")
 
 	// need to create a new viper because https://github.com/spf13/viper/issues/233
-	v.BindPFlag("endpoint", f.Lookup("endpoint"))
-	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
-	v.BindPFlag("access_key", f.Lookup("access-key"))
+	util.BindPFlag(v, "endpoint", f.Lookup("endpoint"))
+	util.BindPFlag(v, "admin_secret", f.Lookup("admin-secret"))
+	util.BindPFlag(v, "access_key", f.Lookup("access-key"))
 
 	return scriptsUpdateConfigV2Cmd
 }

--- a/cli/util/viper.go
+++ b/cli/util/viper.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+// ViperEnvPrefix - Env prefix to be used in viper
+const ViperEnvPrefix = "HASURA_GRAPHQL"
+
+// ViperEnvReplacer - Env replacer to be used in viper
+var ViperEnvReplacer = strings.NewReplacer(".", "_")
+
+// BindPFlag - binds flag with viper along with env usage
+func BindPFlag(v *viper.Viper, key string, f *pflag.Flag) {
+	v.BindPFlag(key, f)
+	key = ViperEnvReplacer.Replace(key)
+	key = strings.ToUpper(ViperEnvPrefix + "_" + key)
+	f.Usage = f.Usage + fmt.Sprintf(` (env "%s")`, key)
+}


### PR DESCRIPTION
### Description
This PR adds environment variables (if there is one for the flag) also in the help command.

![DeepinScreenshot_select-area_20200408163316](https://user-images.githubusercontent.com/15613164/78777703-a60bf900-79b7-11ea-8b6d-e0a58cf0673c.png)

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [x] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
#4263 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->