### PR TITLE
gh: make all hge-server team members code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 *         @hasura/hge-changelog-owners
 
 # server code owners
-/server/  @hasura/hge-server-owners
+/server/  @hasura/hge-server
 
 # docs code owners
 /docs/    @hasura/hge-docs-owners
@@ -13,4 +13,3 @@
 
 # console code owners
 /console/ @hasura/hge-console-owners
-


### PR DESCRIPTION
We’d like to experiment with giving code ownership of the server code to the entire server team. It is the responsibility of team members to decide which PRs they are or are not equipped to review.