### PR TITLE
server: create hlint config, apply most hints

### DIFF
--- a/server/.hlint.yaml
+++ b/server/.hlint.yaml
@@ -1,0 +1,72 @@
+# HLint configuration file
+# https://github.com/ndmitchell/hlint
+##########################
+
+# This file contains a template configuration file, which is typically
+# placed as .hlint.yaml in the root of your project
+
+
+# Specify additional command line arguments
+#
+# - arguments: [--color, --cpp-simple, -XQuasiQuotes]
+
+
+# Control which extensions/flags/modules/functions can be used
+#
+# - extensions:
+#   - default: false # all extension are banned by default
+#   - name: [PatternGuards, ViewPatterns] # only these listed extensions can be used
+#   - {name: CPP, within: CrossPlatform} # CPP can only be used in a given module
+#
+# - flags:
+#   - {name: -w, within: []} # -w is allowed nowhere
+#
+# - modules:
+#   - {name: [Data.Set, Data.HashSet], as: Set} # if you import Data.Set qualified, it must be as 'Set'
+#   - {name: Control.Arrow, within: []} # Certain modules are banned entirely
+#
+# - functions:
+#   - {name: unsafePerformIO, within: []} # unsafePerformIO can only appear in no modules
+
+
+# Add custom hints for this project
+#
+# Will suggest replacing "wibbleMany [myvar]" with "wibbleOne myvar"
+# - error: {lhs: "wibbleMany [x]", rhs: wibbleOne x}
+
+
+# Turn on hints that are off by default
+#
+# Ban "module X(module X) where", to require a real export list
+# - warn: {name: Use explicit module export list}
+#
+# Replace a $ b $ c with a . b $ c
+# - group: {name: dollar, enabled: true}
+#
+# Generalise map to fmap, ++ to <>
+# - group: {name: generalise, enabled: true}
+
+
+# Ignore some builtin hints
+# - ignore: {name: Use let}
+# - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
+
+- ignore: {name: Parse error}
+- ignore: {name: Reduce duplication}
+- ignore: {name: Redundant bracket}
+- ignore: {name: Redundant do}
+- ignore: {name: Redundant multi-way if}
+
+- ignore: {name: Use $>,        within: Hasura.RQL.Types.DML}
+- ignore: {name: Use camelCase, within: Control.Arrow.Extended}
+- ignore: {name: Use fmap,      within: Control.Arrow.Extended}
+- ignore: {name: Use fmap,      within: Control.Arrow.Trans}
+- ignore: {name: Use fmap,      within: Hasura.Incremental.Internal.Cache}
+
+
+# Define some custom infix operators
+# - fixity: infixr 3 ~^#^~
+
+
+# To generate a suitable file for HLint do:
+# $ hlint --default > .hlint.yaml

--- a/server/src-lib/Control/Arrow/Trans.hs
+++ b/server/src-lib/Control/Arrow/Trans.hs
@@ -83,7 +83,7 @@ instance (ArrowChoice arr) => Arrow (ErrorA e arr) where
   {-# INLINE first #-}
 
 reassociateEither :: Either (Either a b) c -> Either a (Either b c)
-reassociateEither = either (either Left (Right . Left)) (Right . Right)
+reassociateEither = either (fmap Left) (Right . Right)
 
 instance (ArrowChoice arr) => ArrowChoice (ErrorA e arr) where
   left (ErrorA f) = ErrorA (arr reassociateEither . left f)

--- a/server/src-lib/Data/URL/Template.hs
+++ b/server/src-lib/Data/URL/Template.hs
@@ -46,7 +46,7 @@ printURLTemplate :: URLTemplate -> Text
 printURLTemplate = T.concat . map printTemplateItem . unURLTemplate
 
 parseURLTemplate :: Text -> Either String URLTemplate
-parseURLTemplate t = parseOnly parseTemplate t
+parseURLTemplate = parseOnly parseTemplate
   where
     parseTemplate :: Parser URLTemplate
     parseTemplate = do

--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Poll.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Poll.hs
@@ -64,15 +64,13 @@ import           Hasura.RQL.Types
 -- -------------------------------------------------------------------------------------------------
 -- Subscribers
 
-data Subscriber
-  = Subscriber
+data Subscriber = Subscriber
   { _sRootAlias        :: !G.Alias
   , _sOnChangeCallback :: !OnChange
   }
 
 -- | live query onChange metadata, used for adding more extra analytics data
-data LiveQueryMetadata
-  = LiveQueryMetadata
+data LiveQueryMetadata = LiveQueryMetadata
   { _lqmExecutionTime :: !Clock.DiffTime
   -- ^ Time spent waiting on the generated query to execute on postgres or the remote.
   }
@@ -146,7 +144,7 @@ mkRespHash = ResponseHash . CH.hash
 -- 'CohortId'; the latter is a completely synthetic key used only to identify the cohort in the
 -- generated SQL query.
 type CohortKey = CohortVariables
--- | This has the invariant, maintained in 'removeLiveQuery', that it contains no 'Cohort' with 
+-- | This has the invariant, maintained in 'removeLiveQuery', that it contains no 'Cohort' with
 -- zero total (existing + new) subscribers.
 type CohortMap = TMap.TMap CohortKey Cohort
 
@@ -234,7 +232,7 @@ data Poller
 data PollerIOState
   = PollerIOState
   { _pThread  :: !(Immortal.Thread)
-  -- ^ a handle on the poller’s worker thread that can be used to 'Immortal.stop' it if all its 
+  -- ^ a handle on the poller’s worker thread that can be used to 'Immortal.stop' it if all its
   -- cohorts stop listening
   , _pMetrics :: !RefetchMetrics
   }
@@ -330,7 +328,7 @@ pollQuery metrics batchSize pgExecCtx pgQuery handler =
       return (cohortSnapshotMap, queryVarsBatches)
 
     flip A.mapConcurrently_ queryVarsBatches $ \queryVars -> do
-      (dt, mxRes) <- timing _rmQuery $ 
+      (dt, mxRes) <- timing _rmQuery $
         runExceptT $ runLazyTx' pgExecCtx $ executeMultiplexedQuery pgQuery queryVars
       let lqMeta = LiveQueryMetadata $ fromUnits dt
           operations = getCohortOperations cohortSnapshotMap lqMeta mxRes

--- a/server/src-lib/Hasura/GraphQL/Execute/Query.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/Query.hs
@@ -156,9 +156,7 @@ prepareWithPlan :: (MonadState PlanningSt m) => UnresolvedVal -> m S.SQLExp
 prepareWithPlan = \case
   R.UVPG annPGVal -> do
     let AnnPGVal varM _ colVal = annPGVal
-    argNum <- case varM of
-      Just var -> getVarArgNum var
-      Nothing  -> getNextArgNum
+    argNum <- maybe getNextArgNum getVarArgNum varM
     addPrepArg argNum (toBinaryValue colVal, pstValue colVal)
     return $ toPrepParam argNum (pstType colVal)
 

--- a/server/src-lib/Hasura/GraphQL/Logging.hs
+++ b/server/src-lib/Hasura/GraphQL/Logging.hs
@@ -10,6 +10,7 @@ module Hasura.GraphQL.Logging
 import qualified Data.Aeson                             as J
 import qualified Language.GraphQL.Draft.Syntax          as G
 
+import           Data.Bifunctor                         (bimap)
 import           Hasura.GraphQL.Transport.HTTP.Protocol (GQLReqUnparsed)
 import           Hasura.Prelude
 import           Hasura.Server.Utils                    (RequestId)
@@ -41,7 +42,7 @@ instance L.ToEngineLog QueryLog L.Hasura where
 -- | key-value map to be printed as JSON
 encodeSql :: EQ.GeneratedSqlMap -> J.Value
 encodeSql sql =
-  jValFromAssocList $ map (\(a, q) -> (alName a, fmap J.toJSON q)) sql
+  jValFromAssocList $ bimap alName (fmap J.toJSON) <$> sql
   where
     alName = G.unName . G.unAlias
     jValFromAssocList xs = J.object $ map (uncurry (J..=)) xs

--- a/server/src-lib/Hasura/GraphQL/RemoteServer.hs
+++ b/server/src-lib/Hasura/GraphQL/RemoteServer.hs
@@ -61,12 +61,12 @@ fetchRemoteSchema manager name def@(RemoteSchemaInfo url headerConf _ timeout) =
   typMap <- either remoteSchemaErr return $ VT.fromSchemaDoc sDoc $
      VT.TLRemoteType name def
   let mQrTyp = Map.lookup qRootN typMap
-      mMrTyp = maybe Nothing (`Map.lookup` typMap) mRootN
-      mSrTyp = maybe Nothing (`Map.lookup` typMap) sRootN
+      mMrTyp = (`Map.lookup` typMap) =<< mRootN
+      mSrTyp = (`Map.lookup` typMap) =<< sRootN
   qrTyp <- liftMaybe noQueryRoot mQrTyp
   let mRmQR = VT.getObjTyM qrTyp
-      mRmMR = join $ VT.getObjTyM <$> mMrTyp
-      mRmSR = join $ VT.getObjTyM <$> mSrTyp
+      mRmMR = VT.getObjTyM =<< mMrTyp
+      mRmSR = VT.getObjTyM =<< mSrTyp
   rmQR <- liftMaybe (err400 Unexpected "query root has to be an object type") mRmQR
   return $ GC.RemoteGCtx typMap rmQR mRmMR mRmSR
 

--- a/server/src-lib/Hasura/GraphQL/Resolve/Insert.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/Insert.hs
@@ -455,7 +455,7 @@ insertMultipleObjects strfyNum role tn multiObjIns addCols mutOutput errP =
           insertObj strfyNum role tn objIns addCols
 
       let affRows = sum $ map fst insResps
-          columnValues = catMaybes $ map snd insResps
+          columnValues = mapMaybe snd insResps
       cteExp <- mkSelCTEFromColVals tn tableColInfos columnValues
       let sql = toSQL $ RR.mkMutationOutputExp tn tableColInfos (Just affRows) cteExp mutOutput strfyNum
       runIdentity . Q.getRow

--- a/server/src-lib/Hasura/GraphQL/Schema.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema.hs
@@ -188,7 +188,7 @@ mkGCtxRole' tn descM insPermM selPermM updColsM delPermM pkeyCols constraints vi
     -- column fields used in insert input object
     insInpObjFldsM = (mkColFldMap (mkInsInpTy tn) . fst) <$> insPermM
     -- relationship input objects
-    relInsInpObjsM = const (mkRelInsInps tn isUpsertable) <$> insPermM
+    relInsInpObjsM = mkRelInsInps tn isUpsertable <$ insPermM
     -- update set input type
     updSetInpObjM = mkUpdSetInp tn <$> updColsM
     -- update increment input type
@@ -754,11 +754,11 @@ mkGCtxMap annotatedObjects tableCache functionCache actionCache = do
             concatMap (Map.keys . _rootMutationFields) rootFields
 
       -- TODO: The following exception should result in inconsistency
-      when (not $ null duplicateQueryFields) $
+      unless (null duplicateQueryFields) $
         throw400 Unexpected $ "following query root fields are duplicated: "
         <> showNames duplicateQueryFields
 
-      when (not $ null duplicateMutationFields) $
+      unless (null duplicateMutationFields) $
         throw400 Unexpected $ "following mutation root fields are duplicated: "
         <> showNames duplicateMutationFields
 

--- a/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
@@ -349,7 +349,7 @@ onStart serverEnv wsConn (StartMsg opId q) = catchAndIgnore $ do
           logOpEv ODStarted (Just reqId)
           -- log the generated SQL and the graphql query
           L.unLogger logger $ QueryLog query genSql reqId
-          (withElapsedTime $ liftIO $ runExceptT action) >>= \case
+          withElapsedTime (liftIO $ runExceptT action) >>= \case
             (_,      Left err) -> postExecErr reqId err
             (telemTimeIO_DT, Right encJson) -> do
               -- Telemetry. NOTE: don't time network IO:
@@ -374,7 +374,7 @@ onStart serverEnv wsConn (StartMsg opId q) = catchAndIgnore $ do
         G.OperationTypeQuery    -> return Telem.Query
 
       -- if it's not a subscription, use HTTP to execute the query on the remote
-      (runExceptT $ flip runReaderT execCtx $
+      runExceptT (flip runReaderT execCtx $
         E.execRemoteGQ reqId userInfo reqHdrs q rsi opDef) >>= \case
           Left  err           -> postExecErr reqId err
           Right (telemTimeIO_DT, !val) -> do

--- a/server/src-lib/Hasura/GraphQL/Transport/WebSocket/Protocol.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/WebSocket/Protocol.hs
@@ -24,19 +24,17 @@ import           Hasura.GraphQL.Transport.HTTP.Protocol
 import           Hasura.Prelude
 
 -- | These come from the client and are websocket connection-local.
-newtype OperationId
-  = OperationId { unOperationId :: Text }
-  deriving (Show, Eq, J.ToJSON, J.FromJSON, Hashable)
+newtype OperationId = OperationId
+  { unOperationId :: Text
+  } deriving (Show, Eq, J.ToJSON, J.FromJSON, Hashable)
 
-data StartMsg
-  = StartMsg
+data StartMsg = StartMsg
   { _smId      :: !OperationId
   , _smPayload :: !GQLReqUnparsed
   } deriving (Show, Eq)
 $(J.deriveJSON (J.aesonDrop 3 J.snakeCase) ''StartMsg)
 
-data StopMsg
-  = StopMsg
+newtype StopMsg = StopMsg
   { _stId :: OperationId
   } deriving (Show, Eq)
 $(J.deriveJSON (J.aesonDrop 3 J.snakeCase) ''StopMsg)
@@ -48,8 +46,7 @@ data ClientMsg
   | CMConnTerm
   deriving (Show, Eq)
 
-data ConnParams
-  = ConnParams
+newtype ConnParams = ConnParams
   { _cpHeaders :: Maybe (Map.HashMap Text Text)
   } deriving (Show, Eq)
 $(J.deriveJSON (J.aesonDrop 3 J.snakeCase) ''ConnParams)

--- a/server/src-lib/Hasura/GraphQL/Validate/Types.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate/Types.hs
@@ -642,7 +642,7 @@ fromTyDef tyDef loc = case tyDef of
 
 fromSchemaDoc :: G.SchemaDocument -> TypeLoc -> Either Text TypeMap
 fromSchemaDoc (G.SchemaDocument tyDefs) loc = do
-  let tyMap = mkTyInfoMap $ map (flip fromTyDef loc) tyDefs
+  let tyMap = mkTyInfoMap $ map (`fromTyDef` loc) tyDefs
   validateTypeMap tyMap
   return tyMap
 

--- a/server/src-lib/Hasura/Incremental/Internal/Rule.hs
+++ b/server/src-lib/Hasura/Incremental/Internal/Rule.hs
@@ -268,7 +268,7 @@ class (Arrow arr) => ArrowDistribute arr where
     -> arr (e, (HashMap k a, s)) (HashMap k b)
 
 instance (Monoid w, ArrowDistribute arr) => ArrowDistribute (WriterA w arr) where
-  keyed (WriterA f) = WriterA (arr (swap . sequence . fmap swap) . keyed f)
+  keyed (WriterA f) = WriterA (arr (swap . traverse swap) . keyed f)
   {-# INLINE keyed #-}
 
 -- | Unlike 'traverseA', using 'keyed' preserves incrementalization: if the input rule is

--- a/server/src-lib/Hasura/RQL/DDL/Schema/Enum.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Enum.hs
@@ -17,6 +17,7 @@ module Hasura.RQL.DDL.Schema.Enum (
 import           Hasura.Prelude
 
 import           Control.Monad.Validate
+import           Data.Bifunctor                (bimap)
 import           Data.List                     (delete)
 
 import qualified Data.HashMap.Strict           as M
@@ -106,8 +107,7 @@ fetchAndValidateEnumValues tableName maybePrimaryKey columnInfos =
                 , S.selExtr = [S.mkExtr (prciName primaryKeyColumn), commentExtr] }
           fmap mkEnumValues . liftTx $ Q.withQE defaultTxErrorHandler query () True
 
-        mkEnumValues rows = M.fromList . flip map rows $ \(key, comment) ->
-          (EnumValue key, EnumValueInfo comment)
+        mkEnumValues rows = M.fromList . flip map rows $ bimap EnumValue EnumValueInfo
 
         validateEnumValues enumValues = do
           let enumValueNames = map (G.Name . getEnumValue) (M.keys enumValues)

--- a/server/src-lib/Hasura/RQL/DML/Returning.hs
+++ b/server/src-lib/Hasura/RQL/DML/Returning.hs
@@ -153,7 +153,7 @@ mkMutationOutputExp qt allCols preCalAffRows cte mutOutput strfyNum =
     allColumnsAlias = Iden $ snakeCaseQualObject qt <> "__all_columns_alias"
 
     allColumnsSelect = S.CTESelect $ S.mkSelect
-                       { S.selExtr = map S.mkExtr $ map pgiColumn $ sortCols allCols
+                       { S.selExtr = map (S.mkExtr . pgiColumn) $ sortCols allCols
                        , S.selFrom = Just $ S.mkIdenFromExp mutationResultAlias
                        }
 

--- a/server/src-lib/Hasura/RQL/Types/Action.hs
+++ b/server/src-lib/Hasura/RQL/Types/Action.hs
@@ -72,13 +72,12 @@ $(J.deriveJSON
   J.defaultOptions { J.constructorTagModifier = J.snakeCase . drop 6}
   ''ActionKind)
 
-newtype ArgumentName
-  = ArgumentName { unArgumentName :: G.Name }
-  deriving ( Show, Eq, J.FromJSON, J.ToJSON, J.FromJSONKey, J.ToJSONKey
-           , Hashable, DQuote, Lift, Generic, NFData, Cacheable)
+newtype ArgumentName = ArgumentName
+  { unArgumentName :: G.Name
+  } deriving ( Show, Eq, J.FromJSON, J.ToJSON, J.FromJSONKey, J.ToJSONKey
+             , Hashable, DQuote, Lift, Generic, NFData, Cacheable)
 
-data ArgumentDefinition
-  = ArgumentDefinition
+data ArgumentDefinition = ArgumentDefinition
   { _argName        :: !ArgumentName
   , _argType        :: !GraphQLType
   , _argDescription :: !(Maybe G.Description)
@@ -87,8 +86,7 @@ instance NFData ArgumentDefinition
 instance Cacheable ArgumentDefinition
 $(J.deriveJSON (J.aesonDrop 4 J.snakeCase) ''ArgumentDefinition)
 
-data ActionDefinition a
-  = ActionDefinition
+data ActionDefinition a = ActionDefinition
   { _adArguments            :: ![ArgumentDefinition]
   , _adOutputType           :: !GraphQLType
   , _adKind                 :: !ActionKind
@@ -112,9 +110,8 @@ instance (J.FromJSON a) => J.FromJSON (ActionDefinition a) where
 
 type ResolvedActionDefinition = ActionDefinition ResolvedWebhook
 
-data ActionPermissionInfo
-  = ActionPermissionInfo
-  { _apiRole   :: !RoleName
+data ActionPermissionInfo = ActionPermissionInfo
+  { _apiRole :: !RoleName
   } deriving (Show, Eq)
 $(J.deriveToJSON (J.aesonDrop 4 J.snakeCase) ''ActionPermissionInfo)
 

--- a/server/src-lib/Hasura/RQL/Types/EventTrigger.hs
+++ b/server/src-lib/Hasura/RQL/Types/EventTrigger.hs
@@ -174,8 +174,7 @@ instance FromJSON CreateEventTriggerQuery where
 $(deriveToJSON (aesonDrop 4 snakeCase){omitNothingFields=True} ''CreateEventTriggerQuery)
 
 -- | The table operations on which the event trigger will be invoked.
-data TriggerOpsDef
-  = TriggerOpsDef
+data TriggerOpsDef = TriggerOpsDef
   { tdInsert       :: !(Maybe SubscribeOpSpec)
   , tdUpdate       :: !(Maybe SubscribeOpSpec)
   , tdDelete       :: !(Maybe SubscribeOpSpec)
@@ -185,8 +184,7 @@ instance NFData TriggerOpsDef
 instance Cacheable TriggerOpsDef
 $(deriveJSON (aesonDrop 2 snakeCase){omitNothingFields=True} ''TriggerOpsDef)
 
-data DeleteEventTriggerQuery
-  = DeleteEventTriggerQuery
+data DeleteEventTriggerQuery = DeleteEventTriggerQuery
   { detqName :: !TriggerName
   } deriving (Show, Eq, Lift)
 

--- a/server/src-lib/Hasura/RQL/Types/Table.hs
+++ b/server/src-lib/Hasura/RQL/Types/Table.hs
@@ -137,7 +137,7 @@ instance FromJSON TableCustomRootFields where
                                         , update, updateByPk
                                         , delete, deleteByPk
                                         ]
-    when (not $ null duplicateRootFields) $ fail $ T.unpack $
+    unless (null duplicateRootFields) $ fail $ T.unpack $
       "the following custom root field names are duplicated: "
       <> showNames duplicateRootFields
 
@@ -279,12 +279,12 @@ data EventTriggerInfo
    , etiOpsDef      :: !TriggerOpsDef
    , etiRetryConf   :: !RetryConf
    , etiWebhookInfo :: !WebhookConfInfo
-   -- ^ The HTTP(s) URL which will be called with the event payload on configured operation. 
-   -- Must be a POST handler. This URL can be entered manually or can be picked up from an 
-   -- environment variable (the environment variable needs to be set before using it for 
-   -- this configuration). 
+   -- ^ The HTTP(s) URL which will be called with the event payload on configured operation.
+   -- Must be a POST handler. This URL can be entered manually or can be picked up from an
+   -- environment variable (the environment variable needs to be set before using it for
+   -- this configuration).
    , etiHeaders     :: ![EventHeaderInfo]
-   -- ^ Custom headers can be added to an event trigger. Each webhook request will have these 
+   -- ^ Custom headers can be added to an event trigger. Each webhook request will have these
    -- headers added.
    } deriving (Show, Eq, Generic)
 instance NFData EventTriggerInfo

--- a/server/src-lib/Hasura/Server/Auth/JWT/Internal.hs
+++ b/server/src-lib/Hasura/Server/Auth/JWT/Internal.hs
@@ -7,8 +7,7 @@ import           Crypto.PubKey.RSA        (PublicKey (..))
 import           Data.ASN1.BinaryEncoding (DER (..))
 import           Data.ASN1.Encoding       (decodeASN1')
 import           Data.ASN1.Types          (ASN1 (End, IntVal, Start),
-                                           ASN1ConstructionType (Sequence),
-                                           fromASN1)
+                                           ASN1ConstructionType (Sequence), fromASN1)
 import           Data.Int                 (Int64)
 import           Data.Text.Conversions
 
@@ -82,13 +81,13 @@ fromX509Pem s = do
       pubKey = X509.certPubKey cert
   case pubKey of
     X509.PubKeyRSA pk -> return $ X509.PubKeyRSA pk
-    _ -> Left "Could not decode RSA public key from x509 cert"
+    _                 -> Left "Could not decode RSA public key from x509 cert"
 
 
 pubKeyToJwk :: X509.PubKey -> Either Text JWK
 pubKeyToJwk pubKey = do
   jwk' <- mkJwk
-  return $ jwk' & jwkKeyOps .~ Just [Verify]
+  return $ jwk' & jwkKeyOps ?~ [Verify]
   where
     mkJwk = case pubKey of
       X509.PubKeyRSA (PublicKey _ n e) ->

--- a/server/src-lib/Hasura/Server/Auth/WebHook.hs
+++ b/server/src-lib/Hasura/Server/Auth/WebHook.hs
@@ -87,7 +87,7 @@ userInfoFromAuthHook logger manager hook reqHeaders = do
       unLogger logger $
         WebHookLog LevelError Nothing (ahUrl hook) (hookMethod hook)
         (Just $ HttpException err) Nothing Nothing
-      throw500 $ "webhook authentication request failed"
+      throw500 "webhook authentication request failed"
 
 
 mkUserInfoFromResp

--- a/server/src-lib/Hasura/Server/Middleware.hs
+++ b/server/src-lib/Hasura/Server/Middleware.hs
@@ -4,6 +4,7 @@ import           Data.Maybe           (fromMaybe)
 import           Network.Wai
 
 import           Control.Applicative
+import           Control.Arrow        (first)
 import           Hasura.Prelude
 import           Hasura.Server.Cors
 import           Hasura.Server.Utils
@@ -65,4 +66,4 @@ corsMiddleware policy app req sendResp = do
       ]
 
     setHeaders hdrs = mapResponseHeaders (\h -> mkRespHdrs hdrs ++ h)
-    mkRespHdrs = map (\(k,v) -> (CI.mk k, v))
+    mkRespHdrs = map $ first CI.mk

--- a/server/src-lib/Hasura/Server/Telemetry.hs
+++ b/server/src-lib/Hasura/Server/Telemetry.hs
@@ -10,10 +10,10 @@ module Hasura.Server.Telemetry
   )
   where
 
-import           Control.Exception     (try)
+import           Control.Exception                (try)
 import           Control.Lens
 import           Data.List
-import           Data.Text.Conversions (UTF8 (..), decodeText)
+import           Data.Text.Conversions            (UTF8 (..), decodeText)
 
 import           Hasura.HTTP
 import           Hasura.Logging
@@ -24,17 +24,17 @@ import           Hasura.Server.Telemetry.Counters
 import           Hasura.Server.Version
 
 import qualified CI
-import qualified Control.Concurrent.Extended   as C
-import qualified Data.Aeson                    as A
-import qualified Data.Aeson.Casing             as A
-import qualified Data.Aeson.TH                 as A
-import qualified Data.ByteString.Lazy          as BL
-import qualified Data.HashMap.Strict           as Map
-import qualified Data.Text                     as T
-import qualified Network.HTTP.Client           as HTTP
-import qualified Network.HTTP.Types            as HTTP
-import qualified Network.Wreq                  as Wreq
-import qualified Language.GraphQL.Draft.Syntax as G
+import qualified Control.Concurrent.Extended      as C
+import qualified Data.Aeson                       as A
+import qualified Data.Aeson.Casing                as A
+import qualified Data.Aeson.TH                    as A
+import qualified Data.ByteString.Lazy             as BL
+import qualified Data.HashMap.Strict              as Map
+import qualified Data.Text                        as T
+import qualified Language.GraphQL.Draft.Syntax    as G
+import qualified Network.HTTP.Client              as HTTP
+import qualified Network.HTTP.Types               as HTTP
+import qualified Network.Wreq                     as Wreq
 
 data RelationshipMetric
   = RelationshipMetric
@@ -174,7 +174,7 @@ computeMetrics sc _mtServiceTimings _mtPgVersion =
     countUserTables predicate = length . filter predicate $ Map.elems userTables
 
     calcPerms :: (RolePermInfo -> Maybe a) -> [RolePermInfo] -> Int
-    calcPerms fn perms = length $ catMaybes $ map fn perms
+    calcPerms fn perms = length $ mapMaybe fn perms
 
     permsOfTbl :: TableInfo -> [(RoleName, RolePermInfo)]
     permsOfTbl = Map.toList . _tiRolePermInfoMap
@@ -189,7 +189,7 @@ computeActionsMetrics ac ao = ActionMetric syncActionsLen asyncActionsLen typeRe
         inputTypesLen = length . nub . concat . (map ((map _argType) . _adArguments . _aiDefinition)) $ actions
         customTypesLen = inputTypesLen + outputTypesLen
 
-        typeRelationships = length . nub . concat . map ((getActionTypeRelationshipNames ao) . _aiDefinition) $ actions
+        typeRelationships = length . nub . concatMap ((getActionTypeRelationshipNames ao) . _aiDefinition) $ actions
 
         -- gives the count of relationships associated with an action
         getActionTypeRelationshipNames :: AnnotatedObjects -> ResolvedActionDefinition -> [RelationshipName]

--- a/server/src-lib/Hasura/Server/Telemetry/Counters.hs
+++ b/server/src-lib/Hasura/Server/Telemetry/Counters.hs
@@ -29,7 +29,6 @@ import qualified Data.Aeson.Casing     as A
 import qualified Data.Aeson.TH         as A
 import qualified Data.HashMap.Strict   as HM
 
-import           Data.Hashable
 import           Data.IORef
 import           Data.Ord              (Down (..))
 import           Data.Time.Clock.POSIX (POSIXTime, getPOSIXTime)


### PR DESCRIPTION
### Description
This PR only applies minor changes, and creates a slightly better-than-default hlint config.

I was exploring the idea of automating some of our [style guide](https://github.com/hasura/graphql-engine/blob/master/server/STYLE.md), by either using stylish-haskell as a pre-commit hook, instrumenting hlint, or trying perhaps other formatters. Regard hlint in particular: while in the past it seems we used to enforce [strict hlint use](https://github.com/hasura/graphql-engine/blame/master/server/CONTRIBUTING.md#L178), the codebase currently has a lot of hlint warnings, a lot of which are false positive. Bluntly activating it would be a bad idea; however, we could choose to make a very selective use of it: disable almost all regular errors, and write our own custom rules.

What this PR does is a step towards that: create a hlint config which disables a lot of the false positive messages. Furthermore, it fixes most of the actually actionable suggestions, and applies changes to match the style guide on some of the file. I've only applied changes that I believe to be uncontroversial, and that should be deemed improvements even if we don't end up using hlint at all. 

### Affected components

- [ ] Server
