### PR TITLE
server: run stylish-haskell on all files

### DIFF
--- a/server/.stylish-haskell.yaml
+++ b/server/.stylish-haskell.yaml
@@ -15,9 +15,37 @@ steps:
   #     # true.
   #     add_language_pragma: true
 
+  # Format record definitions. This is disabled by default.
+  #
+  # You can control the layout of record fields. The only rules that can't be configured
+  # are these:
+  #
+  # - "|" is always aligned with "="
+  # - "," in fields is always aligned with "{"
+  # - "}" is likewise always aligned with "{"
+  #
+  # - records:
+  #     # How to format equals sign between type constructor and data constructor.
+  #     # Possible values:
+  #     # - "same_line" -- leave "=" AND data constructor on the same line as the type constructor.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of the next line.
+  #     equals: "indent 2"
+  #
+  #     # How to format first field of each record constructor.
+  #     # Possible values:
+  #     # - "same_line" -- "{" and first field goes on the same line as the data constructor.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of the data constructor
+  #     first_field: "indent 2"
+  #
+  #     # How many spaces to insert between the column with "," and the beginning of the comment in the next line.
+  #     field_comment: 2
+  #
+  #     # How many spaces to insert before "deriving" clause. Deriving clauses are always on separate lines.
+  #     deriving: 2
+
   # Align the right hand side of some elements.  This is quite conservative
   # and only applies to statements where each element occupies a single
-  # line.
+  # line. All default to true.
   - simple_align:
       cases: true
       top_level_patterns: true
@@ -55,6 +83,18 @@ steps:
       #
       #   > import qualified Data.List      as List (concat, foldl, foldr, head,
       #   >                                 init, last, length)
+      #
+      # - with_module_name: Import list is aligned `list_padding` spaces after
+      #   the module name.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #                          init, last, length)
+      #
+      #   This is mainly intended for use with `pad_module_names: false`.
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, head,
+      #                          init, last, length, scanl, scanr, take, drop,
+      #                          sort, nub)
       #
       # - new_line: Import list starts always on new line.
       #
@@ -126,6 +166,8 @@ steps:
       #
       # - module_name: align under start of module name.
       #   Useful for 'file' and 'group' align settings.
+      #
+      # Default: 4
       list_padding: 4
 
       # Separate lists option affects formatting of import list for type
@@ -189,11 +231,16 @@ steps:
       # is set to true, it will remove those redundant pragmas. Default: true.
       remove_redundant: true
 
+      # Language prefix to be used for pragma declaration, this allows you to
+      # use other options non case-sensitive like "language" or "Language".
+      # If a non correct String is provided, it will default to: LANGUAGE.
+      language_prefix: LANGUAGE
+
   # Replace tabs by spaces. This is disabled by default.
-  # - tabs:
-  #     # Number of spaces to use for each tab. Default: 8, as specified by the
-  #     # Haskell report.
-  #     spaces: 8
+  - tabs:
+      # Number of spaces to use for each tab. Default: 8, as specified by the
+      # Haskell report.
+      spaces: 8
 
   # Remove trailing whitespace
   - trailing_whitespace: {}
@@ -204,7 +251,11 @@ steps:
   # - squash: {}
 
 # A common setting is the number of columns (parts of) code will be wrapped
-# to. Different steps take this into account. Default: 80.
+# to. Different steps take this into account.
+#
+# Set this to null to disable all line wrapping.
+#
+# Default: 80.
 columns: 100
 
 # By default, line endings are converted according to the OS. You can override
@@ -217,7 +268,7 @@ columns: 100
 # - crlf: Convert to CRLF ("\r\n").
 #
 # Default: native.
-newline: native
+newline: lf
 
 # Sometimes, language extensions are specified in a cabal file or from the
 # command line instead of using language pragmas in the file. stylish-haskell
@@ -258,3 +309,9 @@ language_extensions:
 - TypeApplications
 - TypeFamilies
 - TypeOperators
+
+# Attempt to find the cabal file in ancestors of the current directory, and
+# parse options (currently only language extensions) from that.
+#
+# Default: true
+cabal: true

--- a/server/Setup.hs
+++ b/server/Setup.hs
@@ -1,2 +1,2 @@
-import Distribution.Simple
+import           Distribution.Simple
 main = defaultMain

--- a/server/src-lib/Data/Aeson/Extended.hs
+++ b/server/src-lib/Data/Aeson/Extended.hs
@@ -5,9 +5,9 @@ module Data.Aeson.Extended
 
 import           Hasura.Prelude
 
-import           Data.Aeson as J
-import qualified Data.Aeson.Text               as JT
-import qualified Data.Text.Lazy                as LT
+import           Data.Aeson      as J
+import qualified Data.Aeson.Text as JT
+import qualified Data.Text.Lazy  as LT
 
 encodeToStrictText :: (ToJSON a) => a -> Text
 encodeToStrictText = LT.toStrict . JT.encodeToLazyText

--- a/server/src-lib/Data/Parser/Expires.hs
+++ b/server/src-lib/Data/Parser/Expires.hs
@@ -5,7 +5,7 @@ module Data.Parser.Expires
 import           Control.Monad.Except
 import           Data.Text.Conversions
 import           Data.Time.Clock
-import           Data.Time.Format        (defaultTimeLocale, parseTimeM)
+import           Data.Time.Format      (defaultTimeLocale, parseTimeM)
 
 import           Hasura.Prelude
 

--- a/server/src-lib/Data/Text/Extended.hs
+++ b/server/src-lib/Data/Text/Extended.hs
@@ -8,7 +8,7 @@ module Data.Text.Extended
 
 import           Hasura.Prelude
 
-import           Data.Text as DT
+import           Data.Text      as DT
 
 squote :: DT.Text -> DT.Text
 squote t = DT.singleton '\'' <> t <> DT.singleton '\''

--- a/server/src-lib/Data/Time/Clock/Units.hs
+++ b/server/src-lib/Data/Time/Clock/Units.hs
@@ -25,21 +25,21 @@ You can also go the other way using the constructors rather than the selectors:
 0.5
 @
 
-NOTE: the 'Real' and 'Fractional' instances just essentially add or strip the unit label (as 
-above), so you can't use 'realToFrac' to convert between the units types here. Instead try 
+NOTE: the 'Real' and 'Fractional' instances just essentially add or strip the unit label (as
+above), so you can't use 'realToFrac' to convert between the units types here. Instead try
 'fromUnits' which is less of a foot-gun.
 
 The 'Read' instances for these types mirror the behavior of the 'RealFrac' instance wrt numeric
 literals for convenient serialization (e.g. when working with env vars):
 
 @
->>> read "1.2" :: Milliseconds 
+>>> read "1.2" :: Milliseconds
 Milliseconds {milliseconds = 0.0012s}
 @
 
 Generally, if you need to pass around a duration between functions you should use 'DiffTime'
 directly. However if storing a duration in a type that will be serialized, e.g. one having
-a 'ToJSON' instance, it is better to use one of these explicit wrapper types so that it's 
+a 'ToJSON' instance, it is better to use one of these explicit wrapper types so that it's
 obvious what units will be used. -}
 module Data.Time.Clock.Units
   ( Days(..)
@@ -149,7 +149,7 @@ instance (KnownNat picosPerUnit) => RealFrac (TimeUnit picosPerUnit) where
 
 -- we can ignore unit:
 instance Hashable (TimeUnit a) where
-  hashWithSalt salt (TimeUnit dt) = hashWithSalt salt $ 
+  hashWithSalt salt (TimeUnit dt) = hashWithSalt salt $
     (realToFrac :: DiffTime -> Double) dt
 
 

--- a/server/src-lib/Hasura/Cache/Bounded.hs
+++ b/server/src-lib/Hasura/Cache/Bounded.hs
@@ -36,7 +36,7 @@ mkCacheSize v =
   -- NOTE: naively using readMaybe Word16 will silently wrap
   case readMaybe v :: Maybe Natural of
     Just n | n <= max16 && n > 0 -> return (CacheSize $ fromIntegral n)
-    _ -> fail "cache size must be given as a number between 1 and 65535"
+    _                            -> fail "cache size must be given as a number between 1 and 65535"
   where
     max16 = fromIntegral (maxBound :: Word16) :: Natural
 

--- a/server/src-lib/Hasura/Events/Lib.hs
+++ b/server/src-lib/Hasura/Events/Lib.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE StrictData #-}  -- TODO project-wide, maybe. See #3941
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StrictData      #-}
 module Hasura.Events.Lib
   ( initEventEngineCtx
   , processEventQueue
@@ -9,16 +9,16 @@ module Hasura.Events.Lib
   , Event(..)
   ) where
 
-import           Control.Concurrent.Extended   (sleep)
-import           Control.Concurrent.Async      (wait, withAsync, async, link)
+import           Control.Concurrent.Async    (async, link, wait, withAsync)
+import           Control.Concurrent.Extended (sleep)
 import           Control.Concurrent.STM.TVar
-import           Control.Exception.Lifted      (finally, mask_, try)
+import           Control.Exception.Lifted    (finally, mask_, try)
 import           Control.Monad.STM
 import           Data.Aeson
 import           Data.Aeson.Casing
 import           Data.Aeson.TH
 import           Data.Has
-import           Data.Int                      (Int64)
+import           Data.Int                    (Int64)
 import           Data.String
 import           Data.Time.Clock
 import           Data.Word
@@ -27,22 +27,22 @@ import           Hasura.HTTP
 import           Hasura.Prelude
 import           Hasura.RQL.DDL.Headers
 import           Hasura.RQL.Types
-import           Hasura.Server.Version         (HasVersion)
+import           Hasura.Server.Version       (HasVersion)
 import           Hasura.SQL.Types
 
-import qualified Data.ByteString               as BS
-import qualified Data.CaseInsensitive          as CI
-import qualified Data.HashMap.Strict           as M
-import qualified Data.TByteString              as TBS
-import qualified Data.Text                     as T
-import qualified Data.Text.Encoding            as T
-import qualified Data.Text.Encoding            as TE
-import qualified Data.Text.Encoding.Error      as TE
-import qualified Data.Time.Clock               as Time
-import qualified Database.PG.Query             as Q
-import qualified Hasura.Logging                as L
-import qualified Network.HTTP.Client           as HTTP
-import qualified Network.HTTP.Types            as HTTP
+import qualified Data.ByteString             as BS
+import qualified Data.CaseInsensitive        as CI
+import qualified Data.HashMap.Strict         as M
+import qualified Data.TByteString            as TBS
+import qualified Data.Text                   as T
+import qualified Data.Text.Encoding          as T
+import qualified Data.Text.Encoding          as TE
+import qualified Data.Text.Encoding.Error    as TE
+import qualified Data.Time.Clock             as Time
+import qualified Database.PG.Query           as Q
+import qualified Hasura.Logging              as L
+import qualified Network.HTTP.Client         as HTTP
+import qualified Network.HTTP.Types          as HTTP
 
 type Version = T.Text
 
@@ -74,7 +74,7 @@ $(deriveJSON (aesonDrop 2 snakeCase){omitNothingFields=True} ''DeliveryInfo)
 
 -- | Change data for a particular row
 --
--- https://docs.hasura.io/1.0/graphql/manual/event-triggers/payload.html 
+-- https://docs.hasura.io/1.0/graphql/manual/event-triggers/payload.html
 data Event
   = Event
   { eId        :: EventId
@@ -153,8 +153,8 @@ data Invocation
 
 data EventEngineCtx
   = EventEngineCtx
-  { _eeCtxEventThreadsCapacity  :: TVar Int
-  , _eeCtxFetchInterval         :: DiffTime
+  { _eeCtxEventThreadsCapacity :: TVar Int
+  , _eeCtxFetchInterval        :: DiffTime
   }
 
 defaultMaxEventThreads :: Int
@@ -176,13 +176,13 @@ initEventEngineCtx maxT _eeCtxFetchInterval = do
 -- There are a few competing concerns and constraints here; we want to...
 --   - fetch events in batches for lower DB pressure
 --   - don't fetch more than N at a time (since that can mean: space leak, less
---     effective scale out, possible double sends for events we've checked out 
+--     effective scale out, possible double sends for events we've checked out
 --     on exit (TODO clean shutdown procedure))
 --   - try not to cause webhook workers to stall waiting on DB fetch
 --   - limit webhook HTTP concurrency per HASURA_GRAPHQL_EVENTS_HTTP_POOL_SIZE
 processEventQueue
   :: (HasVersion) => L.Logger L.Hasura -> LogEnvHeaders -> HTTP.Manager-> Q.PGPool
-  -> IO SchemaCache -> EventEngineCtx 
+  -> IO SchemaCache -> EventEngineCtx
   -> IO void
 processEventQueue logger logenv httpMgr pool getSchemaCache EventEngineCtx{..} = do
   events0 <- popEventsBatch
@@ -192,10 +192,10 @@ processEventQueue logger logenv httpMgr pool getSchemaCache EventEngineCtx{..} =
     popEventsBatch = do
       let run = runExceptT . Q.runTx pool (Q.RepeatableRead, Just Q.ReadWrite)
       run (fetchEvents fetchBatchSize) >>= \case
-          Left err -> do 
+          Left err -> do
             L.unLogger logger $ EventInternalErr err
             return []
-          Right events -> 
+          Right events ->
             return events
 
     -- work on this batch of events while prefetching the next. Recurse after we've forked workers
@@ -210,16 +210,16 @@ processEventQueue logger logenv httpMgr pool getSchemaCache EventEngineCtx{..} =
       -- worth the effort for something more fine-tuned
       eventsNext <- withAsync popEventsBatch $ \eventsNextA -> do
         -- process approximately in order, minding HASURA_GRAPHQL_EVENTS_HTTP_POOL_SIZE:
-        forM_ events $ \event -> 
+        forM_ events $ \event ->
           mask_ $ do
             atomically $ do  -- block until < HASURA_GRAPHQL_EVENTS_HTTP_POOL_SIZE threads:
               capacity <- readTVar _eeCtxEventThreadsCapacity
               check $ capacity > 0
-              writeTVar _eeCtxEventThreadsCapacity $! (capacity - 1) 
+              writeTVar _eeCtxEventThreadsCapacity $! (capacity - 1)
             -- since there is some capacity in our worker threads, we can launch another:
-            let restoreCapacity = liftIO $ atomically $ 
+            let restoreCapacity = liftIO $ atomically $
                   modifyTVar' _eeCtxEventThreadsCapacity (+ 1)
-            t <- async $ flip runReaderT (logger, httpMgr) $ 
+            t <- async $ flip runReaderT (logger, httpMgr) $
                     processEvent event `finally` restoreCapacity
             link t
 
@@ -228,7 +228,7 @@ processEventQueue logger logenv httpMgr pool getSchemaCache EventEngineCtx{..} =
 
       let lenEvents = length events
       if | lenEvents == fetchBatchSize -> do
-             -- If we've seen N fetches in a row from the DB come back full (i.e. only limited 
+             -- If we've seen N fetches in a row from the DB come back full (i.e. only limited
              -- by our LIMIT clause), then we say we're clearly falling behind:
              let clearlyBehind = fullFetchCount >= 3
              unless alreadyWarned $

--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Options.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Options.hs
@@ -7,7 +7,7 @@ module Hasura.GraphQL.Execute.LiveQuery.Options
 
 import           Hasura.Prelude
 
-import qualified Data.Aeson            as J
+import qualified Data.Aeson     as J
 
 data LiveQueriesOptions
   = LiveQueriesOptions
@@ -30,7 +30,7 @@ instance J.ToJSON LiveQueriesOptions where
 newtype BatchSize = BatchSize { unBatchSize :: Int }
   deriving (Show, Eq, J.ToJSON)
 
--- TODO this is treated as milliseconds in fromEnv and as seconds in ToJSON. 
+-- TODO this is treated as milliseconds in fromEnv and as seconds in ToJSON.
 --      ideally this would have e.g. ... unRefetchInterval :: Milliseconds
 newtype RefetchInterval = RefetchInterval { unRefetchInterval :: DiffTime }
   deriving (Show, Eq, J.ToJSON)

--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Poll.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Poll.hs
@@ -146,7 +146,7 @@ mkRespHash = ResponseHash . CH.hash
 -- 'CohortId'; the latter is a completely synthetic key used only to identify the cohort in the
 -- generated SQL query.
 type CohortKey = CohortVariables
--- | This has the invariant, maintained in 'removeLiveQuery', that it contains no 'Cohort' with 
+-- | This has the invariant, maintained in 'removeLiveQuery', that it contains no 'Cohort' with
 -- zero total (existing + new) subscribers.
 type CohortMap = TMap.TMap CohortKey Cohort
 
@@ -234,7 +234,7 @@ data Poller
 data PollerIOState
   = PollerIOState
   { _pThread  :: !(Immortal.Thread)
-  -- ^ a handle on the poller’s worker thread that can be used to 'Immortal.stop' it if all its 
+  -- ^ a handle on the poller’s worker thread that can be used to 'Immortal.stop' it if all its
   -- cohorts stop listening
   , _pMetrics :: !RefetchMetrics
   }
@@ -330,7 +330,7 @@ pollQuery metrics batchSize pgExecCtx pgQuery handler =
       return (cohortSnapshotMap, queryVarsBatches)
 
     flip A.mapConcurrently_ queryVarsBatches $ \queryVars -> do
-      (dt, mxRes) <- timing _rmQuery $ 
+      (dt, mxRes) <- timing _rmQuery $
         runExceptT $ runLazyTx' pgExecCtx $ executeMultiplexedQuery pgQuery queryVars
       let lqMeta = LiveQueryMetadata $ fromUnits dt
           operations = getCohortOperations cohortSnapshotMap lqMeta mxRes

--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/State.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/State.hs
@@ -18,13 +18,13 @@ import qualified Control.Immortal                         as Immortal
 import qualified Data.Aeson.Extended                      as J
 import qualified StmContainers.Map                        as STMMap
 
-import           Control.Concurrent.Extended              (sleep, forkImmortal)
+import           Control.Concurrent.Extended              (forkImmortal, sleep)
 import           Control.Exception                        (mask_)
 import           Data.String
 import           GHC.AssertNF
 
-import qualified Hasura.Logging                           as L
 import qualified Hasura.GraphQL.Execute.LiveQuery.TMap    as TMap
+import qualified Hasura.Logging                           as L
 
 import           Hasura.Db
 import           Hasura.GraphQL.Execute.LiveQuery.Options
@@ -33,7 +33,7 @@ import           Hasura.GraphQL.Execute.LiveQuery.Poll
 
 -- | The top-level datatype that holds the state for all active live queries.
 --
--- NOTE!: This must be kept consistent with a websocket connection's 'OperationMap', in 'onClose' 
+-- NOTE!: This must be kept consistent with a websocket connection's 'OperationMap', in 'onClose'
 -- and 'onStart'.
 data LiveQueriesState
   = LiveQueriesState

--- a/server/src-lib/Hasura/GraphQL/Transport/HTTP/Protocol.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/HTTP/Protocol.hs
@@ -74,14 +74,14 @@ data GQLBatchedReqs a
   = GQLSingleRequest (GQLReq a)
   | GQLBatchedReqs [GQLReq a]
   deriving (Show, Eq, Generic)
-  
+
 instance J.ToJSON a => J.ToJSON (GQLBatchedReqs a) where
   toJSON (GQLSingleRequest q) = J.toJSON q
-  toJSON (GQLBatchedReqs qs) = J.toJSON qs
+  toJSON (GQLBatchedReqs qs)  = J.toJSON qs
 
 instance J.FromJSON a => J.FromJSON (GQLBatchedReqs a) where
   parseJSON arr@J.Array{} = GQLBatchedReqs <$> J.parseJSON arr
-  parseJSON other = GQLSingleRequest <$> J.parseJSON other
+  parseJSON other         = GQLSingleRequest <$> J.parseJSON other
 
 newtype GQLQueryText
   = GQLQueryText

--- a/server/src-lib/Hasura/GraphQL/Transport/WebSocket/Server.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/WebSocket/Server.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE NondecreasingIndentation #-}
+{-# LANGUAGE RankNTypes               #-}
 
 module Hasura.GraphQL.Transport.WebSocket.Server
   ( WSId(..)
@@ -39,9 +39,9 @@ import qualified Data.TByteString                     as TBS
 import qualified Data.UUID                            as UUID
 import qualified Data.UUID.V4                         as UUID
 import           Data.Word                            (Word16)
+import           GHC.AssertNF
 import           GHC.Int                              (Int64)
 import           Hasura.Prelude
-import           GHC.AssertNF
 import qualified ListT
 import qualified Network.WebSockets                   as WS
 import qualified StmContainers.Map                    as STMMap
@@ -234,13 +234,13 @@ createServerApp (WSServer logger@(L.Logger writeLog) serverStatus) wsHandlers !p
       onReject wsId shuttingDownReject
 
   where
-    -- It's not clear what the unexpected exception handling story here should be. So at 
+    -- It's not clear what the unexpected exception handling story here should be. So at
     -- least log properly and re-raise:
     logUnexpectedExceptions = handle $ \(e :: SomeException) -> do
       writeLog $ L.UnstructuredLog L.LevelError $ fromString $
         "Unexpected exception raised in websocket. Please report this as a bug: "<>show e
       throwIO e
-      
+
     shuttingDownReject =
       WS.RejectRequest 503
                         "Service Unavailable"
@@ -272,7 +272,7 @@ createServerApp (WSServer logger@(L.Logger writeLog) serverStatus) wsHandlers !p
 
       -- ensure we clean up connMap even if an unexpected exception is raised from our worker
       -- threads, or an async exception is raised somewhere in the body here:
-      bracket 
+      bracket
         whenAcceptingInsertConn
         (onConnClose wsConn)
         $ \case

--- a/server/src-lib/Hasura/GraphQL/Validate/Field.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate/Field.hs
@@ -144,7 +144,7 @@ withDirectives dirs act = do
       when (isJust $ _aivVariable val) markNotReusable
       case _aivValue val of
         AGScalar _ (Just (PGValBoolean v)) -> return v
-        _ -> throw500 "did not find boolean scalar for if argument"
+        _                                  -> throw500 "did not find boolean scalar for if argument"
 
 denormSel
   :: ( MonadReader ValidationCtx m

--- a/server/src-lib/Hasura/GraphQL/Validate/Types.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate/Types.hs
@@ -510,8 +510,8 @@ validateUnion tyMap (UnionTyInfo _ un mt) = do
   where
     valIsObjTy mn = case Map.lookup mn tyMap of
       Just (TIObj t) -> return t
-      Nothing -> throwError $ "Could not find type " <> showNamedTy mn <> ", which is defined as a member type of Union " <> showNamedTy un
-      _ -> throwError $ "Union type " <> showNamedTy un <> " can only include object types. It cannot include " <> showNamedTy mn
+      Nothing        -> throwError $ "Could not find type " <> showNamedTy mn <> ", which is defined as a member type of Union " <> showNamedTy un
+      _              -> throwError $ "Union type " <> showNamedTy un <> " can only include object types. It cannot include " <> showNamedTy mn
 
 implmntsIFace :: TypeMap -> ObjTyInfo -> IFaceTyInfo -> Either Text ()
 implmntsIFace tyMap objTyInfo iFaceTyInfo = do

--- a/server/src-lib/Hasura/Incremental/Internal/Dependency.hs
+++ b/server/src-lib/Hasura/Incremental/Internal/Dependency.hs
@@ -7,9 +7,9 @@ module Hasura.Incremental.Internal.Dependency where
 import           Hasura.Prelude
 
 import qualified Data.Dependent.Map            as DM
+import qualified Data.URL.Template             as UT
 import qualified Language.GraphQL.Draft.Syntax as G
 import qualified Network.URI.Extended          as N
-import qualified Data.URL.Template             as UT
 
 import           Control.Applicative
 import           Data.Aeson                    (Value)

--- a/server/src-lib/Hasura/RQL/DDL/Permission.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Permission.hs
@@ -202,7 +202,7 @@ data UpdPerm
   { ucColumns :: !PermColSpec -- Allowed columns
   , ucSet     :: !(Maybe (ColumnValues Value)) -- Preset columns
   , ucFilter  :: !BoolExp     -- Filter expression (applied before update)
-  , ucCheck   :: !(Maybe BoolExp)     
+  , ucCheck   :: !(Maybe BoolExp)
   -- ^ Check expression, which must be true after update.
   -- This is optional because we don't want to break the v1 API
   -- but Nothing should be equivalent to the expression which always
@@ -224,7 +224,7 @@ buildUpdPermInfo
 buildUpdPermInfo tn fieldInfoMap (UpdPerm colSpec set fltr check) = do
   (be, beDeps) <- withPathK "filter" $
     procBoolExp tn fieldInfoMap fltr
-    
+
   checkExpr <- traverse (withPathK "check" . procBoolExp tn fieldInfoMap) check
 
   (setColsSQL, setHeaders, setColDeps) <- procSetObj tn fieldInfoMap set
@@ -333,7 +333,7 @@ setPermCommentTx (SetPermComment (QualifiedObject sn tn) rn pt comment) =
                 |] (comment, sn, tn, rn, permTypeToCode pt) True
 
 purgePerm :: MonadTx m => QualifiedTable -> RoleName -> PermType -> m ()
-purgePerm qt rn pt = 
+purgePerm qt rn pt =
     case pt of
       PTInsert -> dropPermP2 @InsPerm dp
       PTSelect -> dropPermP2 @SelPerm dp

--- a/server/src-lib/Hasura/RQL/DDL/Schema/Cache/Common.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Cache/Common.hs
@@ -68,8 +68,8 @@ $(makeLenses ''BuildOutputs)
 data RebuildableSchemaCache m
   = RebuildableSchemaCache
   { lastBuiltSchemaCache :: !SchemaCache
-  , _rscInvalidationMap :: !InvalidationKeys
-  , _rscRebuild :: !(Inc.Rule (ReaderT BuildReason m) (CatalogMetadata, InvalidationKeys) SchemaCache)
+  , _rscInvalidationMap  :: !InvalidationKeys
+  , _rscRebuild          :: !(Inc.Rule (ReaderT BuildReason m) (CatalogMetadata, InvalidationKeys) SchemaCache)
   }
 $(makeLenses ''RebuildableSchemaCache)
 

--- a/server/src-lib/Hasura/RQL/DDL/Schema/Table.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Table.hs
@@ -36,8 +36,8 @@ import           Hasura.Server.Utils
 import           Hasura.SQL.Types
 
 import qualified Database.PG.Query                  as Q
-import qualified Hasura.GraphQL.Schema              as GS
 import qualified Hasura.GraphQL.Context             as GC
+import qualified Hasura.GraphQL.Schema              as GS
 import qualified Hasura.Incremental                 as Inc
 import qualified Language.GraphQL.Draft.Syntax      as G
 

--- a/server/src-lib/Hasura/RQL/Types/Common.hs
+++ b/server/src-lib/Hasura/RQL/Types/Common.hs
@@ -44,7 +44,7 @@ import           Data.Aeson
 import           Data.Aeson.Casing
 import           Data.Aeson.TH
 import           Instances.TH.Lift             ()
-import           Language.Haskell.TH.Syntax    (Q, TExp, Lift)
+import           Language.Haskell.TH.Syntax    (Lift, Q, TExp)
 
 import qualified Data.HashMap.Strict           as HM
 import qualified Data.Text                     as T

--- a/server/src-lib/Hasura/RQL/Types/EventTrigger.hs
+++ b/server/src-lib/Hasura/RQL/Types/EventTrigger.hs
@@ -166,9 +166,9 @@ instance FromJSON CreateEventTriggerQuery where
     where
       checkEmptyCols spec
         = case spec of
-        Just (SubscribeOpSpec (SubCArray cols) _) -> when (null cols) (fail "found empty column specification")
+        Just (SubscribeOpSpec (SubCArray cols) _)         -> when (null cols) (fail "found empty column specification")
         Just (SubscribeOpSpec _ (Just (SubCArray cols)) ) -> when (null cols) (fail "found empty payload specification")
-        _ -> return ()
+        _                                                 -> return ()
   parseJSON _ = fail "expecting an object"
 
 $(deriveToJSON (aesonDrop 4 snakeCase){omitNothingFields=True} ''CreateEventTriggerQuery)

--- a/server/src-lib/Hasura/RQL/Types/Table.hs
+++ b/server/src-lib/Hasura/RQL/Types/Table.hs
@@ -279,12 +279,12 @@ data EventTriggerInfo
    , etiOpsDef      :: !TriggerOpsDef
    , etiRetryConf   :: !RetryConf
    , etiWebhookInfo :: !WebhookConfInfo
-   -- ^ The HTTP(s) URL which will be called with the event payload on configured operation. 
-   -- Must be a POST handler. This URL can be entered manually or can be picked up from an 
-   -- environment variable (the environment variable needs to be set before using it for 
-   -- this configuration). 
+   -- ^ The HTTP(s) URL which will be called with the event payload on configured operation.
+   -- Must be a POST handler. This URL can be entered manually or can be picked up from an
+   -- environment variable (the environment variable needs to be set before using it for
+   -- this configuration).
    , etiHeaders     :: ![EventHeaderInfo]
-   -- ^ Custom headers can be added to an event trigger. Each webhook request will have these 
+   -- ^ Custom headers can be added to an event trigger. Each webhook request will have these
    -- headers added.
    } deriving (Show, Eq, Generic)
 instance NFData EventTriggerInfo

--- a/server/src-lib/Hasura/Server/Auth/JWT/Internal.hs
+++ b/server/src-lib/Hasura/Server/Auth/JWT/Internal.hs
@@ -7,8 +7,7 @@ import           Crypto.PubKey.RSA        (PublicKey (..))
 import           Data.ASN1.BinaryEncoding (DER (..))
 import           Data.ASN1.Encoding       (decodeASN1')
 import           Data.ASN1.Types          (ASN1 (End, IntVal, Start),
-                                           ASN1ConstructionType (Sequence),
-                                           fromASN1)
+                                           ASN1ConstructionType (Sequence), fromASN1)
 import           Data.Int                 (Int64)
 import           Data.Text.Conversions
 
@@ -82,7 +81,7 @@ fromX509Pem s = do
       pubKey = X509.certPubKey cert
   case pubKey of
     X509.PubKeyRSA pk -> return $ X509.PubKeyRSA pk
-    _ -> Left "Could not decode RSA public key from x509 cert"
+    _                 -> Left "Could not decode RSA public key from x509 cert"
 
 
 pubKeyToJwk :: X509.PubKey -> Either Text JWK

--- a/server/src-lib/Hasura/Server/CheckUpdates.hs
+++ b/server/src-lib/Hasura/Server/CheckUpdates.hs
@@ -2,10 +2,10 @@ module Hasura.Server.CheckUpdates
   ( checkForUpdates
   ) where
 
-import           Control.Exception     (try)
+import           Control.Exception           (try)
 import           Control.Lens
-import           Control.Monad         (forever)
-import           Data.Text.Conversions (toText)
+import           Control.Monad               (forever)
+import           Data.Text.Conversions       (toText)
 
 import qualified CI
 import qualified Control.Concurrent.Extended as C
@@ -19,9 +19,9 @@ import qualified Network.Wreq                as Wreq
 import qualified System.Log.FastLogger       as FL
 
 import           Hasura.HTTP
-import           Hasura.Logging        (LoggerCtx (..))
+import           Hasura.Logging              (LoggerCtx (..))
 import           Hasura.Prelude
-import           Hasura.Server.Version (HasVersion, Version, currentVersion)
+import           Hasura.Server.Version       (HasVersion, Version, currentVersion)
 
 
 newtype UpdateInfo

--- a/server/src-lib/Hasura/Server/Init.hs
+++ b/server/src-lib/Hasura/Server/Init.hs
@@ -491,7 +491,7 @@ serveCmdFooter =
         , "Max event threads"
         )
       , ( "HASURA_GRAPHQL_EVENTS_FETCH_INTERVAL"
-        , "Interval in milliseconds to sleep before trying to fetch events again after a " 
+        , "Interval in milliseconds to sleep before trying to fetch events again after a "
           <> "fetch returned no events from postgres."
         )
       ]
@@ -809,7 +809,7 @@ readAPIs = mapM readAPI . T.splitOn "," . T.pack
           "PGDUMP"    -> Right PGDUMP
           "DEVELOPER" -> Right DEVELOPER
           "CONFIG"    -> Right CONFIG
-          _            -> Left "Only expecting list of comma separated API types metadata,graphql,pgdump,developer,config"
+          _           -> Left "Only expecting list of comma separated API types metadata,graphql,pgdump,developer,config"
 
 readLogLevel :: String -> Either String L.LogLevel
 readLogLevel s = case T.toLower $ T.strip $ T.pack s of
@@ -1090,17 +1090,17 @@ serveOptionsParser =
 -- | This implements the mapping between application versions
 -- and catalog schema versions.
 downgradeShortcuts :: [(String, String)]
-downgradeShortcuts = 
+downgradeShortcuts =
   $(do let s = $(embedStringFile "src-rsr/catalog_versions.txt")
-          
+
            parseVersions = map (parseVersion . words) . lines
-     
+
            parseVersion [tag, version] = (tag, version)
-           parseVersion other = error ("unrecognized tag/catalog mapping " ++ show other)
-       TH.lift (parseVersions s))     
+           parseVersion other          = error ("unrecognized tag/catalog mapping " ++ show other)
+       TH.lift (parseVersions s))
 
 downgradeOptionsParser :: Parser DowngradeOptions
-downgradeOptionsParser = 
+downgradeOptionsParser =
     DowngradeOptions
     <$> choice
         (strOption
@@ -1115,7 +1115,7 @@ downgradeOptionsParser =
           help "Don't run any migrations, just print out the SQL."
         )
   where
-    shortcut v catalogVersion = 
+    shortcut v catalogVersion =
       flag' (DataString.fromString catalogVersion)
         ( long ("to-" <> v) <>
           help ("Downgrade to graphql-engine version " <> v <> " (equivalent to --to-catalog-version " <> catalogVersion <> ")")

--- a/server/src-lib/Hasura/Server/Migrate.hs
+++ b/server/src-lib/Hasura/Server/Migrate.hs
@@ -41,8 +41,8 @@ import           Data.Time.Clock               (UTCTime)
 import           Hasura.Logging                (Hasura, LogLevel (..), ToEngineLog (..))
 import           Hasura.RQL.DDL.Relationship
 import           Hasura.RQL.DDL.Schema
-import           Hasura.Server.Init            (DowngradeOptions (..))
 import           Hasura.RQL.Types
+import           Hasura.Server.Init            (DowngradeOptions (..))
 import           Hasura.Server.Logging         (StartupLog (..))
 import           Hasura.Server.Migrate.Version (latestCatalogVersion, latestCatalogVersionString)
 import           Hasura.Server.Version         (HasVersion)
@@ -77,11 +77,11 @@ instance ToEngineLog MigrationResult Hasura where
     }
 
 -- A migration and (hopefully) also its inverse if we have it.
--- Polymorphic because `m` can be any `MonadTx`, `MonadIO` when 
+-- Polymorphic because `m` can be any `MonadTx`, `MonadIO` when
 -- used in the `migrations` function below.
 data MigrationPair m = MigrationPair
   { mpMigrate :: m ()
-  , mpDown :: Maybe (m ())
+  , mpDown    :: Maybe (m ())
   }
 
 migrateCatalog
@@ -159,12 +159,12 @@ migrateCatalog migrationTime = do
           pure (MRMigrated previousVersion, schemaCache)
       where
         neededMigrations = dropWhile ((/= previousVersion) . fst) (migrations False)
-        
+
     buildCacheAndRecreateSystemMetadata :: m (RebuildableSchemaCache m)
     buildCacheAndRecreateSystemMetadata = do
       schemaCache <- buildRebuildableSchemaCache
       view _2 <$> runCacheRWT schemaCache recreateSystemMetadata
-      
+
     updateCatalogVersion = setCatalogVersion latestCatalogVersionString migrationTime
 
     doesSchemaExist schemaName =
@@ -197,29 +197,29 @@ downgradeCatalog opts time = do
     downgradeFrom previousVersion
         | previousVersion == dgoTargetVersion opts = do
             pure MRNothingToDo
-        | otherwise = 
+        | otherwise =
             case neededDownMigrations (dgoTargetVersion opts) of
-              Left reason -> 
+              Left reason ->
                 throw400 NotSupported $
                   "This downgrade path (from "
-                    <> previousVersion <> " to " 
-                    <> dgoTargetVersion opts <> 
+                    <> previousVersion <> " to "
+                    <> dgoTargetVersion opts <>
                     ") is not supported, because "
                     <> reason
               Right path -> do
-                sequence_ path 
+                sequence_ path
                 unless (dgoDryRun opts) do
                   setCatalogVersion (dgoTargetVersion opts) time
                 pure (MRMigrated previousVersion)
-      
+
       where
-        neededDownMigrations newVersion = 
-          downgrade previousVersion newVersion 
+        neededDownMigrations newVersion =
+          downgrade previousVersion newVersion
             (reverse (migrations (dgoDryRun opts)))
 
-        downgrade 
+        downgrade
           :: T.Text
-          -> T.Text 
+          -> T.Text
           -> [(T.Text, MigrationPair m)]
           -> Either T.Text [m ()]
         downgrade lower upper = skipFutureDowngrades where
@@ -237,7 +237,7 @@ downgradeCatalog opts time = do
             | otherwise = skipFutureDowngrades xs
 
           dropOlderDowngrades [] = Left "the target version is unrecognized."
-          dropOlderDowngrades ((x, MigrationPair{ mpDown = Nothing }):_) = 
+          dropOlderDowngrades ((x, MigrationPair{ mpDown = Nothing }):_) =
             Left $ "there is no available migration back to version " <> x <> "."
           dropOlderDowngrades ((x, MigrationPair{ mpDown = Just y }):xs)
             | x == upper = Right [y]
@@ -271,7 +271,7 @@ migrations dryRun =
             if exists
               then [| Just (runTxOrPrint $(Q.sqlFromFile path)) |]
               else [| Nothing |]
-                 
+
           migrationsFromFile = map $ \(to :: Integer) ->
             let from = to - 1
             in [| ( $(TH.lift $ T.pack (show from))
@@ -288,7 +288,7 @@ migrations dryRun =
   where
     runTxOrPrint :: Q.Query -> m ()
     runTxOrPrint
-      | dryRun = 
+      | dryRun =
           liftIO . TIO.putStrLn . Q.getQueryText
       | otherwise = runTx
 

--- a/server/src-lib/Hasura/Server/Migrate/Version.hs
+++ b/server/src-lib/Hasura/Server/Migrate/Version.hs
@@ -16,11 +16,11 @@ import           Data.FileEmbed             (embedStringFile)
 
 -- | The current catalog schema version. We store this in a file
 -- because we want to append the current verson to the catalog_versions file
--- when tagging a new release, in @tag-release.sh@. 
+-- when tagging a new release, in @tag-release.sh@.
 latestCatalogVersion :: Integer
-latestCatalogVersion = 
+latestCatalogVersion =
   $(do let s = $(embedStringFile "src-rsr/catalog_version.txt")
-       TH.lift (read s :: Integer)) 
+       TH.lift (read s :: Integer))
 
 latestCatalogVersionString :: T.Text
 latestCatalogVersionString = T.pack $ show latestCatalogVersion

--- a/server/src-lib/Hasura/Server/PGDump.hs
+++ b/server/src-lib/Hasura/Server/PGDump.hs
@@ -3,20 +3,20 @@ module Hasura.Server.PGDump
   , execPGDump
   ) where
 
-import           Control.Exception       (IOException, try)
+import           Control.Exception      (IOException, try)
 import           Data.Aeson.Casing
 import           Data.Aeson.TH
-import qualified Data.ByteString.Lazy    as BL
-import           Data.Char               (isSpace)
-import qualified Data.List               as L
-import qualified Data.Text               as T
+import qualified Data.ByteString.Lazy   as BL
+import           Data.Char              (isSpace)
+import qualified Data.List              as L
+import qualified Data.Text              as T
 import           Data.Text.Conversions
-import qualified Database.PG.Query       as Q
+import qualified Database.PG.Query      as Q
 import           Hasura.Prelude
-import qualified Hasura.RQL.Types.Error  as RTE
+import qualified Hasura.RQL.Types.Error as RTE
 import           System.Exit
 import           System.Process
-import qualified Text.Regex.TDFA         as TDFA
+import qualified Text.Regex.TDFA        as TDFA
 
 data PGDumpReqBody =
   PGDumpReqBody

--- a/server/src-lib/Hasura/Server/Query.hs
+++ b/server/src-lib/Hasura/Server/Query.hs
@@ -291,11 +291,11 @@ getQueryAccessMode q = (fromMaybe Q.ReadOnly) <$> getQueryAccessMode' q
          (MonadError QErr m) => RQLQuery -> m (Maybe Q.TxAccess)
     getQueryAccessMode' (RQV1 q') =
       case q' of
-        RQSelect _ -> pure Nothing
-        RQCount _ -> pure Nothing
+        RQSelect _                      -> pure Nothing
+        RQCount _                       -> pure Nothing
         RQRunSql RunSQL {rTxAccessMode} -> pure $ Just rTxAccessMode
-        RQBulk qs -> foldM reconcileAccessModeWith Nothing (zip [0 :: Integer ..] qs)
-        _ -> pure $ Just Q.ReadWrite
+        RQBulk qs                       -> foldM reconcileAccessModeWith Nothing (zip [0 :: Integer ..] qs)
+        _                               -> pure $ Just Q.ReadWrite
       where
         reconcileAccessModeWith expectedMode (i, query) = do
           queryMode <- getQueryAccessMode' query

--- a/server/src-lib/Hasura/Server/SchemaUpdate.hs
+++ b/server/src-lib/Hasura/Server/SchemaUpdate.hs
@@ -5,11 +5,11 @@ where
 import           Hasura.Prelude
 
 import           Hasura.Logging
-import           Hasura.RQL.DDL.Schema     (runCacheRWT)
+import           Hasura.RQL.DDL.Schema       (runCacheRWT)
 import           Hasura.RQL.Types
 import           Hasura.RQL.Types.Run
-import           Hasura.Server.App         (SchemaCacheRef (..), withSCUpdate)
-import           Hasura.Server.Init        (InstanceId (..))
+import           Hasura.Server.App           (SchemaCacheRef (..), withSCUpdate)
+import           Hasura.Server.Init          (InstanceId (..))
 import           Hasura.Server.Logging
 import           Hasura.Server.Query
 
@@ -93,7 +93,7 @@ startSchemaSyncThreads sqlGenCtx pool logger httpMgr cacheRef instanceId cacheIn
   updateEventRef <- liftIO $ STM.newTVarIO Nothing
 
   -- Start listener thread
-  lTId <- liftIO $ C.forkImmortal "SchemeUpdate.listener" logger $ 
+  lTId <- liftIO $ C.forkImmortal "SchemeUpdate.listener" logger $
     listener sqlGenCtx pool logger httpMgr updateEventRef cacheRef instanceId cacheInitTime
   logThreadStarted TTListener lTId
 
@@ -165,7 +165,7 @@ listener sqlGenCtx pool logger httpMgr updateEventRef
             STM.atomically $ STM.writeTVar updateEventRef $ Just payload
 
     onError = logError logger threadType . TEQueryError
-    -- NOTE: we handle expected error conditions here, while unexpected exceptions will result in 
+    -- NOTE: we handle expected error conditions here, while unexpected exceptions will result in
     -- a restart and log from 'forkImmortal'
     logWarn = unLogger logger $
       SchemaSyncThreadLog LevelWarn TTListener $ String

--- a/server/src-lib/Hasura/Server/Telemetry.hs
+++ b/server/src-lib/Hasura/Server/Telemetry.hs
@@ -10,10 +10,10 @@ module Hasura.Server.Telemetry
   )
   where
 
-import           Control.Exception     (try)
+import           Control.Exception                (try)
 import           Control.Lens
 import           Data.List
-import           Data.Text.Conversions (UTF8 (..), decodeText)
+import           Data.Text.Conversions            (UTF8 (..), decodeText)
 
 import           Hasura.HTTP
 import           Hasura.Logging
@@ -24,17 +24,17 @@ import           Hasura.Server.Telemetry.Counters
 import           Hasura.Server.Version
 
 import qualified CI
-import qualified Control.Concurrent.Extended   as C
-import qualified Data.Aeson                    as A
-import qualified Data.Aeson.Casing             as A
-import qualified Data.Aeson.TH                 as A
-import qualified Data.ByteString.Lazy          as BL
-import qualified Data.HashMap.Strict           as Map
-import qualified Data.Text                     as T
-import qualified Network.HTTP.Client           as HTTP
-import qualified Network.HTTP.Types            as HTTP
-import qualified Network.Wreq                  as Wreq
-import qualified Language.GraphQL.Draft.Syntax as G
+import qualified Control.Concurrent.Extended      as C
+import qualified Data.Aeson                       as A
+import qualified Data.Aeson.Casing                as A
+import qualified Data.Aeson.TH                    as A
+import qualified Data.ByteString.Lazy             as BL
+import qualified Data.HashMap.Strict              as Map
+import qualified Data.Text                        as T
+import qualified Language.GraphQL.Draft.Syntax    as G
+import qualified Network.HTTP.Client              as HTTP
+import qualified Network.HTTP.Types               as HTTP
+import qualified Network.Wreq                     as Wreq
 
 data RelationshipMetric
   = RelationshipMetric

--- a/server/src-lib/Hasura/Server/Telemetry/Counters.hs
+++ b/server/src-lib/Hasura/Server/Telemetry/Counters.hs
@@ -148,24 +148,24 @@ recordTimingMetric reqDimensions RequestTimings{..} = liftIO $ do
 -- | The final shape of this part of our metrics data JSON. This should allow
 -- reasonably efficient querying using GIN indexes and JSONB containment
 -- operations (which treat arrays as sets).
-data ServiceTimingMetrics 
+data ServiceTimingMetrics
   = ServiceTimingMetrics
   { collectionTag        :: Int
     -- ^ This is set to a new unique value when the counters reset (e.g. because of a restart)
   , serviceTimingMetrics :: [ServiceTimingMetric]
-  } 
+  }
   deriving (Show, Generic, Eq)
-data ServiceTimingMetric 
+data ServiceTimingMetric
   = ServiceTimingMetric
   { dimensions :: RequestDimensions
-  , bucket   :: RunningTimeBucket
-  , metrics  :: RequestTimingsCount
+  , bucket     :: RunningTimeBucket
+  , metrics    :: RequestTimingsCount
   }
   deriving (Show, Generic, Eq)
 
 
-$(A.deriveJSON (A.aesonDrop 5 A.snakeCase) ''RequestTimingsCount) 
-$(A.deriveJSON (A.aesonDrop 5 A.snakeCase) ''RequestDimensions) 
+$(A.deriveJSON (A.aesonDrop 5 A.snakeCase) ''RequestTimingsCount)
+$(A.deriveJSON (A.aesonDrop 5 A.snakeCase) ''RequestDimensions)
 
 instance A.ToJSON ServiceTimingMetric
 instance A.FromJSON ServiceTimingMetric

--- a/server/src-test/Data/TimeSpec.hs
+++ b/server/src-test/Data/TimeSpec.hs
@@ -1,11 +1,11 @@
 module Data.TimeSpec (spec) where
 -- | Time-related properties we care about.
 
-import Prelude
-import Data.Time.Clock.Units
-import Data.Time
-import Data.Aeson
-import Test.Hspec
+import           Data.Aeson
+import           Data.Time
+import           Data.Time.Clock.Units
+import           Prelude
+import           Test.Hspec
 
 spec :: Spec
 spec = do

--- a/server/src-test/Hasura/Server/MigrateSpec.hs
+++ b/server/src-test/Hasura/Server/MigrateSpec.hs
@@ -68,7 +68,7 @@ spec
 spec pgConnInfo = do
   let dropAndInit time = CacheRefT $ flip modifyMVar \_ ->
         dropCatalog *> (swap <$> migrateCatalog time)
-      
+
   describe "migrateCatalog" $ do
     it "initializes the catalog" $ singleTransaction do
       (dropAndInit =<< liftIO getCurrentTime) `shouldReturn` MRInitialized
@@ -81,7 +81,7 @@ spec pgConnInfo = do
       transact (dropAndInit time) `shouldReturn` MRInitialized
       secondDump <- transact dumpSchema
       secondDump `shouldBe` firstDump
-      
+
     it "supports upgrades after downgrade to version 12" \(NT transact) -> do
       let downgradeTo v = downgradeCatalog DowngradeOptions{ dgoDryRun = False, dgoTargetVersion = v }
           upgradeToLatest time = CacheRefT $ flip modifyMVar \_ ->
@@ -93,14 +93,14 @@ spec pgConnInfo = do
         MRMigrated{} -> True
         _ -> False
       transact (upgradeToLatest time) `shouldReturn` MRMigrated "12"
-      
+
     it "supports downgrades for every Git tag" $ singleTransaction do
       gitOutput <- liftIO $ readProcess "git" ["log", "--no-walk", "--tags", "--pretty=%D"] ""
       let filterOldest = filter (not . isPrefixOf "v1.0.0-alpha")
           extractTagName = Safe.headMay . splitOn ", " <=< stripPrefix "tag: "
           supportedDowngrades = sort (map fst downgradeShortcuts)
           gitTags = (sort . filterOldest . mapMaybe extractTagName . tail . lines) gitOutput
-      for_ gitTags \t -> 
+      for_ gitTags \t ->
         t `shouldSatisfy` (`elem` supportedDowngrades)
 
   describe "recreateSystemMetadata" $ do


### PR DESCRIPTION
### Description
A small PR that simply updates our stylish-haskell config, and runs it on all files, which does nothing more than remove whitespace and align imports. Two changes worth noting in the config:
- newline style is switched from 'native' to 'lf', so that whichever OS one contributor uses won't suddenly change all newlines
- the tabs step is now enabled, as our style guide explicitly recommends spaces

### Affected components
- [ ] Server