### PR TITLE
cli(squash): add set_table_is_enum metadata type (close #4394)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The order and collapsed state of columns is now persisted across page navigation
 
 ### Bug fixes and improvements
 
+- cli: set_table_is_enum metadata type for squashing migrations (close #4394) (#4395)
 - console: query support for actions (#4318)
 - cli: query support for actions (#4318)
 - cli: add retry_conf in event trigger for squashing migrations (close #4296) (#4324)

--- a/cli/migrate/database/hasuradb/squash.go
+++ b/cli/migrate/database/hasuradb/squash.go
@@ -422,6 +422,11 @@ func (q CustomQuery) MergeTables(squashList *database.CustomList) error {
 					}
 				}
 				prevElems = append(prevElems, element)
+			case *setTableIsEnumInput:
+				if tblCfg.GetState() == "untracked" {
+					return fmt.Errorf("cannot set table %s on schema %s has a enum when it is untracked", tblCfg.name, tblCfg.schema)
+				}
+				prevElems = append(prevElems, element)
 			}
 		}
 	}
@@ -993,6 +998,11 @@ func (h *HasuraDB) Squash(l *database.CustomList, ret chan<- interface{}) {
 					args.Table.Name,
 					args.Table.Schema,
 				}
+			case *setTableIsEnumInput:
+				return tableMap{
+					args.Table.Name,
+					args.Table.Schema,
+				}
 			case *createEventTriggerInput:
 				return tableMap{
 					args.Table.Name,
@@ -1194,6 +1204,8 @@ func (h *HasuraDB) Squash(l *database.CustomList, ret chan<- interface{}) {
 		case *trackTableV2Input:
 			q.Version = v2
 			q.Type = trackTable
+		case *setTableIsEnumInput:
+			q.Type = setTableIsEnum
 		case *unTrackTableInput:
 			q.Type = untrackTable
 		case *setTableCustomFieldsV2Input:

--- a/cli/migrate/database/hasuradb/types.go
+++ b/cli/migrate/database/hasuradb/types.go
@@ -66,6 +66,8 @@ func (h *newHasuraIntefaceQuery) UnmarshalJSON(b []byte) error {
 		}
 	case setTableCustomFields:
 		q.Args = &setTableCustomFieldsV2Input{}
+	case setTableIsEnum:
+		q.Args = &setTableIsEnumInput{}
 	case untrackTable:
 		q.Args = &unTrackTableInput{}
 	case createObjectRelationship:
@@ -250,6 +252,7 @@ const (
 	trackTable                  requestTypes = "track_table"
 	addExistingTableOrView                   = "add_existing_table_or_view"
 	setTableCustomFields                     = "set_table_custom_fields"
+	setTableIsEnum                           = "set_table_is_enum"
 	untrackTable                             = "untrack_table"
 	trackFunction                            = "track_function"
 	unTrackFunction                          = "untrack_function"
@@ -359,6 +362,11 @@ type trackTableV2Input struct {
 type setTableCustomFieldsV2Input struct {
 	Table tableSchema `json:"table" yaml:"table"`
 	tableConfiguration
+}
+
+type setTableIsEnumInput struct {
+	Table  tableSchema `json:"table" yaml:"table"`
+	IsEnum bool        `json:"is_enum" yaml:"is_enum"`
 }
 
 type unTrackTableInput struct {


### PR DESCRIPTION
### Description
This PR adds support for `set_table_is_enum` metadata [type](https://hasura.io/docs/1.0/graphql/manual/api-reference/schema-metadata-api/table-view.html#set-table-is-enum) for squashing migrations.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [x] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
#4394 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->