### PR TITLE
cli: add new headers to CORS Allowed list

### DIFF
--- a/cli/pkg/console/apiserver.go
+++ b/cli/pkg/console/apiserver.go
@@ -121,6 +121,8 @@ func allowCors() gin.HandlerFunc {
 	config.AddAllowHeaders("X-Hasura-User-Id")
 	config.AddAllowHeaders(XHasuraAccessKey)
 	config.AddAllowHeaders(XHasuraAdminSecret)
+	config.AddAllowHeaders("hasura-client-name")
+	config.AddAllowHeaders("hasura-collaborator-token")
 	config.AddAllowHeaders("X-Hasura-Role")
 	config.AddAllowHeaders("X-Hasura-Allowed-Roles")
 	config.AddAllowMethods("DELETE")


### PR DESCRIPTION

### Description
Will add two new headers to CORS Allow List

1. `hasura-collaborator-token`
2. `hasura-client-name`

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [x] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)
