### PR TITLE
cli: validate endpoint using ParseRequestURI (fix #4407)

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -160,7 +160,7 @@ func (s *ServerConfig) GetVersionEndpoint() string {
 
 // ParseEndpoint ensures the endpoint is valid.
 func (s *ServerConfig) ParseEndpoint() error {
-	nurl, err := url.Parse(s.Endpoint)
+	nurl, err := url.ParseRequestURI(s.Endpoint)
 	if err != nil {
 		return err
 	}

--- a/cli/commands/init.go
+++ b/cli/commands/init.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -183,6 +184,9 @@ func (o *InitOptions) createFiles() error {
 		}
 	}
 	if o.Endpoint != "" {
+		if _, err := url.ParseRequestURI(o.Endpoint); err != nil {
+			return errors.Wrap(err, "error validating endpoint URL")
+		}
 		config.ServerConfig.Endpoint = o.Endpoint
 	}
 	if o.AdminSecret != "" {


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
This commit adds validation of endpoint URL in `hasura init` command and
replaces validation function to `ParseRequestURI` in [`cli.go`](https://github.com/hasura/graphql-engine/blob/master/cli/cli.go#L163).
### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [X] CLI


### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#4407 


 