### PR TITLE
server: avoid integer overflows (fix #576)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - server: add support for `_inc` on `real`, `double`, `numeric` and `money` (fix #3573)
 - server: support special characters in JSON path query argument with bracket `[]` notation, e.g `obj['Hello World!']` (#3890) (#4482)
 - server: add graphql-engine support for timestamps without timezones (fix #1217)
-- server: support inserting unquoted bigint, and generate an integer overflow error on insert (fix #576) (fix #4368)
+- server: support inserting unquoted bigint, and throw an error if value overflows the bounds of the integer type (fix #576) (fix #4368)
 - console: change react ace editor theme to eclipse (close #4437)
 - console: fix columns reordering for relationship tables in data browser (#4483)
 - docs: add API docs for using environment variables as webhook urls in event triggers
@@ -51,7 +51,7 @@ The order, collapsed state of columns and page size is now persisted across page
 - server: `type` field is not required if `jwk_url` is provided in JWT config
 - server: add a new field `claims_namespace_path` which accepts a JSON Path for looking up hasura claim in the JWT token (#4349)
 - server: support reusing Postgres scalars in custom types (close #4125)
-  
+
 ## `v1.2.0-beta.3`
 
 ### console: manage Postgres check constraints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The order, collapsed state of columns and page size is now persisted across page
 - console: add undefined check to fix error (close #4444) (#4445)
 - console: change react ace editor theme to eclipse (close #4437)
 - docs: add One-Click Render deployment guide (close #3683) (#4209)
+- server: support inserting unquoted bigint, and generate an integer overflow error on insert (fix #576) (fix #4368)
 - server: reserved keywords in column references break parser (fix #3597) #3927
 - server: fix postgres specific error message that exposed database type on invalid query parameters (#4294)
 - server: manage inflight events when HGE instance is gracefully shutdown (close #3548)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - server: add support for `_inc` on `real`, `double`, `numeric` and `money` (fix #3573)
 - server: support special characters in JSON path query argument with bracket `[]` notation, e.g `obj['Hello World!']` (#3890) (#4482)
+- server: support inserting unquoted bigint, and generate an integer overflow error on insert (fix #576) (fix #4368)
 
 ## `v1.2.0-beta.4`
 
@@ -39,7 +40,6 @@ The order, collapsed state of columns and page size is now persisted across page
 - console: add undefined check to fix error (close #4444) (#4445)
 - console: change react ace editor theme to eclipse (close #4437)
 - docs: add One-Click Render deployment guide (close #3683) (#4209)
-- server: support inserting unquoted bigint, and generate an integer overflow error on insert (fix #576) (fix #4368)
 - server: reserved keywords in column references break parser (fix #3597) #3927
 - server: fix postgres specific error message that exposed database type on invalid query parameters (#4294)
 - server: manage inflight events when HGE instance is gracefully shutdown (close #3548)

--- a/server/cabal.project
+++ b/server/cabal.project
@@ -34,7 +34,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/hasura/graphql-parser-hs.git
-  tag: 1380495a7b3269b70a7ab3081d745a5f54171a9c
+  tag: 623ad78aa46e7ba2ef1aa58134ad6136b0a85071
 
 source-repository-package
   type: git

--- a/server/src-lib/Hasura/GraphQL/Validate/InputValue.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate/InputValue.hs
@@ -6,7 +6,6 @@ module Hasura.GraphQL.Validate.InputValue
   , pPrintValueC
   ) where
 
-import           Data.Scientific                 (fromFloatDigits)
 import           Hasura.Prelude
 import           Hasura.Server.Utils             (duplicates)
 
@@ -124,7 +123,7 @@ valueParser =
     pScalar (G.VVariable var) = pVar var
     pScalar G.VNull           = pNull
     pScalar (G.VInt v)        = pVal $ J.Number $ fromIntegral v
-    pScalar (G.VFloat v)      = pVal $ J.Number $ fromFloatDigits v
+    pScalar (G.VFloat v)      = pVal $ J.Number v
     pScalar (G.VBoolean b)    = pVal $ J.Bool b
     pScalar (G.VString sv)    = pVal $ J.String $ G.unStringValue sv
     pScalar (G.VEnum _)       = throwVE "unexpected enum for a scalar"
@@ -181,7 +180,7 @@ constValueParser =
     -- scalar json
     pScalar G.VCNull        = pNull
     pScalar (G.VCInt v)     = pVal $ J.Number $ fromIntegral v
-    pScalar (G.VCFloat v)   = pVal $ J.Number $ fromFloatDigits v
+    pScalar (G.VCFloat v)   = pVal $ J.Number v
     pScalar (G.VCBoolean b) = pVal $ J.Bool b
     pScalar (G.VCString sv) = pVal $ J.String $ G.unStringValue sv
     pScalar (G.VCEnum _)    = throwVE "unexpected enum for a scalar"

--- a/server/tests-py/queries/graphql_mutation/insert/basic/insert_integer_overflow.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/basic/insert_integer_overflow.yaml
@@ -5,7 +5,8 @@
     - extensions:
         path: $.selectionSet.insert_test_types.args.objects[0].c2_integer
         code: parse-failed
-      message: Integer does not fit.  Maybe it is a float, or is there integer overflow?
+      message: The value 2.147483648e9 lies outside the bounds or is not an
+               integer.  Maybe it is a float, or is there integer overflow?
   status: 200
   query:
    query: |

--- a/server/tests-py/queries/graphql_mutation/insert/basic/insert_integer_overflow.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/basic/insert_integer_overflow.yaml
@@ -1,0 +1,24 @@
+- description: Inserting a bigint into an int should cause an error, see #576.
+  url: /v1/graphql
+  response:
+    errors:
+    - extensions:
+        path: $.selectionSet.insert_test_types.args.objects[0].c2_integer
+        code: parse-failed
+      message: Integer does not fit.  Maybe it is a float, or is there integer overflow?
+  status: 200
+  query:
+   query: |
+     mutation {
+       insert_test_types(
+         objects: [
+           {
+           c2_integer : 2147483648
+           }
+         ]
+       ) {
+         returning {
+           c2_integer
+         }
+       }
+     }

--- a/server/tests-py/queries/graphql_mutation/insert/basic/insert_various_postgres_types.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/basic/insert_various_postgres_types.yaml
@@ -64,7 +64,7 @@
           objects: [
             { c1_smallint: 32767
             , c2_integer: 2147483647
-            , c3_bigint: "9223372036854775807"
+            , c3_bigint: 9223372036854775807
             , c4_decimal: 123.45
             , c5_numeric: 1.234
             , c6_real: 0.00390625

--- a/server/tests-py/test_graphql_mutations.py
+++ b/server/tests-py/test_graphql_mutations.py
@@ -30,6 +30,9 @@ class TestGraphQLInsert:
     def test_inserts_various_postgres_types(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + "/insert_various_postgres_types.yaml")
 
+    def test_insert_integer_overflow(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + "/insert_integer_overflow.yaml")
+
     @pytest.mark.xfail(reason="Refer https://github.com/hasura/graphql-engine/issues/348")
     def test_insert_into_array_col_with_array_input(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + "/insert_into_array_col_with_array_input.yaml")


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->
Support inserting unquoted bigint, and generate an integer overflow error on insert (fix #576) (fix #4368)

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Before, when a bigint was inserted unquoted, internally it was cast into an Int32, potentially causing integer overflows. Using the new `Scientific` and `Integer` parsing in hasura/graphql-parser-hs#27, we can now avoid this: the new translation from JSON to PG values triggers appropriate errors. So we can insert integers both quoted `"187461"` and unquoted `187461`.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [x] Tests
- [ ] Other (list it)

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
The implementation has two components:
- Upgrade graphql-parser-hs, which simplifies code in the input value validator.
- Add bounded JSON integer parsing, which triggers an error on integer/float overflow.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Unit tests are included.

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->
Although this will allow you to tell when an `_inc`'d _value_ overflows, we cannot distinguish at query time whether this will overflow the stored value. More precisely: even if numbers `x` and `y` individually fit in an `int32`, `x+y` might not. This code does not check for this type of overflow as the addition is handled by postgresql.

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
