### PR TITLE
cli: disable cloning of actions-codegen and init-templates in cli-migrations

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -382,20 +382,8 @@ func (ec *ExecutionContext) SetHGEHeaders(headers map[string]string) {
 // ExecutionDirectory to see if all the required files and directories are in
 // place.
 func (ec *ExecutionContext) Validate() error {
-	// ensure plugins index exists
-	err := ec.PluginsConfig.Repo.EnsureCloned()
-	if err != nil {
-		return errors.Wrap(err, "ensuring plugins index failed")
-	}
-
-	// ensure codegen-assets repo exists
-	err = ec.CodegenAssetsRepo.EnsureCloned()
-	if err != nil {
-		return errors.Wrap(err, "ensuring codegen-assets repo failed")
-	}
-
 	// validate execution directory
-	err = ec.validateDirectory()
+	err := ec.validateDirectory()
 	if err != nil {
 		return errors.Wrap(err, "validating current directory failed")
 	}
@@ -455,6 +443,20 @@ func (ec *ExecutionContext) Validate() error {
 			GetAdminSecretHeaderName(ec.Version): ec.Config.AdminSecret,
 		}
 		ec.SetHGEHeaders(headers)
+	}
+
+	if ec.GlobalConfig.CLIEnvironment != ServerOnDockerEnvironment {
+		// ensure plugins index exists
+		err = ec.PluginsConfig.Repo.EnsureCloned()
+		if err != nil {
+			return errors.Wrap(err, "ensuring plugins index failed")
+		}
+
+		// ensure codegen-assets repo exists
+		err = ec.CodegenAssetsRepo.EnsureCloned()
+		if err != nil {
+			return errors.Wrap(err, "ensuring codegen-assets repo failed")
+		}
 	}
 	return nil
 }

--- a/scripts/cli-migrations/v2/Dockerfile
+++ b/scripts/cli-migrations/v2/Dockerfile
@@ -10,8 +10,7 @@ RUN busybox dpkg-deb -x libstdc++6*.deb / \
     && rm libstdc++6*.deb
 
 # set an env var to let the cli know that
-# it is running in server environment
-ENV HASURA_GRAPHQL_CLI_ENVIRONMENT=server-on-docker
+# update notification is disabled
 ENV HASURA_GRAPHQL_SHOW_UPDATE_NOTIFICATION=false
 
 COPY docker-entrypoint.sh /bin/
@@ -20,6 +19,10 @@ COPY manifest.yaml /tmp/manifest.yaml
 RUN chmod +x /bin/hasura-cli \
     && hasura-cli plugins install cli-ext --manifest-file /tmp/manifest.yaml \
     && rm /tmp/manifest.yaml
+
+# set an env var to let the cli know that
+# it is running in server environment
+ENV HASURA_GRAPHQL_CLI_ENVIRONMENT=server-on-docker
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 


### PR DESCRIPTION
### Description
This PR disables cloning of `actions-codegen` and `plugins` repo if `HASURA_GRAPHQL_CLI_ENVIRONMENT` is set to `server-on-docker`

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [x] CLI
- [ ] Docs
- [ ] Community Content
- [x] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
#4436 

### Solution and Design
1. Add support for `cli_environment` in global config
2. If `cli_environment` is set to `server-on-docker`, then don't disable any repo cloning

### Steps to test and verify
1. Run `rm -rf ~/.hasura`
2. Run `export HASURA_GRAPHQL_CLI_ENVIRONMENT=server-on-docker`
3. Run `hasura migrate status` and plugins directory shouldn't exist in ~/.hasura
4. Run `unset HASURA_GRAPHQL_CLI_ENVIRONMENT`
5. Run `hasura migrate status` and plugins directory should exist in ~/.hasura

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->