### PR TITLE
server: add support for timestamps without timezone to graphql-engine (fix #1217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes and improvements
 
 - server: add support for `_inc` on `real`, `double`, `numeric` and `money` (fix #3573)
+- server: add graphql-engine support for timestamps without timezones (fix #1217)
 
 ## `v1.2.0-beta.4`
 

--- a/server/src-lib/Hasura/SQL/Types.hs
+++ b/server/src-lib/Hasura/SQL/Types.hs
@@ -342,6 +342,7 @@ data PGScalarType
   | PGText
   | PGCitext
   | PGDate
+  | PGTimeStamp
   | PGTimeStampTZ
   | PGTimeTZ
   | PGJSON
@@ -373,6 +374,7 @@ instance ToSQL PGScalarType where
     PGText        -> "text"
     PGCitext      -> "citext"
     PGDate        -> "date"
+    PGTimeStamp   -> "timestamp"
     PGTimeStampTZ -> "timestamptz"
     PGTimeTZ      -> "timetz"
     PGJSON        -> "json"
@@ -430,6 +432,9 @@ textToPGScalarType t = case t of
 
   "date"                     -> PGDate
 
+  "timestamp"                -> PGTimeStamp
+  "timestamp without time zone" -> PGTimeStamp
+
   "timestamptz"              -> PGTimeStampTZ
   "timestamp with time zone" -> PGTimeStampTZ
 
@@ -467,6 +472,7 @@ pgTypeOid PGVarchar     = PTI.varchar
 pgTypeOid PGText        = PTI.text
 pgTypeOid PGCitext      = PTI.text -- Explict type cast to citext needed, See also Note [Type casting prepared params]
 pgTypeOid PGDate        = PTI.date
+pgTypeOid PGTimeStamp   = PTI.timestamp
 pgTypeOid PGTimeStampTZ = PTI.timestamptz
 pgTypeOid PGTimeTZ      = PTI.timetz
 pgTypeOid PGJSON        = PTI.json

--- a/server/tests-py/queries/graphql_query/aggregations/article_agg_where.yaml
+++ b/server/tests-py/queries/graphql_query/aggregations/article_agg_where.yaml
@@ -97,6 +97,8 @@ response:
           content_max: Sample article content 3
           author_id: 2
           author_id_max: 2
+          published_on: '1999-01-09T04:05:06'
+          published_on_max: '1999-01-09T04:05:06'
         max_fields:
           id: 3
           id_max: 3
@@ -106,6 +108,8 @@ response:
           content_max: Sample article content 3
           author_id: 2
           author_id_max: 2
+          published_on: '1999-01-09T04:05:06'
+          published_on_max: '1999-01-09T04:05:06'
         min:
           id: 2
           id_min: 2
@@ -115,6 +119,8 @@ response:
           content_min: Sample article content 2
           author_id: 1
           author_id_min: 1
+          published_on: '1999-01-08T04:05:07'
+          published_on_min: '1999-01-08T04:05:07'
         min_fields:
           id: 2
           id_min: 2
@@ -124,11 +130,14 @@ response:
           content_min: Sample article content 2
           author_id: 1
           author_id_min: 1
+          published_on: '1999-01-08T04:05:07'
+          published_on_min: '1999-01-08T04:05:07'
       nodes:
       - id: 2
         title: Article 2
         content: Sample article content 2
         is_published: true
+        published_on: '1999-01-08T04:05:07'
         author:
           id: 1
           name: Author 1
@@ -136,6 +145,7 @@ response:
         title: Article 3
         content: Sample article content 3
         is_published: true
+        published_on: '1999-01-09T04:05:06'
         author:
           id: 2
           name: Author 2
@@ -144,6 +154,7 @@ response:
         title: Article 2
         content: Sample article content 2
         is_published: true
+        published_on: '1999-01-08T04:05:07'
         author:
           id: 1
           name: Author 1
@@ -151,6 +162,7 @@ response:
         title: Article 3
         content: Sample article content 3
         is_published: true
+        published_on: '1999-01-09T04:05:06'
         author:
           id: 2
           name: Author 2
@@ -268,6 +280,8 @@ query:
             content_max: content
             author_id
             author_id_max: author_id
+            published_on
+            published_on_max: published_on
           }
           max_fields: max {
             id
@@ -278,6 +292,8 @@ query:
             content_max: content
             author_id
             author_id_max: author_id
+            published_on
+            published_on_max: published_on
           }
           min {
             id
@@ -288,6 +304,8 @@ query:
             content_min: content
             author_id
             author_id_min: author_id
+            published_on
+            published_on_min: published_on
           }
           min_fields: min {
             id
@@ -298,6 +316,8 @@ query:
             content_min: content
             author_id
             author_id_min: author_id
+            published_on
+            published_on_min: published_on
           }
         }
         nodes {
@@ -305,6 +325,7 @@ query:
           title
           content
           is_published
+          published_on
           author {
             id
             name
@@ -315,6 +336,7 @@ query:
           title
           content
           is_published
+          published_on
           author {
             id
             name

--- a/server/tests-py/queries/graphql_query/aggregations/setup.yaml
+++ b/server/tests-py/queries/graphql_query/aggregations/setup.yaml
@@ -6,7 +6,7 @@ args:
   args:
     sql: |
       create table author(
-          id serial primary key, 
+          id serial primary key,
           name text unique
       );
 - type: track_table
@@ -57,28 +57,31 @@ args:
       insert into author (name)
       values
       ('Author 1'),
-      ('Author 2') 
+      ('Author 2')
 
 - type: run_sql
   args:
     sql: |
-      insert into article (title,content,author_id,is_published)
+      insert into article (title,content,author_id,is_published,published_on)
       values
       (
         'Article 1',
         'Sample article content 1',
         1,
-        false
+        false,
+        '1999-01-08 04:05:06'
       ),
       (
         'Article 2',
         'Sample article content 2',
         1,
-        true
+        true,
+        '1999-01-08 04:05:07'
       ),
       (
         'Article 3',
         'Sample article content 3',
         2,
-        true
+        true,
+        '1999-01-09 04:05:06'
       )


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->
This adds Hasura support for the `timestamp` column type. As a consequence, this allows aggregations on timestamps without timezone. (fix #1217)

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->
Timestamps without timezones are tricky, because they may internally get converted back and forth, causing an offset caused by mismatched timezones. However, this does not seem to be the case: there was already a test for correct insert-output behavior in `server/tests-py/queries/graphql_mutation/insert/basic/insert_various_postgres_types.yaml` and this test is unaffected by this change.

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [ ] No new GraphQL schema is generated
- [x] New GraphQL schema is being generated:
   - [x] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
