### PR TITLE
cli: add suport for .env file (fix #4129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Next release
 
+### cli: add support for .env file
+
+ENV vars can now be read from .env file present at the project root directory. A global flag, `--envfile`, is added so you can explicitly provide the .env filename, which defaults to `.env` filename if no flag is provided.
+
+**Example**:
+
+```
+hasura console --envfile production.env
+```
+The above command will read ENV vars from `production.env` file present at the project root directory.
+
+(close #4129) (#4454)
+
 ### Bug fixes and improvements
 
 - server: add support for `_inc` on `real`, `double`, `numeric` and `money` (fix #3573)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+	"github.com/subosito/gotenv"
 	"golang.org/x/crypto/ssh/terminal"
 	"gopkg.in/yaml.v2"
 )
@@ -206,6 +207,8 @@ type ExecutionContext struct {
 
 	// ExecutionDirectory is the directory in which command is being executed.
 	ExecutionDirectory string
+	// Envfile is the .env file to load ENV vars from
+	Envfile string
 	// MigrationDir is the name of directory where migrations are stored.
 	MigrationDir string
 	// MetadataDir is the name of directory where metadata files are stored.
@@ -412,6 +415,11 @@ func (ec *ExecutionContext) Validate() error {
 		return errors.Wrap(err, "validating current directory failed")
 	}
 
+	// load .env file
+	err = ec.loadEnvfile()
+	if err != nil {
+		return errors.Wrap(err, "loading .env file failed")
+	}
 	// set names of config file
 	ec.ConfigFile = filepath.Join(ec.ExecutionDirectory, "config.yaml")
 
@@ -586,6 +594,25 @@ func (ec *ExecutionContext) Spin(message string) {
 	} else {
 		ec.Logger.Println(message)
 	}
+}
+
+// loadEnvfile loads .env file
+func (ec *ExecutionContext) loadEnvfile() error {
+	envfile := filepath.Join(ec.ExecutionDirectory, ec.Envfile)
+	err := gotenv.Load(envfile)
+	if err != nil {
+		// return error if user provided envfile name
+		if ec.Envfile != ".env" {
+			return err
+		}
+		if !os.IsNotExist(err) {
+			ec.Logger.Warn(err)
+		}
+	}
+	if err == nil {
+		ec.Logger.Info("ENV vars read from: ", envfile)
+	}
+	return nil
 }
 
 // setupLogger creates a default logger if context does not have one set.

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -610,7 +610,7 @@ func (ec *ExecutionContext) loadEnvfile() error {
 		}
 	}
 	if err == nil {
-		ec.Logger.Info("ENV vars read from: ", envfile)
+		ec.Logger.Debug("ENV vars read from: ", envfile)
 	}
 	return nil
 }

--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -77,6 +77,7 @@ func init() {
 	f.StringVar(&ec.ExecutionDirectory, "project", "", "directory where commands are executed (default: current dir)")
 	f.BoolVar(&ec.SkipUpdateCheck, "skip-update-check", false, "Skip automatic update check on command execution")
 	f.BoolVar(&ec.NoColor, "no-color", false, "do not colorize output (default: false)")
+	f.StringVar(&ec.Envfile, "envfile", ".env", ".env filename to load ENV vars from")
 }
 
 // NewDefaultHasuraCommand creates the `hasura` command with default arguments

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.1
 	github.com/stretchr/testify v1.4.0
+	github.com/subosito/gotenv v1.2.0
 	github.com/theplant/cldr v0.0.0-20190423050709-9f76f7ce4ee8 // indirect
 	github.com/theplant/htmltestingutils v0.0.0-20190423050759-0e06de7b6967 // indirect
 	github.com/theplant/testingutils v0.0.0-20190603093022-26d8b4d95c61 // indirect


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
This commit adds support for loading ENV vars using .env file in the project root directory. It also introduces a global flag, `--envfile` to facilitate loading of named .env files. (fix #4129) 

### Changelog

- [X] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->
- [X] CLI
- [ ] Docs

Note: I'll update the docs required for the same here: #4408 

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#4129 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

Used `godotenv.Load` function to load ENV vars from `.env` file at the project root. The `Load` func is called as soon at the value for `ExecutionDirectory` is set. 




