### PR TITLE
cli(test): fix cli init test to use initDir from subtest group

### DIFF
--- a/.circleci/test-cli.sh
+++ b/.circleci/test-cli.sh
@@ -29,7 +29,7 @@ PID=$!
 wait_for_port 8080
 
 # test cli
-HASURA_GRAPHQL_TEST_ENDPOINT="http://localhost:8080" TEST_TAGS="test_plugins" make test
+HASURA_GRAPHQL_TEST_ENDPOINT="http://localhost:8080" make test
 kill -s INT $PID
 
 # start graphql-engine with admin secret

--- a/cli/integration_test/v1/init.go
+++ b/cli/integration_test/v1/init.go
@@ -1,20 +1,12 @@
 package v1
 
 import (
-	"math/rand"
 	"os"
-	"path/filepath"
-	"strconv"
 	"testing"
-	"time"
 
 	"github.com/hasura/graphql-engine/cli"
 	"github.com/hasura/graphql-engine/cli/commands"
 )
-
-func init() {
-	rand.Seed(time.Now().UTC().UnixNano())
-}
 
 func TestInitCmd(t *testing.T, ec *cli.ExecutionContext, initDir string) {
 	tt := []struct {
@@ -27,7 +19,7 @@ func TestInitCmd(t *testing.T, ec *cli.ExecutionContext, initDir string) {
 			Version:     cli.V1,
 			Endpoint:    os.Getenv("HASURA_GRAPHQL_TEST_ENDPOINT"),
 			AdminSecret: os.Getenv("HASURA_GRAPHQL_TEST_ADMIN_SECRET"),
-			InitDir:     filepath.Join(os.TempDir(), "hasura-cli-test-"+strconv.Itoa(rand.Intn(1000))),
+			InitDir:     initDir,
 		}, nil},
 	}
 

--- a/cli/integration_test/v2/init.go
+++ b/cli/integration_test/v2/init.go
@@ -1,20 +1,12 @@
 package v2
 
 import (
-	"math/rand"
 	"os"
-	"path/filepath"
-	"strconv"
 	"testing"
-	"time"
 
 	"github.com/hasura/graphql-engine/cli"
 	"github.com/hasura/graphql-engine/cli/commands"
 )
-
-func init() {
-	rand.Seed(time.Now().UTC().UnixNano())
-}
 
 func TestInitCmd(t *testing.T, ec *cli.ExecutionContext, initDir string) {
 	tt := []struct {
@@ -27,7 +19,7 @@ func TestInitCmd(t *testing.T, ec *cli.ExecutionContext, initDir string) {
 			Version:     cli.V2,
 			Endpoint:    os.Getenv("HASURA_GRAPHQL_TEST_ENDPOINT"),
 			AdminSecret: os.Getenv("HASURA_GRAPHQL_TEST_ADMIN_SECRET"),
-			InitDir:     filepath.Join(os.TempDir(), "hasura-cli-test-"+strconv.Itoa(rand.Intn(1000))),
+			InitDir:     initDir,
 		}, nil},
 	}
 


### PR DESCRIPTION
### Description
This PR fixes an issue with cli init test not using the correct init directory.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [x] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->