### PR TITLE
add few more rql queries to be access mode agnostic

### DIFF
--- a/server/src-lib/Hasura/Server/Query.hs
+++ b/server/src-lib/Hasura/Server/Query.hs
@@ -292,7 +292,10 @@ getQueryAccessMode q = (fromMaybe Q.ReadOnly) <$> getQueryAccessMode' q
     getQueryAccessMode' (RQV1 q') =
       case q' of
         RQSelect _ -> pure Nothing
-        RQCount _ -> pure Nothing
+        RQCount _  -> pure Nothing
+        RQGetInconsistentMetadata _     -> pure Nothing
+        RQExportMetadata _              -> pure Nothing
+        RQDumpInternalState _           -> pure Nothing
         RQRunSql RunSQL {rTxAccessMode} -> pure $ Just rTxAccessMode
         RQBulk qs -> foldM reconcileAccessModeWith Nothing (zip [0 :: Integer ..] qs)
         _ -> pure $ Just Q.ReadWrite
@@ -304,10 +307,7 @@ getQueryAccessMode q = (fromMaybe Q.ReadOnly) <$> getQueryAccessMode' q
             "incompatible access mode requirements in bulk query, " <>
             "expected access mode: " <>
             (T.pack $ maybe "ANY" show expectedMode) <>
-            " but " <>
-            "$.args[" <>
-            (T.pack $ show i) <>
-            "] forces " <>
+            " but " <> "$.args[" <> (T.pack $ show i) <> "] forces " <>
             (T.pack $ show errMode)
     getQueryAccessMode' (RQV2 _) = pure $ Just Q.ReadWrite
 


### PR DESCRIPTION

### Description

Few more RQL queries can be run in READ ONLY mode.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

