### PR TITLE
Move changelog entry to the right section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next release
 
+### Bug fixes and improvements
+
+- server: add support for `_inc` on `real`, `double`, `numeric` and `money` (fix #3573)
+
 ## `v1.2.0-beta.4`
 
 ### add query support in actions
@@ -34,7 +38,6 @@ The order, collapsed state of columns and page size is now persisted across page
 - console: add undefined check to fix error (close #4444) (#4445)
 - console: change react ace editor theme to eclipse (close #4437)
 - docs: add One-Click Render deployment guide (close #3683) (#4209)
-- server: add support for `_inc` on `real`, `double`, `numeric` and `money` (fix #3573)
 - server: reserved keywords in column references break parser (fix #3597) #3927
 - server: fix postgres specific error message that exposed database type on invalid query parameters (#4294)
 - server: manage inflight events when HGE instance is gracefully shutdown (close #3548)


### PR DESCRIPTION
In #4429 I added a changelog entry to an - at the time of submitting the PR - unreleased version of graphql-engine. During the review process, 1.2.0-beta.4 got released, and afterwards my PR was merged, resulting in the change being listed for the wrong version. This fixes that.