### PR TITLE
fix recreating action's permission (fix #4377)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - server: add support for `_inc` on `real`, `double`, `numeric` and `money` (fix #3573)
 - server: support special characters in JSON path query argument with bracket `[]` notation, e.g `obj['Hello World!']` (#3890) (#4482)
 - docs: add API docs for using environment variables as webhook urls in event triggers
+- server: fix recreating action's permissions (close #4377)
 
 ## `v1.2.0-beta.4`
 
@@ -48,7 +49,7 @@ The order, collapsed state of columns and page size is now persisted across page
 - server: `type` field is not required if `jwk_url` is provided in JWT config
 - server: add a new field `claims_namespace_path` which accepts a JSON Path for looking up hasura claim in the JWT token (#4349)
 - server: support reusing Postgres scalars in custom types (close #4125)
-  
+
 ## `v1.2.0-beta.3`
 
 ### console: manage Postgres check constraints

--- a/server/src-lib/Hasura/RQL/DDL/Action.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Action.hs
@@ -249,8 +249,8 @@ runCreateActionPermission
 runCreateActionPermission createActionPermission = do
   actionInfo <- getActionInfo actionName
   void $ onJust (Map.lookup role $ _aiPermissions actionInfo) $ const $
-    throw400 AlreadyExists $ "permission for role: " <> role
-    <<> "is already defined on " <>> actionName
+    throw400 AlreadyExists $ "permission for role " <> role
+    <<> " is already defined on " <>> actionName
   persistCreateActionPermission createActionPermission
   buildSchemaCacheFor $ MOActionPermission actionName role
   pure successMsg
@@ -282,6 +282,7 @@ runDropActionPermission dropActionPermission = do
     throw400 NotExists $
     "permission for role: " <> role <<> " is not defined on " <>> actionName
   liftTx $ deleteActionPermissionFromCatalog actionName role
+  buildSchemaCacheFor $ MOActionPermission actionName role
   return successMsg
   where
     actionName = _dapAction dropActionPermission

--- a/server/tests-py/queries/actions/metadata/recreate_permission.yaml
+++ b/server/tests-py/queries/actions/metadata/recreate_permission.yaml
@@ -1,0 +1,32 @@
+# For https://github.com/hasura/graphql-engine/issues/4377
+- description: Create permission for action
+  url: /v1/query
+  status: 200
+  response:
+    message: success
+  query:
+    type: create_action_permission
+    args:
+      action: create_user
+      role: user
+- description: Drop the permission
+  url: /v1/query
+  status: 200
+  response:
+    message: success
+  query:
+    type: drop_action_permission
+    args:
+      action: create_user
+      role: user
+
+- description: Recreate action permission
+  url: /v1/query
+  status: 200
+  response:
+    message: success
+  query:
+    type: create_action_permission
+    args:
+      action: create_user
+      role: user

--- a/server/tests-py/queries/actions/metadata/setup.yaml
+++ b/server/tests-py/queries/actions/metadata/setup.yaml
@@ -1,0 +1,21 @@
+type: bulk
+args:
+- type: set_custom_types
+  args:
+    objects:
+    - name: User
+      fields:
+      - name: user_id
+        type: ID!
+      - name: name
+        type: String!
+- type: create_action
+  args:
+    name: create_user
+    definition:
+      kind: synchronous
+      arguments:
+      - name: name
+        type: String!
+      output_type: User!
+      handler: http://127.0.0.1:5593/create-user

--- a/server/tests-py/queries/actions/metadata/teardown.yaml
+++ b/server/tests-py/queries/actions/metadata/teardown.yaml
@@ -1,0 +1,7 @@
+type: bulk
+args:
+- type: drop_action
+  args:
+    name: create_user
+- type: set_custom_types
+  args: {}

--- a/server/tests-py/test_actions.py
+++ b/server/tests-py/test_actions.py
@@ -377,3 +377,13 @@ class TestSetCustomTypes:
 
     def test_create_action_pg_scalar(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + '/create_action_pg_scalar.yaml')
+
+@pytest.mark.usefixtures('per_class_tests_db_state')
+class TestActionsMetadata:
+
+    @classmethod
+    def dir(cls):
+        return 'queries/actions/metadata'
+
+    def test_recreate_permission(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + '/recreate_permission.yaml')


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Re-defining action's permission fails for a given role. The PR fixes the same.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [x] Tests

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
fix #4377 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
The bug exists because the schema cache reloading isn't invoked after deleting the permission in the catalog. It is a simple fix by adding a line of code which invokes schema cache reload.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
1. Allow permission for role user
2. Remove permission for role user
3. Try to re-allow permission for role user

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->
N/A

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes

#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated


#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes
