### PR TITLE
fix intermittent errors occur when query actions used with variables

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Resolve.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve.hs
@@ -124,14 +124,14 @@ queryFldToPGAST fld actionExecuter = do
       -- The variables captured in non-action queries are used to generate
       -- an SQL query, but in case of query actions it's converted into JSON
       -- and included in the action's webhook payload.
+      let f = case jsonAggType of
+             DS.JASMultipleRows -> QRFActionExecuteList
+             DS.JASSingleObject -> QRFActionExecuteObject
       markNotReusable
       f <$> actionExecuter (RA.resolveActionQuery fld ctx (userVars userInfo))
       where
         outputType = _saecOutputType ctx
         jsonAggType = RA.mkJsonAggSelect outputType
-        f = case jsonAggType of
-             DS.JASMultipleRows -> QRFActionExecuteList
-             DS.JASSingleObject -> QRFActionExecuteObject
 
 mutFldToTx
   :: ( HasVersion

--- a/server/src-lib/Hasura/GraphQL/Resolve.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve.hs
@@ -124,10 +124,10 @@ queryFldToPGAST fld actionExecuter = do
       -- The variables captured in non-action queries are used to generate
       -- an SQL query, but in case of query actions it's converted into JSON
       -- and included in the action's webhook payload.
+      markNotReusable
       let f = case jsonAggType of
              DS.JASMultipleRows -> QRFActionExecuteList
              DS.JASSingleObject -> QRFActionExecuteObject
-      markNotReusable
       f <$> actionExecuter (RA.resolveActionQuery fld ctx (userVars userInfo))
       where
         outputType = _saecOutputType ctx

--- a/server/src-lib/Hasura/GraphQL/Resolve.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve.hs
@@ -119,10 +119,11 @@ queryFldToPGAST fld actionExecuter = do
     QCAsyncActionFetch ctx ->
       QRFActionSelect <$> RA.resolveAsyncActionQuery userInfo ctx fld
     QCAction ctx -> do
-      case jsonAggType of
-        DS.JASMultipleRows -> QRFActionExecuteList
-        DS.JASSingleObject -> QRFActionExecuteObject
-      <$> actionExecuter (RA.resolveActionQuery fld ctx (userVars userInfo))
+      let f = case jsonAggType of
+                DS.JASMultipleRows -> QRFActionExecuteList
+                DS.JASSingleObject -> QRFActionExecuteObject
+      markNotReusable
+      f <$> actionExecuter (RA.resolveActionQuery fld ctx (userVars userInfo))
       where
         outputType = _saecOutputType ctx
         jsonAggType = RA.mkJsonAggSelect outputType

--- a/server/tests-py/queries/actions/sync/get_user_by_email_success.yaml
+++ b/server/tests-py/queries/actions/sync/get_user_by_email_success.yaml
@@ -3,8 +3,8 @@ url: /v1/graphql
 status: 200
 query:
   query: |
-    query {
-      get_user_by_email(email: "clarke@gmail.com"){
+    query ($email: String!){
+      get_user_by_email(email: $email){
           id
           user {
             name
@@ -13,6 +13,8 @@ query:
       }
     }
 
+  variables:
+    email: clarke@gmail.com
 
 response:
   data:

--- a/server/tests-py/test_actions.py
+++ b/server/tests-py/test_actions.py
@@ -131,7 +131,7 @@ class TestQueryActions:
     #     }
     #   ]
     # }
-    def test_query_actions_with_variables(self, hge_ctx):
+    def test_query_action_should_not_throw_validation_error(self, hge_ctx):
         for _ in range(100):
             self.test_query_action_success_output_object(hge_ctx)
 

--- a/server/tests-py/test_actions.py
+++ b/server/tests-py/test_actions.py
@@ -117,6 +117,23 @@ class TestQueryActions:
         assert code == 200,resp
         check_query_f(hge_ctx, self.dir() + '/get_users_by_email_success.yaml')
 
+    # This test is to make sure that query actions work well with variables.
+    # Earlier the HGE used to add the query action to the plan cache, which
+    # results in interrmittent validation errors, like:
+    # {
+    #   "errors": [
+    #     {
+    #       "extensions": {
+    #         "path": "$.variableValues",
+    #         "code": "validation-failed"
+    #       },
+    #       "message": "unexpected variables: email"
+    #     }
+    #   ]
+    # }
+    def test_query_actions_with_variables(self, hge_ctx):
+        for _ in range(100):
+            self.test_query_action_success_output_object(hge_ctx)
 
 def mk_headers_with_secret(hge_ctx, headers={}):
     admin_secret = hge_ctx.hge_key

--- a/server/tests-py/test_actions.py
+++ b/server/tests-py/test_actions.py
@@ -132,7 +132,7 @@ class TestQueryActions:
     #   ]
     # }
     def test_query_action_should_not_throw_validation_error(self, hge_ctx):
-        for _ in range(100):
+        for _ in range(25):
             self.test_query_action_success_output_object(hge_ctx)
 
 def mk_headers_with_secret(hge_ctx, headers={}):


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->
fixes #4520 

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

A query action when used with variables used to give intermittent errors when executed multiple times. This PR fixes the bug by not adding the query action to the plan cache.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [x] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
