### PR TITLE
preserve the selection set in derived action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Along with the check for filtering rows that can be updated, you can now set a p
 - server: support special characters in JSON path query argument with bracket `[]` notation, e.g `obj['Hello World!']` (#3890) (#4482)
 - server: add graphql-engine support for timestamps without timezones (fix #1217)
 - server: support inserting unquoted bigint, and throw an error if value overflows the bounds of the integer type (fix #576) (fix #4368)
+- console: while deriving action, map selection set of parent mutation to action's returning type (#4530)
 - console: change react ace editor theme to eclipse (close #4437)
 - console: fix columns reordering for relationship tables in data browser (#4483)
 - console: format row count in data browser for readablity (#4433)

--- a/console/src/shared/utils/deriveAction.js
+++ b/console/src/shared/utils/deriveAction.js
@@ -97,6 +97,10 @@ const deriveAction = (
   const operationDefinition = rootFields[0];
   const operationName = operationDefinition.name.value;
 
+  const selectedFields = operationDefinition.selectionSet.selections.map(s => {
+    return s.name.value;
+  });
+
   // get action name if not provided
   if (!actionName) {
     actionName = operationAst.definitions[0].name
@@ -212,7 +216,10 @@ const deriveAction = (
     Object.values(getTypeFields(refOperationOutputType)).forEach(
       outputTypeField => {
         const fieldTypeMetadata = getUnderlyingType(outputTypeField.type);
-        if (isScalarType(fieldTypeMetadata.type)) {
+        if (
+          isScalarType(fieldTypeMetadata.type) &&
+          selectedFields.includes(outputTypeField.name)
+        ) {
           outputTypeFields[outputTypeField.name] = wrapTypename(
             fieldTypeMetadata.type.name,
             fieldTypeMetadata.wraps

--- a/console/src/shared/utils/deriveAction.js
+++ b/console/src/shared/utils/deriveAction.js
@@ -228,6 +228,11 @@ const deriveAction = (
       }
     );
   });
+  if (!Object.keys(outputTypeFields).length) {
+    throw new Error(
+      `no scalar found in the selection set of your operation; only scalar fields of the operation get mapped onto the output type of the derived action`
+    );
+  }
 
   Object.keys(outputTypeFields).forEach(fieldName => {
     actionOutputType.fields.push({

--- a/server/src-lib/Hasura/RQL/Types/Action.hs
+++ b/server/src-lib/Hasura/RQL/Types/Action.hs
@@ -112,7 +112,7 @@ instance (Cacheable a) => Cacheable (ActionDefinition a)
 
 instance (J.FromJSON a) => J.FromJSON (ActionDefinition a) where
   parseJSON = J.withObject "ActionDefinition" $ \o -> do
-    _adArguments <- o J..: "arguments"
+    _adArguments <- o J..:? "arguments" J..!= []
     _adOutputType <- o J..: "output_type"
     _adHeaders <- o J..:? "headers" J..!= []
     _adForwardClientHeaders <- o J..:? "forward_client_headers" J..!= False


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

If an action is derived from a query, this PR makes sure that the selection set of the query is mapped onto the action's output type.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Try deriving an action from a query by selecting only some fields from its returning type. The derived action must have only the selected field in the output type. 
