### PR TITLE
cli: remove irrelevant flags from init command (close #4508)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes and improvements
 
-(Remove this and start adding entries)
+- cli: remove irrelevant flags from init command (close #4508) (#4549)
 
 ## `v1.2.0-beta.5`
 

--- a/cli/commands/init.go
+++ b/cli/commands/init.go
@@ -68,12 +68,9 @@ func NewInitCmd(ec *cli.ExecutionContext) *cobra.Command {
 	f := initCmd.Flags()
 	f.Var(cli.NewConfigVersionValue(cli.V2, &opts.Version), "version", "config version to be used")
 	f.StringVar(&opts.InitDir, "directory", "", "name of directory where files will be created")
-	f.StringVar(&opts.MetadataDir, "metadata-directory", "metadata", "name of directory where metadata files will be created")
 	f.StringVar(&opts.Endpoint, "endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
 	f.StringVar(&opts.AdminSecret, "admin-secret", "", "admin secret for Hasura GraphQL Engine")
 	f.StringVar(&opts.AdminSecret, "access-key", "", "access key for Hasura GraphQL Engine")
-	f.StringVar(&opts.ActionKind, "action-kind", "synchronous", "kind to be used for an action")
-	f.StringVar(&opts.ActionHandler, "action-handler-webhook-baseurl", "http://localhost:3000", "webhook baseurl to be used for an action")
 	f.StringVar(&opts.Template, "install-manifest", "", "install manifest to be cloned")
 	f.MarkDeprecated("access-key", "use --admin-secret instead")
 	f.MarkDeprecated("directory", "use directory-name argument instead")
@@ -88,10 +85,6 @@ type InitOptions struct {
 	Endpoint    string
 	AdminSecret string
 	InitDir     string
-	MetadataDir string
-
-	ActionKind    string
-	ActionHandler string
 
 	Template string
 }
@@ -176,10 +169,10 @@ func (o *InitOptions) createFiles() error {
 			ServerConfig: cli.ServerConfig{
 				Endpoint: "http://localhost:8080",
 			},
-			MetadataDirectory: o.MetadataDir,
+			MetadataDirectory: "metadata",
 			ActionConfig: &types.ActionExecutionConfig{
-				Kind:                  o.ActionKind,
-				HandlerWebhookBaseURL: o.ActionHandler,
+				Kind:                  "synchronous",
+				HandlerWebhookBaseURL: "http://localhost:3000",
 			},
 		}
 	}

--- a/docs/graphql/manual/hasura-cli/hasura_init.rst
+++ b/docs/graphql/manual/hasura-cli/hasura_init.rst
@@ -39,13 +39,10 @@ Options
 
 ::
 
-      --action-handler-webhook-baseurl string   webhook baseurl to be used for an action (default "http://localhost:3000")
-      --action-kind string                      kind to be used for an action (default "synchronous")
       --admin-secret string                     admin secret for Hasura GraphQL engine
       --endpoint string                         http(s) endpoint for Hasura GraphQL engine
   -h, --help                                    help for init
       --install-manifest string                 install manifest to be cloned
-      --metadata-directory string               name of directory where metadata files will be created (default "metadata")
       --version string                          config version to be used (default "2")
 
 Options inherited from parent commands


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
This commit removes `--action-kind`, `--metadata-directory` and `--action-handler-webhook-baseurl` flags from the `hasura init` command. It also updates the docs for the `hasura init` command.  

### Affected components
<!-- Remove non-affected components from the list -->

- [X] CLI
- [X] Docs

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#4508 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

I have removed the flags and replaced the values in the config object with the respective default values.
