### PR TITLE
readme: update badges (close #4225)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hasura GraphQL Engine
 
-[![Docker](https://img.shields.io/docker/v/hasura/graphql-engine/latest)(https://hub.docker.com/r/hasura/graphql-engine)]
+[![Docker](https://img.shields.io/docker/v/hasura/graphql-engine/latest)](https://hub.docker.com/r/hasura/graphql-engine)
 [![Docs](https://img.shields.io/badge/docs-v1.0-brightgreen.svg?style=flat)](https://hasura.io/docs)
 [![CircleCI](https://circleci.com/gh/hasura/graphql-engine.svg?style=shield)](https://circleci.com/gh/hasura/graphql-engine)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hasura GraphQL Engine
 
-[![Docker](https://img.shields.io/docker/v/hasura/graphql-engine/latest)](https://hub.docker.com/r/hasura/graphql-engine)
+[![Docker](https://img.shields.io/docker/v/hasura/graphql-engine/latest?label=docker)](https://hub.docker.com/r/hasura/graphql-engine)
 [![Docs](https://img.shields.io/badge/docs-v1.0-brightgreen.svg?style=flat)](https://hasura.io/docs)
 [![CircleCI](https://circleci.com/gh/hasura/graphql-engine.svg?style=shield)](https://circleci.com/gh/hasura/graphql-engine)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Hasura GraphQL Engine
 
+[![Docker](https://img.shields.io/docker/v/hasura/graphql-engine/latest)(https://hub.docker.com/r/hasura/graphql-engine)]
 [![Docs](https://img.shields.io/badge/docs-v1.0-brightgreen.svg?style=flat)](https://hasura.io/docs)
 [![CircleCI](https://circleci.com/gh/hasura/graphql-engine.svg?style=shield)](https://circleci.com/gh/hasura/graphql-engine)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hasura GraphQL Engine
 
-[![Docker](https://img.shields.io/docker/v/hasura/graphql-engine/latest?label=docker)](https://hub.docker.com/r/hasura/graphql-engine)
-[![Docs](https://img.shields.io/badge/docs-v1.0-brightgreen.svg?style=flat)](https://hasura.io/docs)
+[![Latest release](https://img.shields.io/github/v/release/hasura/graphql-engine)](https://github.com/hasura/graphql-engine/releases/latest)
+[![Docs](https://img.shields.io/badge/docs-v1.x-brightgreen.svg?style=flat)](https://hasura.io/docs)
 [![CircleCI](https://circleci.com/gh/hasura/graphql-engine.svg?style=shield)](https://circleci.com/gh/hasura/graphql-engine)
 
 


### PR DESCRIPTION
fixes #4225 

### Change
Include docker version `semver: latest` badge in README.
URL: https://img.shields.io/docker/v/hasura/graphql-engine/latest?label=docker

### Look
![](https://i.imgur.com/qAUXN1m.png)