### PR TITLE
server: validation code simplifications

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Execute.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute.hs
@@ -354,8 +354,7 @@ getSubsOpM pgExecCtx initialReusability fld actionExecuter =
     _            -> do
       (astUnresolved, finalReusability) <- runReusabilityTWith initialReusability $
         GR.queryFldToPGAST fld actionExecuter
-      let varTypes = finalReusability ^? _Reusable
-      EL.buildLiveQueryPlan pgExecCtx (VQ._fAlias fld) astUnresolved varTypes
+      EL.buildLiveQueryPlan pgExecCtx (VQ._fAlias fld) astUnresolved finalReusability
 
 getSubsOp
   :: ( MonadError QErr m

--- a/server/src-lib/Hasura/GraphQL/Resolve.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve.hs
@@ -38,6 +38,7 @@ import qualified Hasura.GraphQL.Resolve.Introspect as RIntro
 import qualified Hasura.GraphQL.Resolve.Mutation   as RM
 import qualified Hasura.GraphQL.Resolve.Select     as RS
 import qualified Hasura.GraphQL.Validate           as V
+import           Hasura.GraphQL.Validate.Types     (MonadReusability, markNotReusable)
 import qualified Hasura.RQL.DML.Select             as DS
 import qualified Hasura.SQL.DML                    as S
 

--- a/server/src-lib/Hasura/GraphQL/Resolve/Types.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/Types.hs
@@ -1,7 +1,5 @@
 module Hasura.GraphQL.Resolve.Types
   ( module Hasura.GraphQL.Resolve.Types
-  -- * Re-exports
-  , MonadReusability(..)
   ) where
 
 import           Control.Lens.TH
@@ -12,7 +10,6 @@ import qualified Data.Sequence                  as Seq
 import qualified Data.Text                      as T
 import qualified Language.GraphQL.Draft.Syntax  as G
 
-import           Hasura.GraphQL.Validate.Types
 import           Hasura.RQL.DDL.Headers         (HeaderConf)
 import           Hasura.RQL.Types.Action
 import           Hasura.RQL.Types.BoolExp


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Rather than defining a new monad class and constructing new instances
of it, just use the `StateT` that it is really based on. I am proposing this change for several reasons: it is shorter, we reduce the amount of code that can be incorrect, and most importantly, it is easier to understand. At first I found it difficult to understand `MonadReusability`. But its description as a state monad explains everything to me. However, this description is only present in its implementation.

This PR also gets rid of some dead code, and `Monoid` instances that aren't
actually monoids (such as the ones for `QueryReusability` and `UnionTyInfo`).

Also avoid an instance of prisms where this doesn't add much value. This has the added benefit of the code being more welcoming to programmers who are perhaps not so familiar with lenses/prisms.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No Breaking changes
