### PR TITLE
rollback graphiql explorer to ^0.5.1 (closes #4605)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Read more about the session argument for computed fields in the [docs](https://h
 
 (Add entries here in the order of: server, console, cli, docs, others)
 
+- console: rollback graphiql explorer to ^0.5.1 (closes #4605) (#4608)
 
 ## `v1.2.0`
 

--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -8631,9 +8631,9 @@
       }
     },
     "graphiql-explorer": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/graphiql-explorer/-/graphiql-explorer-0.6.2.tgz",
-      "integrity": "sha512-hYSM+TI/0IAXltMOL7YXrvnA5xrKoDjjN7qiksxca2DY7yu46cyHVHG0IKIrBozMDBQLvFOhQMPrzplErwVZ1g=="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/graphiql-explorer/-/graphiql-explorer-0.5.1.tgz",
+      "integrity": "sha512-kp0mcnqi8lsy5O5rXM22oAee8SF2atmXM5FvkJSR3y9g0Va4BMrbJSzTY25RM7YMs8bl7CWIpWYM5yCYg8gz8g=="
     },
     "graphql": {
       "version": "14.5.8",

--- a/console/package.json
+++ b/console/package.json
@@ -71,7 +71,7 @@
     "brace": "^0.11.1",
     "deep-equal": "^1.0.1",
     "graphiql": "1.0.0-alpha.0",
-    "graphiql-explorer": "0.6.2",
+    "graphiql-explorer": "^0.5.1",
     "graphql": "14.5.8",
     "graphql-voyager": "^1.0.0-rc.27",
     "history": "^3.0.0",


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Newer version of explorer breaks on safari. #4605

**edit**: this doesnt seem to be the cause

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)
