### PR TITLE
cli: add support for alternative configuration filename (fix #4561)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Read more about the session argument for computed fields in the [docs](https://h
 
 ### Bug fixes and improvements
 
-(Add entries here in the order of: server, console, cli, docs, others)
+-cli: add support for alternative configuration filename (fix #4561) #4611
 
 - console: add read replica support section to pro popup (#4118)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,10 @@ Read more about the session argument for computed fields in the [docs](https://h
 
 ### Bug fixes and improvements
 
--cli: add support for alternative configuration filename (fix #4561) #4611
+(Add entries here in the order of: server, console, cli, docs, others)
 
 - console: add read replica support section to pro popup (#4118)
+- cli: add support for alternative configuration filename (fix #4561) #4611
 
 ## `v1.2.0`
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -449,6 +449,14 @@ func (ec *ExecutionContext) SetHGEHeaders(headers map[string]string) {
 	ec.HGEHeaders = headers
 }
 
+// getConfigFilename returns the name of the configuration file
+func (ec *ExecutionContext) getConfigFilename() string {
+	if _, err := os.Stat(filepath.Join(ec.ExecutionDirectory, "hasura-config.yaml")); err == nil {
+		return "hasura-config"
+	}
+	return "config"
+}
+
 // Validate prepares the ExecutionContext ec and then validates the
 // ExecutionDirectory to see if all the required files and directories are in
 // place.
@@ -478,7 +486,8 @@ func (ec *ExecutionContext) Validate() error {
 	}
 
 	// set names of config file
-	ec.ConfigFile = filepath.Join(ec.ExecutionDirectory, "config.yaml")
+	configFilename := ec.getConfigFilename() + ".yaml"
+	ec.ConfigFile = filepath.Join(ec.ExecutionDirectory, configFilename)
 
 	// read config and parse the values into Config
 	err = ec.readConfig()
@@ -574,7 +583,7 @@ func (ec *ExecutionContext) readConfig() error {
 	v.SetEnvPrefix(util.ViperEnvPrefix)
 	v.SetEnvKeyReplacer(util.ViperEnvReplacer)
 	v.AutomaticEnv()
-	v.SetConfigName("config")
+	v.SetConfigName(ec.getConfigFilename())
 	v.SetDefault("version", "1")
 	v.SetDefault("endpoint", "http://localhost:8080")
 	v.SetDefault("admin_secret", "")

--- a/cli/commands/init.go
+++ b/cli/commands/init.go
@@ -43,9 +43,6 @@ func NewInitCmd(ec *cli.ExecutionContext) *cobra.Command {
 
   # Now, edit <my-directory>/config.yaml to add endpoint and admin secret
 
-  # Create a directory with configuration filename hasura-config.yaml
-  hasura init <my-project> --hasura-config
-
   # Create a directory with endpoint and admin secret configured:
   hasura init <my-project> --endpoint https://my-graphql-engine.com --admin-secret adminsecretkey
 
@@ -78,7 +75,6 @@ func NewInitCmd(ec *cli.ExecutionContext) *cobra.Command {
 	f.StringVar(&opts.AdminSecret, "admin-secret", "", "admin secret for Hasura GraphQL Engine")
 	f.StringVar(&opts.AdminSecret, "access-key", "", "access key for Hasura GraphQL Engine")
 	f.StringVar(&opts.Template, "install-manifest", "", "install manifest to be cloned")
-	f.BoolVar(&opts.HasuraConfig, "hasura-config", false, "config filename hasura-config.yaml (default: config.yaml)")
 	f.MarkDeprecated("access-key", "use --admin-secret instead")
 	f.MarkDeprecated("directory", "use directory-name argument instead")
 
@@ -88,11 +84,10 @@ func NewInitCmd(ec *cli.ExecutionContext) *cobra.Command {
 type InitOptions struct {
 	EC *cli.ExecutionContext
 
-	Version      cli.ConfigVersion
-	Endpoint     string
-	AdminSecret  string
-	InitDir      string
-	HasuraConfig bool
+	Version     cli.ConfigVersion
+	Endpoint    string
+	AdminSecret string
+	InitDir     string
 
 	Template string
 }
@@ -224,17 +219,9 @@ func (o *InitOptions) createFiles() error {
 		config.ServerConfig.AdminSecret = o.AdminSecret
 	}
 
-	// set config filename
-	var configFilename string
-	if o.HasuraConfig {
-		configFilename = "hasura-config.yaml"
-	} else {
-		configFilename = "config.yaml"
-	}
-
 	// write the config file
 	o.EC.Config = config
-	o.EC.ConfigFile = filepath.Join(o.EC.ExecutionDirectory, configFilename)
+	o.EC.ConfigFile = filepath.Join(o.EC.ExecutionDirectory, "config.yaml")
 	err = o.EC.WriteConfig(nil)
 	if err != nil {
 		return errors.Wrap(err, "cannot write config file")

--- a/cli/commands/init.go
+++ b/cli/commands/init.go
@@ -43,6 +43,9 @@ func NewInitCmd(ec *cli.ExecutionContext) *cobra.Command {
 
   # Now, edit <my-directory>/config.yaml to add endpoint and admin secret
 
+  # Create a directory with configuration filename hasura-config.yaml
+  hasura init <my-project> --hasura-config
+
   # Create a directory with endpoint and admin secret configured:
   hasura init <my-project> --endpoint https://my-graphql-engine.com --admin-secret adminsecretkey
 
@@ -75,6 +78,7 @@ func NewInitCmd(ec *cli.ExecutionContext) *cobra.Command {
 	f.StringVar(&opts.AdminSecret, "admin-secret", "", "admin secret for Hasura GraphQL Engine")
 	f.StringVar(&opts.AdminSecret, "access-key", "", "access key for Hasura GraphQL Engine")
 	f.StringVar(&opts.Template, "install-manifest", "", "install manifest to be cloned")
+	f.BoolVar(&opts.HasuraConfig, "hasura-config", false, "config filename hasura-config.yaml (default: config.yaml)")
 	f.MarkDeprecated("access-key", "use --admin-secret instead")
 	f.MarkDeprecated("directory", "use directory-name argument instead")
 
@@ -84,10 +88,11 @@ func NewInitCmd(ec *cli.ExecutionContext) *cobra.Command {
 type InitOptions struct {
 	EC *cli.ExecutionContext
 
-	Version     cli.ConfigVersion
-	Endpoint    string
-	AdminSecret string
-	InitDir     string
+	Version      cli.ConfigVersion
+	Endpoint     string
+	AdminSecret  string
+	InitDir      string
+	HasuraConfig bool
 
 	Template string
 }
@@ -219,9 +224,17 @@ func (o *InitOptions) createFiles() error {
 		config.ServerConfig.AdminSecret = o.AdminSecret
 	}
 
+	// set config filename
+	var configFilename string
+	if o.HasuraConfig {
+		configFilename = "hasura-config.yaml"
+	} else {
+		configFilename = "config.yaml"
+	}
+
 	// write the config file
 	o.EC.Config = config
-	o.EC.ConfigFile = filepath.Join(o.EC.ExecutionDirectory, "config.yaml")
+	o.EC.ConfigFile = filepath.Join(o.EC.ExecutionDirectory, configFilename)
 	err = o.EC.WriteConfig(nil)
 	if err != nil {
 		return errors.Wrap(err, "cannot write config file")

--- a/cli/directory.go
+++ b/cli/directory.go
@@ -87,7 +87,7 @@ func ValidateDirectory(dir string) error {
 	}
 	// if neither config.yaml or hasura-config.yaml is found, return error
 	if len(notFound) > 1 {
-		return errors.Errorf("cannot validate directory '%s': [%s] not found", dir, strings.Join(notFound, ", "))
+		return errors.Errorf("cannot validate directory | configuration file not found")
 	}
 	return nil
 }

--- a/cli/directory.go
+++ b/cli/directory.go
@@ -49,9 +49,11 @@ func (ec *ExecutionContext) validateDirectory() error {
 }
 
 // filesRequired are the files that are mandatory to qualify for a project
-// directory.
+// directory. Either of the configuration files, config.yaml or hasura-config.yaml
+// validate the project directory.
 var filesRequired = []string{
 	"config.yaml",
+	"hasura-config.yaml",
 }
 
 // recursivelyValidateDirectory tries to parse 'startFrom' as a project
@@ -83,7 +85,8 @@ func ValidateDirectory(dir string) error {
 			notFound = append(notFound, f)
 		}
 	}
-	if len(notFound) > 0 {
+	// if neither config.yaml or hasura-config.yaml is found, return error
+	if len(notFound) > 1 {
 		return errors.Errorf("cannot validate directory '%s': [%s] not found", dir, strings.Join(notFound, ", "))
 	}
 	return nil


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
This PR adds an additional flag `--hasura-config` to `hasura init` to allow creating a hasura project directory using config filename `hasura-config.yaml`. 
### Changelog
- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] CLI
- [ ] Docs

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#4561 
### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
Add a flag to `--hasura-config` to name the configuration file as `hasura-config.yaml`.
To make sure config file is picked up in all other commands: 
* Changed the `ValidateDirectory` func in `directory.go` to return error if neither of the configuration files, `config.yaml` and `hasura-config.yaml` are not found. 
* Added a `getConfigFilename` func in `cli.go` to return the name of the config file found. 

In case a directory contains a `config.yaml` and `hasura-config.yaml`, the latter will be used as the configuration file for hasura project.
