### PR TITLE
cli(migrations): load correct server image (fix #4610)

### DIFF
--- a/scripts/cli-migrations/Makefile
+++ b/scripts/cli-migrations/Makefile
@@ -6,6 +6,11 @@ BINARY ?= $(BUILD_DIR)/_cli_output/binaries/cli-hasura-linux-amd64
 IMAGE_TAG ?= cli-migrations
 BUILD_OUTPUT ?= $(BUILD_DIR)/_cli_migrations_output
 CLI_EXT_MANIFEST_FILE ?= $(BUILD_DIR)/_cli_ext_output/manifest-dev.yaml
+SERVER_BUILD_OUTPUT := $(BUILD_DIR)/_server_output
+
+.PHONY: load-server-image
+load-server-image:
+	docker load -i '$(SERVER_BUILD_OUTPUT)/image.tar'
 
 .PHONY: build-cli-migrations-v1
 .ONESHELL:
@@ -37,4 +42,4 @@ test-cli-migrations-v2:
 	./test.sh
 
 .PHONY: all
-all: build-cli-migrations-v1 build-cli-migrations-v2 test-cli-migrations-v1 test-cli-migrations-v2
+all: load-server-image build-cli-migrations-v1 build-cli-migrations-v2 test-cli-migrations-v1 test-cli-migrations-v2


### PR DESCRIPTION
### Description
This PR fixes an issue with the build system not loading the server image for building cli-migrations.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [x] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
#4610 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->
