### PR TITLE
ci: add build_image as required job for test_and_build_cli_migrations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -653,6 +653,7 @@ workflows:
     - test_and_build_cli_migrations:
         <<: *filter_only_vtags
         requires:
+        - build_image
         - test_and_build_cli
     - test_console:
         <<: *filter_only_vtags


### PR DESCRIPTION
### Description
This PR adds `build_image` as required job for `test_and_build_cli_migrations` job.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [x] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->