### PR TITLE
server: cache default values (fix #3773)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ A scheduled trigger can be used to execute custom business logic based on time. 
 
 A cron trigger will be useful when something needs to be done periodically. For example, you can create a cron trigger to  generate an end-of-day sales report every weekday at 9pm.
 
-You can also schedule one-off events based on a timestamp. For example, a new scheduled event can be created for 2 weeks from when a user signs up to send them an email about their experience. 
+You can also schedule one-off events based on a timestamp. For example, a new scheduled event can be created for 2 weeks from when a user signs up to send them an email about their experience.
 
 <Add docs links>
 
@@ -51,6 +51,7 @@ Read more about the session argument for computed fields in the [docs](https://h
 (Add entries here in the order of: server, console, cli, docs, others)
 - server: compile with GHC 8.10.1, closing a space leak with subscriptions. (close #4517) (#3388)
 
+- server: cache default variables for non-optional variables better (fix #3773)
 - server: avoid loss of precision when passing values in scientific notation (fix #4733)
 - server: fix mishandling of GeoJSON inputs in subscriptions (fix #3239)
 - console: avoid count queries for large tables (#4692)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Read more about the session argument for computed fields in the [docs](https://h
 (Add entries here in the order of: server, console, cli, docs, others)
 - server: compile with GHC 8.10.1, closing a space leak with subscriptions. (close #4517) (#3388)
 
-- server: cache default variables for non-optional variables better (fix #3773)
+- server: fix an issue with query plan caching where valid queries would intermittently fail (fix #3773)
 - server: avoid loss of precision when passing values in scientific notation (fix #4733)
 - server: fix mishandling of GeoJSON inputs in subscriptions (fix #3239)
 - console: avoid count queries for large tables (#4692)

--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Plan.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Plan.hs
@@ -210,6 +210,7 @@ deriving instance (Hashable (f TxtEncodedPGVal)) => Hashable (ValidatedVariables
 deriving instance (J.ToJSON (f TxtEncodedPGVal)) => J.ToJSON (ValidatedVariables f)
 
 type ValidatedQueryVariables = ValidatedVariables (Map.HashMap G.Variable)
+-- | See the explanation for 'CohortVariables'.
 type ValidatedSyntheticVariables = ValidatedVariables []
 
 -- | Checks if the provided arguments are valid values for their corresponding types.

--- a/server/src-lib/Hasura/GraphQL/Resolve/Action.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/Action.hs
@@ -54,8 +54,7 @@ import           Hasura.Server.Utils               (mkClientHeadersForward, mkSe
 import           Hasura.Server.Version             (HasVersion)
 import           Hasura.Session
 import           Hasura.SQL.Types
-import           Hasura.SQL.Value                  (PGScalarValue (..), pgScalarValueToJson,
-                                                    toTxtValue)
+import           Hasura.SQL.Value                  (PGScalarValue(..), toTxtValue)
 
 newtype ActionContext
   = ActionContext {_acName :: ActionName}
@@ -539,7 +538,7 @@ callWebhook manager outputType outputFields reqHeaders confHeaders
 annInpValueToJson :: AnnInpVal -> J.Value
 annInpValueToJson annInpValue =
   case _aivValue annInpValue of
-    AGScalar _ pgColumnValueM -> maybe J.Null pgScalarValueToJson pgColumnValueM
+    AGScalar _ pgColumnValueM -> maybe J.Null J.toJSON pgColumnValueM
     AGEnum _ enumValue        -> case enumValue of
       AGESynthetic enumValueM   -> J.toJSON enumValueM
       AGEReference _ enumValueM -> J.toJSON enumValueM

--- a/server/src-lib/Hasura/GraphQL/Resolve/InputValue.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/InputValue.hs
@@ -95,13 +95,20 @@ asPGColumnTypeAndValueM v = do
     -- whether the result is 'Nothing' or 'Just', which would change the generated query, so we have
     -- to unconditionally mark the query non-reusable.
     | G.isNullable (_aivType v) -> markNotReusable
-    | otherwise                 -> do
-      -- TODO fix: the wrong value is being saved here
-      let defVal = case scalarValueM of
-            (WithScalarType _ Nothing   ) -> ReusableNoDefault
-            (WithScalarType _ (Just val)) -> ReusableDefault val
-      recordVariableUse variableName columnType defVal
-
+    | otherwise                 -> case _aivDefault v of
+        Nothing -> do
+          recordVariableUse variableName columnType ReusableNoDefault
+        Just dv -> do
+          defValueM <- case dv of
+            AGScalar colTy val -> pure $ WithScalarType colTy val
+            AGEnum _ (AGEReference _ maybeValue) -> do
+              let maybeScalarValue = PGValText . RQL.getEnumValue <$> maybeValue
+              pure $ WithScalarType PGText maybeScalarValue
+            _ -> tyMismatch "pgvalue" v
+          let defVal = case defValueM of
+                (WithScalarType _ Nothing   ) -> ReusableNoDefault
+                (WithScalarType _ (Just val)) -> ReusableDefault val
+          recordVariableUse variableName columnType defVal
   let isVariable = isJust $ _aivVariable v
   pure (columnType, fmap (flip OpaqueValue isVariable) <$> scalarValueM)
 

--- a/server/src-lib/Hasura/GraphQL/Resolve/InputValue.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/InputValue.hs
@@ -95,7 +95,12 @@ asPGColumnTypeAndValueM v = do
     -- whether the result is 'Nothing' or 'Just', which would change the generated query, so we have
     -- to unconditionally mark the query non-reusable.
     | G.isNullable (_aivType v) -> markNotReusable
-    | otherwise                 -> recordVariableUse variableName columnType
+    | otherwise                 -> do
+      -- TODO fix: the wrong value is being saved here
+      let defVal = case scalarValueM of
+            (WithScalarType _ Nothing   ) -> ReusableNoDefault
+            (WithScalarType _ (Just val)) -> ReusableDefault val
+      recordVariableUse variableName columnType defVal
 
   let isVariable = isJust $ _aivVariable v
   pure (columnType, fmap (flip OpaqueValue isVariable) <$> scalarValueM)

--- a/server/src-lib/Hasura/GraphQL/Validate.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate.hs
@@ -98,7 +98,9 @@ validateVariables varDefsL inpVals = withPathK "variableValues" $ do
       annInpValM <- withPathK (G.unName $ G.unVariable var) $
                     mapM (validateInputValue jsonParser ty) inpValM
       let varValM = case annInpValM of
-            Nothing -> annDefM
+            Nothing -> case annDefM of
+              Nothing -> Nothing
+              Just dv -> Just $ dv { _aivDefault = Just $ _aivValue dv }
             Just iv -> case annDefM of
               Nothing -> Just iv
               Just dv -> Just $ iv { _aivDefault = Just $ _aivValue dv }

--- a/server/src-lib/Hasura/GraphQL/Validate.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate.hs
@@ -97,7 +97,11 @@ validateVariables varDefsL inpVals = withPathK "variableValues" $ do
       let inpValM = Map.lookup var inpVals
       annInpValM <- withPathK (G.unName $ G.unVariable var) $
                     mapM (validateInputValue jsonParser ty) inpValM
-      let varValM = annInpValM <|> annDefM
+      let varValM = case annInpValM of
+            Nothing -> annDefM
+            Just iv -> case annDefM of
+              Nothing -> Just iv
+              Just dv -> Just $ iv { _aivDefault = Just $ _aivValue dv }
       onNothing varValM $ throwVE $
         "expecting a value for non-nullable variable: " <>
         showVars [var] <>

--- a/server/src-lib/Hasura/GraphQL/Validate/InputValue.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate/InputValue.hs
@@ -312,10 +312,14 @@ withParsed expectedTy valParser val fn = do
   case unP parsedVal of
     Nothing              ->
       if G.isNullable expectedTy
-      then AnnInpVal expectedTy Nothing <$> fn Nothing
+      then do
+        v <- fn Nothing
+        return $ AnnInpVal expectedTy Nothing v Nothing
       else throwVE $ "null value found for non-nullable type: "
            <> G.showGT expectedTy
-    Just (Right v)       -> AnnInpVal expectedTy Nothing <$> fn (Just v)
+    Just (Right v)       -> do
+      v' <- fn (Just v)
+      return $ AnnInpVal expectedTy Nothing v' Nothing
     Just (Left (var, v)) -> do
       let varTxt = G.unName $ G.unVariable var
       unless (isTypeAllowed expectedTy $ _aivType v) $

--- a/server/src-lib/Hasura/GraphQL/Validate/Types.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate/Types.hs
@@ -840,7 +840,7 @@ instance (MonadReusability m) => MonadReusability (ReaderT r m) where
   recordVariableUse a b c = lift $ recordVariableUse a b c
   markNotReusable = lift markNotReusable
 instance (MonadReusability m) => MonadReusability (StateT s m) where
-  recordVariableUse a b = lift $ recordVariableUse a b
+  recordVariableUse a b c = lift $ recordVariableUse a b c
   markNotReusable = lift markNotReusable
 
 newtype ReusabilityT m a = ReusabilityT { unReusabilityT :: StateT QueryReusability m a }

--- a/server/src-lib/Hasura/GraphQL/Validate/Types.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate/Types.hs
@@ -713,6 +713,7 @@ data AnnInpVal
   { _aivType     :: !G.GType
   , _aivVariable :: !(Maybe G.Variable)
   , _aivValue    :: !AnnGValue
+  , _aivDefault  :: !(Maybe AnnGValue)
   } deriving (Show, Eq)
 
 type AnnGObject = OMap.InsOrdHashMap G.Name AnnInpVal

--- a/server/src-lib/Hasura/SQL/Types.hs
+++ b/server/src-lib/Hasura/SQL/Types.hs
@@ -334,26 +334,33 @@ data PGScalarType
   = PGSmallInt
   | PGInteger
   | PGBigInt
+
   | PGSerial
   | PGBigSerial
+
   | PGFloat
   | PGDouble
   | PGNumeric
   | PGMoney
+
   | PGBoolean
   | PGChar
   | PGVarchar
   | PGText
   | PGCitext
+
   | PGDate
   | PGTimeStamp
   | PGTimeStampTZ
   | PGTimeTZ
+
   | PGJSON
   | PGJSONB
+
   | PGGeometry
   | PGGeography
   | PGRaster
+
   | PGUUID
   | PGUnknown !T.Text
   deriving (Show, Eq, Lift, Generic, Data)

--- a/server/src-lib/Hasura/SQL/Value.hs
+++ b/server/src-lib/Hasura/SQL/Value.hs
@@ -1,7 +1,6 @@
 module Hasura.SQL.Value
   ( PGScalarValue(..)
   , pgColValueToInt
-  , pgScalarValueToJson
   , withConstructorFn
   , parsePGValue
 
@@ -61,56 +60,63 @@ data PGScalarValue
   = PGValInteger !Int32
   | PGValSmallInt !Int16
   | PGValBigInt !Int64
+
   | PGValFloat !Float
   | PGValDouble !Double
   | PGValNumeric !Scientific
   | PGValMoney !Scientific
+
   | PGValBoolean !Bool
   | PGValChar !Char
   | PGValVarchar !T.Text
   | PGValText !T.Text
   | PGValCitext !T.Text
+
   | PGValDate !Day
   | PGValTimeStamp !LocalTime
   | PGValTimeStampTZ !UTCTime
   | PGValTimeTZ !ZonedTimeOfDay
+
   | PGNull !PGScalarType
+
   | PGValJSON !Q.JSON
   | PGValJSONB !Q.JSONB
+
   | PGValGeo !GeometryWithCRS
   | PGValRaster !RasterWKB
+
   | PGValUUID !UUID.UUID
   | PGValUnknown !T.Text
   deriving (Show, Eq)
 
-pgScalarValueToJson :: PGScalarValue -> Value
-pgScalarValueToJson = \case
-  PGValInteger i  -> toJSON i
-  PGValSmallInt i -> toJSON i
-  PGValBigInt i   -> toJSON i
-  PGValFloat f    -> toJSON f
-  PGValDouble d   -> toJSON d
-  PGValNumeric sc -> toJSON sc
-  PGValMoney m    -> toJSON m
-  PGValBoolean b  -> toJSON b
-  PGValChar t     -> toJSON t
-  PGValVarchar t  -> toJSON t
-  PGValText t     -> toJSON t
-  PGValCitext t   -> toJSON t
-  PGValDate d     -> toJSON d
-  PGValTimeStamp u ->
-    toJSON $ formatTime defaultTimeLocale "%FT%T%QZ" u
-  PGValTimeStampTZ u ->
-    toJSON $ formatTime defaultTimeLocale "%FT%T%QZ" u
-  PGValTimeTZ (ZonedTimeOfDay tod tz) ->
-    toJSON (show tod ++ timeZoneOffsetString tz)
-  PGNull _ -> Null
-  PGValJSON (Q.JSON j)    -> j
-  PGValJSONB (Q.JSONB j)  -> j
-  PGValGeo o    -> toJSON o
-  PGValRaster r -> toJSON r
-  PGValUUID u -> toJSON u
-  PGValUnknown t -> toJSON t
+instance ToJSON PGScalarValue where
+  toJSON = \case
+    PGValInteger i  -> toJSON i
+    PGValSmallInt i -> toJSON i
+    PGValBigInt i   -> toJSON i
+    PGValFloat f    -> toJSON f
+    PGValDouble d   -> toJSON d
+    PGValNumeric sc -> toJSON sc
+    PGValMoney m    -> toJSON m
+    PGValBoolean b  -> toJSON b
+    PGValChar t     -> toJSON t
+    PGValVarchar t  -> toJSON t
+    PGValText t     -> toJSON t
+    PGValCitext t   -> toJSON t
+    PGValDate d     -> toJSON d
+    PGValTimeStamp u ->
+      toJSON $ formatTime defaultTimeLocale "%FT%T%QZ" u
+    PGValTimeStampTZ u ->
+      toJSON $ formatTime defaultTimeLocale "%FT%T%QZ" u
+    PGValTimeTZ (ZonedTimeOfDay tod tz) ->
+      toJSON (show tod ++ timeZoneOffsetString tz)
+    PGNull _ -> Null
+    PGValJSON (Q.JSON j)    -> j
+    PGValJSONB (Q.JSONB j)  -> j
+    PGValGeo o    -> toJSON o
+    PGValRaster r -> toJSON r
+    PGValUUID u -> toJSON u
+    PGValUnknown t -> toJSON t
 
 pgColValueToInt :: PGScalarValue -> Maybe Int
 pgColValueToInt (PGValInteger i)  = Just $ fromIntegral i

--- a/server/tests-py/queries/graphql_query/caching/default_values.yaml
+++ b/server/tests-py/queries/graphql_query/caching/default_values.yaml
@@ -1,0 +1,29 @@
+- description: Test that default values are properly cached (#3773)
+  url: /v1/graphql
+  status: 200
+  response:
+    data:
+      users:
+      - name: Alyssa
+  query:
+    query: |
+      query ($id:Int!=1) {
+        users (where: {id: {_eq: $id}}) {
+          name
+        }
+      }
+
+- description: Test that default values are properly cached (#3773)
+  url: /v1/graphql
+  status: 200
+  response:
+    data:
+      users:
+      - name: Alyssa
+  query:
+    query: |
+      query ($id:Int!=1) {
+        users (where: {id: {_eq: $id}}) {
+          name
+        }
+      }

--- a/server/tests-py/test_graphql_queries.py
+++ b/server/tests-py/test_graphql_queries.py
@@ -606,3 +606,6 @@ class TestGraphQLQueryCaching:
 
     def test_include_directive(self, hge_ctx, transport):
         check_query_f(hge_ctx, self.dir() + '/include_directive.yaml', transport)
+
+    def test_default_values(self, hge_ctx, transport):
+        check_query_f(hge_ctx, self.dir() + '/default_values.yaml', transport)


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
This is a really dirty way to fix #3773 and fix #4577.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

The origin of #3773 is that the "validation" stage not just validates correctness of input data, but also gives back updated values. In particular, the "validation" combines the GraphQL query specification with the argument values, so that any default values are overwritten. As a consequence, the default value was not accessible during the query planning stage.

As a dirty hack to this, this code adds a field to `AnnInpVal` that specifies a default value (if any). This can then be updated at a later stage, so that the default value is available during the query planning stage.

The real solution here would be:
1. to parse, rather than validate, the query,
2. to separate the parsing (or validation) of the GraphQL query from the parsing (or validation) of argument values, so that we do not risk overwriting default values, and
3. to model the query planning in a more type-safe way, so that we avoid the temptation of overwriting one value with another.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
See #3773 and #4577.

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->
This PR does NOT contain a regression test, as I do not know of an easy way to test this. So when #4111 is merged, we should pay attention that this bug does not re-appear.

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No Breaking changes
