### PR TITLE
cli: include new commands in help text (fix #4623)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,7 @@ Read more about the session argument for computed fields in the [docs](https://h
 
 ### Bug fixes and improvements
 
-(Add entries here in the order of: server, console, cli, docs, others)
-
+- cli: include new commands for the hasura root command (fix #4623)
 
 ## `v1.2.0`
 

--- a/cli/commands/help.go
+++ b/cli/commands/help.go
@@ -48,6 +48,7 @@ func (o *helpOptions) run() {
 				NewMigrateCmd(o.EC),
 				NewMetadataCmd(o.EC),
 				NewConsoleCmd(o.EC),
+				NewActionsCmd(o.EC),
 			},
 		},
 		{
@@ -55,6 +56,9 @@ func (o *helpOptions) run() {
 			Commands: []*cobra.Command{
 				NewCompletionCmd(o.EC),
 				NewVersionCmd(o.EC),
+				NewPluginsCmd(o.EC),
+				NewScriptsCmd(o.EC),
+				NewUpdateCLICmd(o.EC),
 			},
 		},
 	}


### PR DESCRIPTION
# Description
Include new commands for the `hasura` root command
```
GraphQL commands:
  init       Initialize directory for Hasura GraphQL Engine migrations
  migrate    Manage migrations on the database
  metadata   Manage Hasura GraphQL Engine metadata saved in the database
  console    Open console to manage database and try out APIs
  actions    Manage actions on hasura

Other commands:
  completion   Generate auto completion code
  version      Print the CLI version
  plugins      Manage plugins for the cli
  scripts      Execute helper scripts to manage Hasura Projects
  update-cli   Update the CLI to latest or a specific version
```
### Changelog
- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
- [x] CLI

### Related Issues
#4623

#### Breaking changes
- [x] No Breaking changes
