### PR TITLE
console: remove nonworking in safari prod build css property

### DIFF
--- a/console/src/components/Common/TableCommon/Table.scss
+++ b/console/src/components/Common/TableCommon/Table.scss
@@ -188,7 +188,6 @@ a.expanded {
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 100%;
 }
 
 .bulkDeleteButton {


### PR DESCRIPTION
Solves https://github.com/hasura/graphql-engine/issues/4632

### Description
This is a quick fix for https://github.com/hasura/graphql-engine/issues/4632. The issue only appears with production build in Safari. 

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components

- [x] Console