### PR TITLE
--from-server should not be specified for hasura migrate export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ RETURNS boolean AS $$
   );
 $$ LANGUAGE sql STABLE;
 ```
+
 and make a query like:
 
 ```
@@ -25,7 +26,7 @@ query {
     content
     likedByMe
   }
-}     
+}
 ```
 
 Support for this is now added through the `add_computed_field` API.
@@ -36,6 +37,7 @@ Read more about the session argument for computed fields in the [docs](https://h
 
 (Add entries here in the order of: server, console, cli, docs, others)
 
+- docs: Fixed typo on how to export metadata (#4638)
 
 ## `v1.2.0`
 
@@ -101,6 +103,7 @@ The `internal` field for action errors is improved with more debug information. 
 `response` and `error` fields instead of just `webhook_response` field.
 
 Before:
+
 ```json
 {
   "errors": [
@@ -121,7 +124,9 @@ Before:
   ]
 }
 ```
+
 After:
+
 ```json
 {
   "errors": [
@@ -185,6 +190,7 @@ ENV vars can now be read from .env file present at the project root directory. A
 ```
 hasura console --envfile production.env
 ```
+
 The above command will read ENV vars from `production.env` file present at the project root directory.
 
 (close #4129) (#4454)

--- a/docs/graphql/manual/migrations/basics.rst
+++ b/docs/graphql/manual/migrations/basics.rst
@@ -31,7 +31,7 @@ Now run:
 
   # Export current Hasura state
   hasura migrate create --from-server <endpoint>
-  hasura metadata export --from-server <endpoint>
+  hasura metadata export <endpoint>
 
 Generating migrations
 ---------------------


### PR DESCRIPTION
### Description
Removed `--from-server` on `hasura migrate export [...]` command.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components

- [x] Docs

