### PR TITLE
console: avoid count queries for large tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Read more about the session argument for computed fields in the [docs](https://h
 
 (Add entries here in the order of: server, console, cli, docs, others)
 
+- console: avoid count queries for large tables (#4681)
 - console: add read replica support section to pro popup (#4118)
 - cli: list all avialable commands in root command help (fix #4623)
 

--- a/console/src/components/Services/Data/DataState.js
+++ b/console/src/components/Services/Data/DataState.js
@@ -22,6 +22,8 @@ const defaultViewState = {
   manualTriggers: [],
   triggeredRow: -1,
   triggeredFunction: null,
+  estimatedCount: 0,
+  isCountEstimated: 0,
 };
 
 const defaultPermissionsState = {

--- a/console/src/components/Services/Data/TableBrowseRows/FilterQuery.js
+++ b/console/src/components/Services/Data/TableBrowseRows/FilterQuery.js
@@ -27,6 +27,7 @@ import Button from '../../../Common/Button/Button';
 import ReloadEnumValuesButton from '../Common/Components/ReloadEnumValuesButton';
 import styles from '../../../Common/FilterQuery/FilterQuery.scss';
 import { getPersistedPageSize } from './localStorageUtils';
+import { isEmpty } from '../../../Common/utils/jsUtils';
 
 const history = createHistory();
 
@@ -205,7 +206,7 @@ class FilterQuery extends Component {
   componentDidMount() {
     const { dispatch, tableSchema, curQuery } = this.props;
     const limit = getPersistedPageSize();
-    if (!this.props.urlQuery) {
+    if (isEmpty(this.props.urlQuery)) {
       dispatch(setDefaultQuery({ ...curQuery, limit }));
       return;
     }

--- a/console/src/components/Services/Data/TableBrowseRows/ViewActions.js
+++ b/console/src/components/Services/Data/TableBrowseRows/ViewActions.js
@@ -97,7 +97,7 @@ const vMakeRowsRequest = () => {
             dispatch({
               type: V_REQUEST_SUCCESS,
               data: data[0],
-              estimatedCount: data[1].result[1],
+              estimatedCount: parseInt(data[1].result[1][0], 10),
             }),
             dispatch({ type: V_REQUEST_PROGRESS, data: false }),
           ]);
@@ -160,8 +160,7 @@ const vMakeCountRequest = () => {
 
 const vMakeTableRequests = () => (dispatch, getState) => {
   dispatch(vMakeRowsRequest()).then(() => {
-    const estimatedCountResult = getState().tables.view.estimatedCount[0];
-    const estimatedCount = parseInt(estimatedCountResult, 10);
+    const { estimatedCount } = getState().tables.view;
     if (estimatedCount > COUNT_LIMIT) {
       dispatch({
         type: V_COUNT_REQUEST_SUCCESS,

--- a/console/src/components/Services/Data/TableBrowseRows/ViewTable.js
+++ b/console/src/components/Services/Data/TableBrowseRows/ViewTable.js
@@ -110,6 +110,7 @@ class ViewTable extends Component {
       triggeredFunction,
       location,
       estimatedCount,
+      isCountEstimated,
     } = this.props;
 
     // check if table exists
@@ -161,7 +162,8 @@ class ViewTable extends Component {
     // Choose the right nav bar header thing
     const header = (
       <TableHeader
-        count={count}
+        count={isCountEstimated ? estimatedCount : count}
+        isCountEstimated={isCountEstimated}
         dispatch={dispatch}
         table={tableSchema}
         tabName="browse"

--- a/console/src/components/Services/Data/TableCommon/TableHeader.js
+++ b/console/src/components/Services/Data/TableCommon/TableHeader.js
@@ -22,10 +22,12 @@ import {
   getTableRelationshipsRoute,
 } from '../../../Common/utils/routesUtils';
 import { getReadableNumber } from '../../../Common/utils/jsUtils';
+import { COUNT_LIMIT } from '../constants';
 
 const TableHeader = ({
   tabName,
   count,
+  isCountEstimated,
   table,
   migrationMode,
   readOnlyMode,
@@ -39,7 +41,9 @@ const TableHeader = ({
 
   let countDisplay = '';
   if (!(count === null || count === undefined)) {
-    countDisplay = '(' + getReadableNumber(count) + ')';
+    countDisplay = `(${
+      isCountEstimated ? ` > ${COUNT_LIMIT} ` : getReadableNumber(count)
+    })`;
   }
   const activeTab = tabNameMap[tabName];
 

--- a/console/src/components/Services/Data/constants.js
+++ b/console/src/components/Services/Data/constants.js
@@ -38,6 +38,8 @@ export const Integers = [
   'bigint',
 ];
 
+export const COUNT_LIMIT = 100000;
+
 export const Reals = ['float4', 'float8', 'numeric'];
 
 export const Numerics = [...Integers, ...Reals];


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

#### Currently

On the browse rows page, console makes two concurrent queries:
1. A query to fetch the first 10 rows and make an estimated count
2. A query to get exact count

This query to get exact count overloads the database if the the table has large amount of data.

#### Fix

The browse rows page makes:
1. A query to fetch the first 10 rows and make an estimated count
2. If the estimated count is greater than 100000, the count is not shown (as the estimated count doesnt yet account for filters) and the pagination is rendered based on the estimated count.
3. If the estimated coutn is less than 100000, a query is made to fetch the exact count asynchronously. Until the exact count is fetched, the UI is rendered based on the estimated count.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
