### PR TITLE
docs: fix link in heroku deployment index

### DIFF
--- a/docs/graphql/manual/deployment/heroku/index.rst
+++ b/docs/graphql/manual/deployment/heroku/index.rst
@@ -113,7 +113,7 @@ Advanced
 - :ref:`heroku_existing_db`
 - :ref:`GraphQL engine server logs <heroku_logs>`
 - :ref:`Updating GraphQL engine <heroku_update>`
-- :ref:`Setting up migrations <auth>`
+- :ref:`Setting up migrations <migrations>`
 
 .. toctree::
    :titlesonly:


### PR DESCRIPTION
### Description

There is a link in Heroku deployment that points to authentication instead of migrations. This PR is fixing that link.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components

- [x] Docs

### Affected files

