### PR TITLE
console: refactor usage of react-router and `connect` function

### DIFF
--- a/console/src/components/Common/Layout/RightContainer/RightContainer.js
+++ b/console/src/components/Common/Layout/RightContainer/RightContainer.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 const RightContainer = ({ children }) => {
   const styles = require('./RightContainer.scss');
@@ -11,9 +12,7 @@ const RightContainer = ({ children }) => {
             styles.main + ' ' + styles.padd_left_remove + ' ' + styles.padd_top
           }
         >
-          <div className={styles.rightBar + ' '}>
-            {children && React.cloneElement(children)}
-          </div>
+          <div className={styles.rightBar + ' '}>{children}</div>
         </div>
       </div>
     </div>
@@ -26,7 +25,5 @@ const mapStateToProps = state => {
   };
 };
 
-const rightContainerConnector = connect =>
-  connect(mapStateToProps)(RightContainer);
-
-export default rightContainerConnector;
+const ConnectedRightContainer = connect(mapStateToProps)(RightContainer);
+export default ConnectedRightContainer;

--- a/console/src/components/Common/Layout/index.js
+++ b/console/src/components/Common/Layout/index.js
@@ -1,3 +1,3 @@
-import rightContainerConnector from './RightContainer/RightContainer';
+import ConnectedRightContainer from './RightContainer/RightContainer';
 
-export { rightContainerConnector };
+export { ConnectedRightContainer };

--- a/console/src/components/Login/Login.js
+++ b/console/src/components/Login/Login.js
@@ -6,6 +6,7 @@ import globals from '../../Globals';
 import { verifyLogin } from './Actions';
 import { CLI_CONSOLE_MODE } from '../../constants';
 import { getAdminSecret } from '../Services/ApiExplorer/ApiRequest/utils';
+import { connect } from 'react-redux';
 
 const styles = require('./Login.scss');
 const hasuraLogo = require('./blue-logo.svg');
@@ -153,8 +154,6 @@ const Login = ({ dispatch }) => {
   );
 };
 
-const generatedLoginConnector = connect => {
-  return connect()(Login);
-};
+const ConnectedLogin = connect()(Login);
 
-export default generatedLoginConnector;
+export default ConnectedLogin;

--- a/console/src/components/Services/About/About.js
+++ b/console/src/components/Services/About/About.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import Helmet from 'react-helmet';
 
 import Endpoints, { globalCookiePolicy } from '../../../Endpoints';
@@ -164,6 +165,5 @@ const mapStateToProps = state => {
   };
 };
 
-const aboutConnector = connect => connect(mapStateToProps)(About);
-
-export default aboutConnector;
+const ConnectedAbout = connect(mapStateToProps)(About);
+export default ConnectedAbout;

--- a/console/src/components/Services/Actions/Add/index.js
+++ b/console/src/components/Services/Actions/Add/index.js
@@ -1,4 +1,5 @@
 import AddAction from './Add';
+import { connect } from 'react-redux';
 
 const mapStateToProps = state => {
   return {
@@ -6,5 +7,5 @@ const mapStateToProps = state => {
   };
 };
 
-const connector = connect => connect(mapStateToProps)(AddAction);
-export default connector;
+const ConnectedAddAction = connect(mapStateToProps)(AddAction);
+export default ConnectedAddAction;

--- a/console/src/components/Services/Actions/Codegen/index.js
+++ b/console/src/components/Services/Actions/Codegen/index.js
@@ -1,4 +1,5 @@
 import Codegen from './Main';
+import { connect } from 'react-redux';
 
 const mapStateToProps = state => {
   return {
@@ -8,5 +9,5 @@ const mapStateToProps = state => {
   };
 };
 
-const connector = connect => connect(mapStateToProps)(Codegen);
-export default connector;
+const ConnectedCodegen = connect(mapStateToProps)(Codegen);
+export default ConnectedCodegen;

--- a/console/src/components/Services/Actions/Containers/Main.js
+++ b/console/src/components/Services/Actions/Containers/Main.js
@@ -7,6 +7,7 @@ import PageContainer from '../../../Common/Layout/PageContainer/PageContainer';
 import LeftSidebar from '../Sidebar/LeftSidebar';
 import styles from '../../../Common/TableCommon/Table.scss';
 import { appPrefix } from '../constants';
+import { connect } from 'react-redux';
 
 class Container extends React.Component {
   render() {
@@ -62,4 +63,5 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect => connect(mapStateToProps)(Container);
+const ConnectedActionsContainer = connect(mapStateToProps)(Container);
+export default ConnectedActionsContainer;

--- a/console/src/components/Services/Actions/Landing/index.js
+++ b/console/src/components/Services/Actions/Landing/index.js
@@ -1,4 +1,5 @@
 import Landing from './Main';
+import { connect } from 'react-redux';
 
 const mapStateToProps = state => {
   return {
@@ -6,5 +7,5 @@ const mapStateToProps = state => {
   };
 };
 
-const connector = connect => connect(mapStateToProps)(Landing);
-export default connector;
+const ConnectedLanding = connect(mapStateToProps)(Landing);
+export default ConnectedLanding;

--- a/console/src/components/Services/Actions/Modify/index.js
+++ b/console/src/components/Services/Actions/Modify/index.js
@@ -1,4 +1,5 @@
 import Modify from './Main';
+import { connect } from 'react-redux';
 
 const mapStateToProps = state => {
   return {
@@ -8,5 +9,5 @@ const mapStateToProps = state => {
   };
 };
 
-const connector = connect => connect(mapStateToProps)(Modify);
-export default connector;
+const ConnectedModify = connect(mapStateToProps)(Modify);
+export default ConnectedModify;

--- a/console/src/components/Services/Actions/Permissions/index.js
+++ b/console/src/components/Services/Actions/Permissions/index.js
@@ -1,4 +1,5 @@
 import Permissions from './Main';
+import { connect } from 'react-redux';
 
 const mapStateToProps = state => {
   return {
@@ -8,5 +9,5 @@ const mapStateToProps = state => {
   };
 };
 
-const connector = connect => connect(mapStateToProps)(Permissions);
-export default connector;
+const ConnectedActionPermissions = connect(mapStateToProps)(Permissions);
+export default ConnectedActionPermissions;

--- a/console/src/components/Services/Actions/Relationships/index.js
+++ b/console/src/components/Services/Actions/Relationships/index.js
@@ -1,4 +1,5 @@
 import Relationships from './Main';
+import { connect } from 'react-redux';
 
 const mapStateToProps = state => {
   return {
@@ -10,5 +11,5 @@ const mapStateToProps = state => {
   };
 };
 
-const connector = connect => connect(mapStateToProps)(Relationships);
-export default connector;
+const ConnectedActionRelationships = connect(mapStateToProps)(Relationships);
+export default ConnectedActionRelationships;

--- a/console/src/components/Services/Actions/Router.js
+++ b/console/src/components/Services/Actions/Router.js
@@ -1,17 +1,17 @@
 import React from 'react';
 import { Route, IndexRedirect } from 'react-router';
-import { rightContainerConnector } from '../../Common/Layout';
-import Container from './Containers/Main';
+import RightContainer from '../../Common/Layout';
+import ActionsContainer from './Containers/Main';
 import { fetchActions } from './ServerIO';
 import globals from '../../../Globals';
-import ActionsLandingPage from './Landing';
-import ActionRelationships from './Relationships';
-import ActionPermissions from './Permissions';
-import ActionsCodegen from './Codegen';
-import ModifyAction from './Modify';
-import AddAction from './Add';
-import TypesManage from './Types/Manage';
-import TypesRelationships from './Types/Relationships';
+import ConnectedAddAction from './Add';
+import ConnectedModify from './Modify';
+import ConnectedCodegen from './Codegen';
+import ConnectedManage from './Types/Manage';
+import ConnectedRelationships from './Types/Relationships';
+import ConnectedActionRelationships from './Relationships';
+import ConnectedActionPermissions from './Permissions';
+import ConnectedLanding from './Landing/';
 
 const actionsInit = ({ dispatch }) => {
   return (nextState, replaceState, cb) => {
@@ -31,30 +31,30 @@ const getActionsRouter = (connect, store, composeOnEnterHooks) => {
   return (
     <Route
       path="actions"
-      component={Container(connect)}
+      component={ActionsContainer}
       onEnter={composeOnEnterHooks([actionsInit(store)])}
       onChange={actionsInit(store)}
     >
       <IndexRedirect to="manage" />
-      <Route path="manage" component={rightContainerConnector(connect)}>
+      <Route path="manage" component={RightContainer}>
         <IndexRedirect to="actions" />
-        <Route path="actions" component={ActionsLandingPage(connect)} />
-        <Route path="add" component={AddAction(connect)} />
-        <Route path=":actionName/modify" component={ModifyAction(connect)} />
+        <Route path="actions" component={ConnectedLanding} />
+        <Route path="add" component={ConnectedAddAction} />
+        <Route path=":actionName/modify" component={ConnectedModify} />
         <Route
           path=":actionName/relationships"
-          component={ActionRelationships(connect)}
+          component={ConnectedActionRelationships}
         />
-        <Route path=":actionName/codegen" component={ActionsCodegen(connect)} />
+        <Route path=":actionName/codegen" component={ConnectedCodegen} />
         <Route
           path=":actionName/permissions"
-          component={ActionPermissions(connect)}
+          component={ConnectedActionPermissions}
         />
       </Route>
-      <Route path="types" component={rightContainerConnector(connect)}>
+      <Route path="types" component={RightContainer}>
         <IndexRedirect to="manage" />
-        <Route path="manage" component={TypesManage(connect)} />
-        <Route path="relationships" component={TypesRelationships(connect)} />
+        <Route path="manage" component={ConnectedManage} />
+        <Route path="relationships" component={ConnectedRelationships} />
       </Route>
     </Route>
   );

--- a/console/src/components/Services/Actions/Types/Manage/index.js
+++ b/console/src/components/Services/Actions/Types/Manage/index.js
@@ -1,4 +1,5 @@
 import Manage from './Main';
+import { connect } from 'react-redux';
 
 const mapStateToProps = state => {
   return {
@@ -7,5 +8,5 @@ const mapStateToProps = state => {
   };
 };
 
-const connector = connect => connect(mapStateToProps)(Manage);
-export default connector;
+const ConnectedManage = connect(mapStateToProps)(Manage);
+export default ConnectedManage;

--- a/console/src/components/Services/Actions/Types/Relationships/index.js
+++ b/console/src/components/Services/Actions/Types/Relationships/index.js
@@ -1,4 +1,5 @@
 import Relationships from './Main';
+import { connect } from 'react-redux';
 
 const mapStateToProps = state => {
   return {
@@ -7,5 +8,5 @@ const mapStateToProps = state => {
   };
 };
 
-const connector = connect => connect(mapStateToProps)(Relationships);
-export default connector;
+const ConnectedRelationships = connect(mapStateToProps)(Relationships);
+export default ConnectedRelationships;

--- a/console/src/components/Services/ApiExplorer/ApiExplorer.js
+++ b/console/src/components/Services/ApiExplorer/ApiExplorer.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 
@@ -107,19 +108,17 @@ ApiExplorer.propTypes = {
   location: PropTypes.object.isRequired,
 };
 
-const generatedApiExplorer = connect => {
-  const mapStateToProps = state => {
-    return {
-      ...state.apiexplorer,
-      serverVersion: state.main.serverVersion ? state.main.serverVersion : '',
-      credentials: {},
-      dataApiExplorerData: { ...state.dataApiExplorer },
-      dataHeaders: state.tables.dataHeaders,
-      tables: state.tables.allSchemas,
-      serverConfig: state.main.serverConfig ? state.main.serverConfig.data : {},
-    };
+const mapStateToProps = state => {
+  return {
+    ...state.apiexplorer,
+    serverVersion: state.main.serverVersion ? state.main.serverVersion : '',
+    credentials: {},
+    dataApiExplorerData: { ...state.dataApiExplorer },
+    dataHeaders: state.tables.dataHeaders,
+    tables: state.tables.allSchemas,
+    serverConfig: state.main.serverConfig ? state.main.serverConfig.data : {},
   };
-  return connect(mapStateToProps)(ApiExplorer);
 };
 
-export default generatedApiExplorer;
+const ConnectedApiExplorer = connect(mapStateToProps)(ApiExplorer);
+export default ConnectedApiExplorer;

--- a/console/src/components/Services/Data/Add/AddExistingTableView.js
+++ b/console/src/components/Services/Data/Add/AddExistingTableView.js
@@ -6,6 +6,7 @@ import {
   setDefaults,
   addExistingTableSql,
 } from './AddExistingTableViewActions';
+import { connect } from 'react-redux';
 
 class AddExistingTableView extends Component {
   constructor(props) {
@@ -110,7 +111,7 @@ const mapStateToProps = state => {
   };
 };
 
-const addExistingTableViewConnector = connect =>
-  connect(mapStateToProps)(AddExistingTableView);
-
-export default addExistingTableViewConnector;
+const ConnectedAddExistingTableView = connect(mapStateToProps)(
+  AddExistingTableView
+);
+export default ConnectedAddExistingTableView;

--- a/console/src/components/Services/Data/Add/AddTable.js
+++ b/console/src/components/Services/Data/Add/AddTable.js
@@ -55,6 +55,7 @@ import {
   uniqueKeyDescription,
   checkConstraintsDescription,
 } from '../Common/TooltipMessages';
+import { connect } from 'react-redux';
 
 /* AddTable is a wrapper which wraps
  *  1) Table Name input
@@ -588,6 +589,5 @@ const mapStateToProps = state => ({
   schemaList: state.tables.schemaList,
 });
 
-const addTableConnector = connect => connect(mapStateToProps)(AddTable);
-
-export default addTableConnector;
+const ConnectedAddTable = connect(mapStateToProps)(AddTable);
+export default ConnectedAddTable;

--- a/console/src/components/Services/Data/DataPageContainer.js
+++ b/console/src/components/Services/Data/DataPageContainer.js
@@ -11,6 +11,7 @@ import { updateCurrentSchema } from './DataActions';
 import { NotFoundError } from '../../Error/PageNotFound';
 import { CLI_CONSOLE_MODE } from '../../../constants';
 import { getSchemaBaseRoute } from '../../Common/utils/routesUtils';
+import { connect } from 'react-redux';
 
 const DataPageContainer = ({
   currentSchema,
@@ -121,7 +122,5 @@ const mapStateToProps = state => {
   };
 };
 
-const dataPageConnector = connect =>
-  connect(mapStateToProps)(DataPageContainer);
-
-export default dataPageConnector;
+const ConnectedDataPageContainer = connect(mapStateToProps)(DataPageContainer);
+export default ConnectedDataPageContainer;

--- a/console/src/components/Services/Data/DataRouter.js
+++ b/console/src/components/Services/Data/DataRouter.js
@@ -1,144 +1,125 @@
 import React from 'react';
-// import {push} fropm 'react-router-redux';
 import { Route, IndexRedirect } from 'react-router';
 import globals from '../../../Globals';
-// import { loadAdminSecretState } from '../../AppState';
 import { SERVER_CONSOLE_MODE } from '../../../constants';
 
-import {
-  schemaConnector,
-  viewTableConnector,
-  insertItemConnector,
-  rawSQLConnector,
-  editItemConnector,
-  addExistingTableViewConnector,
-  addTableConnector,
-  modifyTableConnector,
-  modifyViewConnector,
-  relationshipsConnector,
-  relationshipsViewConnector,
-  permissionsConnector,
-  dataPageConnector,
-  migrationsConnector,
-  functionWrapperConnector,
-  permissionsSummaryConnector,
-  ModifyCustomFunction,
-  PermissionCustomFunction,
-  // metadataConnector,
-} from '.';
-
-import { rightContainerConnector } from '../../Common/Layout';
+import { ModifyCustomFunction, PermissionCustomFunction } from '.';
 
 import {
   fetchDataInit,
   fetchFunctionInit,
   UPDATE_CURRENT_SCHEMA,
   updateSchemaInfo,
-  // ADMIN_SECRET_ERROR,
 } from './DataActions';
-
-// import { changeRequestHeader } from '../../ApiExplorer/Actions';
-// import { validateLogin } from '../../Main/Actions';
+import ConnectedDataPageContainer from './DataPageContainer';
+import { ConnectedRightContainer } from '../../Common/Layout';
+import ConnectedSchema from './Schema/Schema';
+import ConnectedFunctionWrapper from './Function/FunctionWrapper';
+import ConnectedViewTable from './TableBrowseRows/ViewTable';
+import ConnectedEditItem from './TableBrowseRows/EditItem';
+import ConnectedInsertItem from './TableInsertItem/InsertItem';
+import ConnectedModifyTable from './TableModify/ModifyTable';
+import ConnectedRelationships from './TableRelationships/Relationships';
+import ConnectedPermissions from './TablePermissions/Permissions';
+import ConnectedModifyView from './TableModify/ModifyView';
+import ConnectedRelationshipsView from './TableRelationships/RelationshipsView';
+import ConnectedPermissionsSummary from './PermissionsSummary/PermissionsSummary';
+import ConnectedAddTable from './Add/AddTable';
+import ConnectedAddExistingTableView from './Add/AddExistingTableView';
+import ConnectedRawSQL from './RawSQL/RawSQL';
+import ConnectedMigrations from './Migrations/Migrations';
 
 const makeDataRouter = (
-  connect,
-  store,
   composeOnEnterHooks,
-  requireSchema,
   migrationRedirects,
   consoleModeRedirects
 ) => {
+  console.log({ composeOnEnterHooks });
   return (
-    <Route path="data" component={dataPageConnector(connect)}>
+    <Route path="data" component={ConnectedDataPageContainer}>
       <IndexRedirect to="schema/public" />
-      <Route path="schema" component={rightContainerConnector(connect)}>
+      <Route path="schema" component={ConnectedRightContainer}>
         <IndexRedirect to="public" />
-        <Route path=":schema" component={schemaConnector(connect)} />
-        <Route path=":schema/tables" component={schemaConnector(connect)} />
-        <Route path=":schema/views" component={schemaConnector(connect)} />
+        <Route path=":schema" component={ConnectedSchema} />
+        <Route path=":schema/tables" component={ConnectedSchema} />
+        <Route path=":schema/views" component={ConnectedSchema} />
         <Route
           path=":schema/functions/:functionName"
-          component={functionWrapperConnector(connect)}
+          component={ConnectedFunctionWrapper}
         >
           <IndexRedirect to="modify" />
           <Route path="modify" component={ModifyCustomFunction} />
           <Route path="permissions" component={PermissionCustomFunction} />
         </Route>
-        <Route
-          path=":schema/tables/:table"
-          component={viewTableConnector(connect)}
-        >
+        <Route path=":schema/tables/:table" component={ConnectedViewTable}>
           <IndexRedirect to="browse" />
-          <Route path="browse" component={viewTableConnector(connect)} />
+          <Route path="browse" component={ConnectedViewTable} />
         </Route>
         <Route
           path=":schema/tables/:table/edit"
-          component={editItemConnector(connect)}
+          component={ConnectedEditItem}
         />
         <Route
           path=":schema/tables/:table/insert"
-          component={insertItemConnector(connect)}
+          component={ConnectedInsertItem}
         />
         <Route
           path=":schema/tables/:table/modify"
           onEnter={migrationRedirects}
-          component={modifyTableConnector(connect)}
+          component={ConnectedModifyTable}
         />
         <Route
           path=":schema/tables/:table/relationships"
-          component={relationshipsConnector(connect)}
+          component={ConnectedRelationships}
         />
         <Route
           path=":schema/tables/:table/permissions"
-          component={permissionsConnector(connect)}
+          component={ConnectedPermissions}
           tableType={'table'}
         />
         <Route
           path=":schema/views/:table/browse"
-          component={viewTableConnector(connect)}
+          component={ConnectedViewTable}
         />
         <Route
           path=":schema/views/:table/modify"
           onEnter={migrationRedirects}
-          component={modifyViewConnector(connect)}
+          component={ConnectedModifyView}
         />
         <Route
           path=":schema/views/:table/relationships"
-          component={relationshipsViewConnector(connect)}
+          component={ConnectedRelationshipsView}
         />
         <Route
           path=":schema/views/:table/permissions"
-          component={permissionsConnector(connect)}
+          component={ConnectedPermissions}
           tableType={'view'}
         />
         <Route
           path=":schema/permissions"
-          component={permissionsSummaryConnector(connect)}
+          component={ConnectedPermissionsSummary}
         />
       </Route>
       <Route
         path="schema/:schema/table/add"
         onEnter={composeOnEnterHooks([migrationRedirects])}
-        component={addTableConnector(connect)}
+        component={ConnectedAddTable}
       />
       <Route
         path="schema/:schema/existing-table-view/add"
-        component={addExistingTableViewConnector(connect)}
+        component={ConnectedAddExistingTableView}
       />
-      <Route path="sql" component={rawSQLConnector(connect)} />
-      {/*
-      <Route path="metadata" component={metadataConnector(connect)} />
-      */}
+      <Route path="sql" component={ConnectedRawSQL} />
       <Route
         path="migrations"
         onEnter={composeOnEnterHooks([consoleModeRedirects])}
-        component={migrationsConnector(connect)}
+        component={ConnectedMigrations}
       />
     </Route>
   );
 };
 
-const dataRouterUtils = (connect, store, composeOnEnterHooks) => {
+const dataRouterUtils = (store, composeOnEnterHooks) => {
   const requireSchema = (nextState, replaceState, cb) => {
     // check if admin secret is available in localstorage. if so use that.
     // if localstorage admin secret didn't work, redirect to login (meaning value has changed)
@@ -202,10 +183,7 @@ const dataRouterUtils = (connect, store, composeOnEnterHooks) => {
 
   return {
     makeDataRouter: makeDataRouter(
-      connect,
-      store,
       composeOnEnterHooks,
-      requireSchema,
       migrationRedirects,
       consoleModeRedirects
     ),

--- a/console/src/components/Services/Data/Function/FunctionWrapper.js
+++ b/console/src/components/Services/Data/Function/FunctionWrapper.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { RESET } from './customFunctionReducer';
 
 import { setTable } from '../DataActions';
+import { connect } from 'react-redux';
 
 class FunctionWrapper extends React.Component {
   componentDidMount() {
@@ -34,7 +35,5 @@ const mapStateToProps = state => {
   };
 };
 
-const functionWrapperConnector = connect =>
-  connect(mapStateToProps)(FunctionWrapper);
-
-export default functionWrapperConnector;
+const ConnectedFunctionWrapper = connect(mapStateToProps)(FunctionWrapper);
+export default ConnectedFunctionWrapper;

--- a/console/src/components/Services/Data/Migrations/Migrations.js
+++ b/console/src/components/Services/Data/Migrations/Migrations.js
@@ -4,6 +4,7 @@ import Helmet from 'react-helmet';
 import Toggle from '../../../Common/Toggle/Toggle';
 import { updateMigrationModeStatus } from '../../../Main/Actions';
 import { getConfirmation } from '../../../Common/utils/jsUtils';
+import { connect } from 'react-redux';
 
 const Migrations = ({ dispatch, migrationMode }) => {
   const styles = require('./Migrations.scss');
@@ -78,6 +79,5 @@ const mapStateToProps = state => ({
   migrationMode: state.main.migrationMode,
 });
 
-const migrationsConnector = connect => connect(mapStateToProps)(Migrations);
-
-export default migrationsConnector;
+const ConnectedMigrations = connect(mapStateToProps)(Migrations);
+export default ConnectedMigrations;

--- a/console/src/components/Services/Data/PermissionsSummary/PermissionsSummary.js
+++ b/console/src/components/Services/Data/PermissionsSummary/PermissionsSummary.js
@@ -32,6 +32,7 @@ import {
   getTablePermissionsByRoles,
   getPermissionRowAccessSummary,
 } from './utils';
+import { connect } from 'react-redux';
 
 class PermissionsSummary extends Component {
   initState = {
@@ -1054,14 +1055,14 @@ class PermissionsSummary extends Component {
   }
 }
 
-const permissionsSummaryConnector = connect => {
-  const mapStateToProps = state => {
-    return {
-      allSchemas: state.tables.allSchemas,
-      currentSchema: state.tables.currentSchema,
-    };
+const mapStateToProps = state => {
+  return {
+    allSchemas: state.tables.allSchemas,
+    currentSchema: state.tables.currentSchema,
   };
-  return connect(mapStateToProps)(PermissionsSummary);
 };
 
-export default permissionsSummaryConnector;
+const ConnectedPermissionsSummary = connect(mapStateToProps)(
+  PermissionsSummary
+);
+export default ConnectedPermissionsSummary;

--- a/console/src/components/Services/Data/RawSQL/RawSQL.js
+++ b/console/src/components/Services/Data/RawSQL/RawSQL.js
@@ -25,6 +25,7 @@ import {
   ACE_EDITOR_FONT_SIZE,
 } from '../../../Common/AceEditor/utils';
 import { CLI_CONSOLE_MODE } from '../../../../constants';
+import { connect } from 'react-redux';
 
 const RawSQL = ({
   sql,
@@ -555,6 +556,5 @@ const mapStateToProps = state => ({
   serverVersion: state.main.serverVersion ? state.main.serverVersion : '',
 });
 
-const rawSQLConnector = connect => connect(mapStateToProps)(RawSQL);
-
-export default rawSQLConnector;
+const ConnectedRawSQL = connect(mapStateToProps)(RawSQL);
+export default ConnectedRawSQL;

--- a/console/src/components/Services/Data/Schema/Schema.js
+++ b/console/src/components/Services/Data/Schema/Schema.js
@@ -39,6 +39,7 @@ import { getConfirmation } from '../../../Common/utils/jsUtils';
 import ToolTip from '../../../Common/Tooltip/Tooltip';
 import KnowMoreLink from '../../../Common/KnowMoreLink/KnowMoreLink';
 import RawSqlButton from '../Common/Components/RawSqlButton';
+import { connect } from 'react-redux';
 
 class Schema extends Component {
   constructor(props) {
@@ -731,6 +732,5 @@ const mapStateToProps = state => ({
   serverVersion: state.main.serverVersion ? state.main.serverVersion : '',
 });
 
-const schemaConnector = connect => connect(mapStateToProps)(Schema);
-
-export default schemaConnector;
+const ConnectedSchema = connect(mapStateToProps)(Schema);
+export default ConnectedSchema;

--- a/console/src/components/Services/Data/TableBrowseRows/EditItem.js
+++ b/console/src/components/Services/Data/TableBrowseRows/EditItem.js
@@ -13,6 +13,7 @@ import { findTable, generateTableDef } from '../../../Common/utils/pgUtils';
 import { getTableBrowseRoute } from '../../../Common/utils/routesUtils';
 import { TypedInput } from '../Common/Components/TypedInput';
 import { fetchEnumOptions } from './EditActions';
+import { connect } from 'react-redux';
 
 class EditItem extends Component {
   constructor() {
@@ -250,6 +251,5 @@ const mapStateToProps = (state, ownProps) => {
   };
 };
 
-const editItemConnector = connect => connect(mapStateToProps)(EditItem);
-
-export default editItemConnector;
+const ConnectedEditItem = connect(mapStateToProps)(EditItem);
+export default ConnectedEditItem;

--- a/console/src/components/Services/Data/TableBrowseRows/ViewTable.js
+++ b/console/src/components/Services/Data/TableBrowseRows/ViewTable.js
@@ -16,6 +16,7 @@ import ViewRows from './ViewRows';
 import { NotFoundError } from '../../../Error/PageNotFound';
 import { exists } from '../../../Common/utils/jsUtils';
 import { getPersistedPageSize } from './localStorageUtils';
+import { connect } from 'react-redux';
 
 class ViewTable extends Component {
   constructor(props) {
@@ -226,6 +227,5 @@ const mapStateToProps = (state, ownProps) => {
   };
 };
 
-const viewTableConnector = connect => connect(mapStateToProps)(ViewTable);
-
-export default viewTableConnector;
+const ConnectedViewTable = connect(mapStateToProps)(ViewTable);
+export default ConnectedViewTable;

--- a/console/src/components/Services/Data/TableInsertItem/InsertItem.js
+++ b/console/src/components/Services/Data/TableInsertItem/InsertItem.js
@@ -15,6 +15,7 @@ import {
 } from '../../../Common/utils/pgUtils';
 import { TypedInput } from '../Common/Components/TypedInput';
 import styles from '../../../Common/TableCommon/Table.scss';
+import { connect } from 'react-redux';
 
 class InsertItem extends Component {
   constructor() {
@@ -310,6 +311,5 @@ const mapStateToProps = (state, ownProps) => {
   };
 };
 
-const insertItemConnector = connect => connect(mapStateToProps)(InsertItem);
-
-export default insertItemConnector;
+const ConnectedInsertItem = connect(mapStateToProps)(InsertItem);
+export default ConnectedInsertItem;

--- a/console/src/components/Services/Data/TableModify/ModifyTable.js
+++ b/console/src/components/Services/Data/TableModify/ModifyTable.js
@@ -51,6 +51,7 @@ import {
   uniqueKeyDescription,
   checkConstraintsDescription,
 } from '../Common/TooltipMessages';
+import { connect } from 'react-redux';
 
 class ModifyTable extends React.Component {
   componentDidMount() {
@@ -357,6 +358,5 @@ const mapStateToProps = (state, ownProps) => ({
   ...state.tables.modify,
 });
 
-const modifyTableConnector = connect => connect(mapStateToProps)(ModifyTable);
-
-export default modifyTableConnector;
+const ConnectedModifyTable = connect(mapStateToProps)(ModifyTable);
+export default ConnectedModifyTable;

--- a/console/src/components/Services/Data/TableModify/ModifyView.js
+++ b/console/src/components/Services/Data/TableModify/ModifyView.js
@@ -28,6 +28,7 @@ import RootFields from './RootFields';
 import Tooltip from '../../../Common/Tooltip/Tooltip';
 import { changeViewRootFields } from '../Common/TooltipMessages';
 import styles from './ModifyTable.scss';
+import { connect } from 'react-redux';
 
 const ModifyView = props => {
   const {
@@ -350,6 +351,5 @@ const mapStateToProps = (state, ownProps) => {
   };
 };
 
-const modifyViewConnector = connect => connect(mapStateToProps)(ModifyView);
-
-export default modifyViewConnector;
+const ConnectedModifyView = connect(mapStateToProps)(ModifyView);
+export default ConnectedModifyView;

--- a/console/src/components/Services/Data/TablePermissions/Permissions.js
+++ b/console/src/components/Services/Data/TablePermissions/Permissions.js
@@ -92,6 +92,7 @@ import {
   getDefaultFilterType,
   getUpdateTooltip,
 } from './utils';
+import { connect } from 'react-redux';
 
 class Permissions extends Component {
   constructor() {
@@ -1968,6 +1969,5 @@ const mapStateToProps = (state, ownProps) => ({
   ...state.tables.modify,
 });
 
-const permissionsConnector = connect => connect(mapStateToProps)(Permissions);
-
-export default permissionsConnector;
+const ConnectedPermissions = connect(mapStateToProps)(Permissions);
+export default ConnectedPermissions;

--- a/console/src/components/Services/Data/TableRelationships/Relationships.js
+++ b/console/src/components/Services/Data/TableRelationships/Relationships.js
@@ -22,6 +22,7 @@ import AddManualRelationship from './AddManualRelationship';
 import suggestedRelationshipsRaw from './autoRelations';
 import RelationshipEditor from './RelationshipEditor';
 import { NotFoundError } from '../../../Error/PageNotFound';
+import { connect } from 'react-redux';
 
 const addRelationshipCellView = (
   dispatch,
@@ -515,7 +516,5 @@ const mapStateToProps = (state, ownProps) => ({
   ...state.tables.modify,
 });
 
-const relationshipsConnector = connect =>
-  connect(mapStateToProps)(Relationships);
-
-export default relationshipsConnector;
+const ConnectedRelationships = connect(mapStateToProps)(Relationships);
+export default ConnectedRelationships;

--- a/console/src/components/Services/Data/TableRelationships/RelationshipsView.js
+++ b/console/src/components/Services/Data/TableRelationships/RelationshipsView.js
@@ -8,6 +8,7 @@ import { setTable, UPDATE_REMOTE_SCHEMA_MANUAL_REL } from '../DataActions';
 import AddManualRelationship from './AddManualRelationship';
 import RelationshipEditor from './RelationshipEditor';
 import { NotFoundError } from '../../../Error/PageNotFound';
+import { connect } from 'react-redux';
 
 class RelationshipsView extends Component {
   componentDidMount() {
@@ -190,7 +191,5 @@ const mapStateToProps = (state, ownProps) => ({
   ...state.tables.modify,
 });
 
-const relationshipsViewConnector = connect =>
-  connect(mapStateToProps)(RelationshipsView);
-
-export default relationshipsViewConnector;
+const ConnectedRelationshipsView = connect(mapStateToProps)(RelationshipsView);
+export default ConnectedRelationshipsView;

--- a/console/src/components/Services/Data/index.js
+++ b/console/src/components/Services/Data/index.js
@@ -5,30 +5,12 @@
  *
  */
 
-export dataPageConnector from './DataPageContainer';
-export PageContainer from './DataSubSidebar';
-export viewTableConnector from './TableBrowseRows/ViewTable';
-export addExistingTableViewConnector from './Add/AddExistingTableView';
-export addTableConnector from './Add/AddTable';
-export rawSQLConnector from './RawSQL/RawSQL';
-export permissionsSummaryConnector from './PermissionsSummary/PermissionsSummary';
-export insertItemConnector from './TableInsertItem/InsertItem';
-export editItemConnector from './TableBrowseRows/EditItem';
-export modifyTableConnector from './TableModify/ModifyTable';
-export modifyViewConnector from './TableModify/ModifyView';
-export relationshipsConnector from './TableRelationships/Relationships';
-export relationshipsViewConnector from './TableRelationships/RelationshipsView';
-export permissionsConnector from './TablePermissions/Permissions';
-export schemaConnector from './Schema/Schema';
-export migrationsConnector from './Migrations/Migrations';
-
 export dataRouterUtils from './DataRouter';
 
 export dataReducer from './DataReducer';
 
 /* Function component */
 
-export functionWrapperConnector from './Function/FunctionWrapper';
 export ModifyCustomFunction from './Function/Modify/ModifyCustomFunction';
 export PermissionCustomFunction from './Function/Permission/Permission';
 

--- a/console/src/components/Services/EventTrigger/Add/AddTrigger.js
+++ b/console/src/components/Services/EventTrigger/Add/AddTrigger.js
@@ -39,6 +39,7 @@ import {
   getTableName,
   getTrackedTables,
 } from '../../../Common/utils/pgUtils';
+import { connect } from 'react-redux';
 
 class AddTrigger extends Component {
   constructor(props) {
@@ -624,6 +625,5 @@ const mapStateToProps = state => {
   };
 };
 
-const addTriggerConnector = connect => connect(mapStateToProps)(AddTrigger);
-
-export default addTriggerConnector;
+const ConnectedAddTrigger = connect(mapStateToProps)(AddTrigger);
+export default ConnectedAddTrigger;

--- a/console/src/components/Services/EventTrigger/EventPageContainer.js
+++ b/console/src/components/Services/EventTrigger/EventPageContainer.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router';
 import PageContainer from '../../Common/Layout/PageContainer/PageContainer';
 import LeftContainer from '../../Common/Layout/LeftContainer/LeftContainer';
 import EventSubSidebar from './EventSubSidebar';
+import { connect } from 'react-redux';
 
 const appPrefix = '/events';
 
@@ -58,7 +59,7 @@ const mapStateToProps = state => {
   };
 };
 
-const eventPageConnector = connect =>
-  connect(mapStateToProps)(EventPageContainer);
-
-export default eventPageConnector;
+const ConnectedEventPageContainer = connect(mapStateToProps)(
+  EventPageContainer
+);
+export default ConnectedEventPageContainer;

--- a/console/src/components/Services/EventTrigger/EventRouter.js
+++ b/console/src/components/Services/EventTrigger/EventRouter.js
@@ -3,75 +3,67 @@ import React from 'react';
 import { Route, IndexRedirect } from 'react-router';
 import globals from '../../../Globals';
 
-import {
-  landingConnector,
-  addTriggerConnector,
-  modifyTriggerConnector,
-  processedEventsConnector,
-  pendingEventsConnector,
-  runningEventsConnector,
-  eventPageConnector,
-  streamingLogsConnector,
-} from '.';
-
-import { rightContainerConnector } from '../../Common/Layout';
+import { ConnectedRightContainer } from '../../Common/Layout';
 
 import {
   loadTriggers,
   loadPendingEvents,
   loadRunningEvents,
 } from '../EventTrigger/EventActions';
+import ConnectedEventPageContainer from './EventPageContainer';
+import ConnectedEventTriggerLanding from './Landing/EventTrigger';
+import ConnectedProcessedEventsViewTable from './ProcessedEvents/ViewTable';
+import ConnectedPendingEventsViewTable from './PendingEvents/ViewTable';
+import ConnectedRunningEventsViewTable from './RunningEvents/ViewTable';
+import ConnectedStreamingLogs from './StreamingLogs/Logs';
+import ConnectedAddTrigger from './Add/AddTrigger';
+import ConnectedModifyTrigger from './Modify/Connector';
 
-const makeEventRouter = (
-  connect,
-  store,
+const makeEventRouter = ({
   composeOnEnterHooks,
   requireSchema,
   requirePendingEvents,
-  requireRunningEvents
-) => {
+  requireRunningEvents,
+}) => {
   return (
     <Route
       path="events"
-      component={eventPageConnector(connect)}
+      component={ConnectedEventPageContainer}
       onEnter={composeOnEnterHooks([requireSchema])}
     >
       <IndexRedirect to="manage" />
-      <Route path="manage" component={rightContainerConnector(connect)}>
+      <Route path="manage" component={ConnectedRightContainer}>
         <IndexRedirect to="triggers" />
-        <Route path="triggers" component={landingConnector(connect)} />
+        <Route path="triggers" component={ConnectedEventTriggerLanding} />
         <Route
           path="triggers/:trigger/processed"
-          component={processedEventsConnector(connect)}
+          component={ConnectedProcessedEventsViewTable}
         />
         <Route
           path="triggers/:trigger/pending"
-          component={pendingEventsConnector(connect)}
+          component={ConnectedPendingEventsViewTable}
           onEnter={composeOnEnterHooks([requirePendingEvents])}
         />
         <Route
           path="triggers/:trigger/running"
-          component={runningEventsConnector(connect)}
+          component={ConnectedRunningEventsViewTable}
           onEnter={composeOnEnterHooks([requireRunningEvents])}
         />
         <Route
           path="triggers/:trigger/logs"
-          component={streamingLogsConnector(connect)}
+          component={ConnectedStreamingLogs}
         />
       </Route>
-      <Route
-        path="manage/triggers/add"
-        component={addTriggerConnector(connect)}
-      />
+      <Route path="manage/triggers/add" component={ConnectedAddTrigger} />
       <Route
         path="manage/triggers/:trigger/modify"
-        component={modifyTriggerConnector(connect)}
+        component={ConnectedModifyTrigger}
       />
     </Route>
   );
 };
 
-const eventRouterUtils = (connect, store, composeOnEnterHooks) => {
+const eventRouterUtils = (store, composeOnEnterHooks) => {
   const requireSchema = (nextState, replaceState, cb) => {
     // check if admin secret is available in localstorage. if so use that.
     // if localstorage admin secret didn't work, redirect to login (meaning value has changed)
@@ -144,14 +136,12 @@ const eventRouterUtils = (connect, store, composeOnEnterHooks) => {
   };
 
   return {
-    makeEventRouter: makeEventRouter(
-      connect,
-      store,
+    makeEventRouter: makeEventRouter({
       composeOnEnterHooks,
       requireSchema,
       requirePendingEvents,
-      requireRunningEvents
-    ),
+      requireRunningEvents,
+    }),
     requireSchema,
   };
 };

--- a/console/src/components/Services/EventTrigger/Landing/EventTrigger.js
+++ b/console/src/components/Services/EventTrigger/Landing/EventTrigger.js
@@ -11,6 +11,7 @@ import globals from '../../../../Globals';
 import Button from '../../../Common/Button/Button';
 import TopicDescription from '../../Common/Landing/TopicDescription';
 import TryItOut from '../../Common/Landing/TryItOut';
+import { connect } from 'react-redux';
 
 const appPrefix = globals.urlPrefix + '/events';
 
@@ -120,6 +121,5 @@ const mapStateToProps = state => ({
   readOnlyMode: state.main.readOnlyMode,
 });
 
-const eventTriggerConnector = connect => connect(mapStateToProps)(EventTrigger);
-
-export default eventTriggerConnector;
+const ConnectedEventTriggerLanding = connect(mapStateToProps)(EventTrigger);
+export default ConnectedEventTriggerLanding;

--- a/console/src/components/Services/EventTrigger/Modify/Connector.js
+++ b/console/src/components/Services/EventTrigger/Modify/Connector.js
@@ -1,4 +1,5 @@
 import Modify from './Modify';
+import { connect } from 'react-redux';
 
 const mapStateToProps = (state, ownProps) => {
   return {
@@ -13,6 +14,5 @@ const mapStateToProps = (state, ownProps) => {
   };
 };
 
-const modifyTriggerConnector = connect => connect(mapStateToProps)(Modify);
-
-export default modifyTriggerConnector;
+const ConnectedModifyTrigger = connect(mapStateToProps)(Modify);
+export default ConnectedModifyTrigger;

--- a/console/src/components/Services/EventTrigger/PendingEvents/ViewTable.js
+++ b/console/src/components/Services/EventTrigger/PendingEvents/ViewTable.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { vSetDefaults, vMakeRequest, vExpandHeading } from './ViewActions'; // eslint-disable-line no-unused-vars
 import { setTrigger } from '../EventActions';
 import TableHeader from '../TableCommon/TableHeader';
@@ -210,6 +211,5 @@ const mapStateToProps = (state, ownProps) => {
   };
 };
 
-const pendingEventsConnector = connect => connect(mapStateToProps)(ViewTable);
-
-export default pendingEventsConnector;
+const ConnectedPendingEventsViewTable = connect(mapStateToProps)(ViewTable);
+export default ConnectedPendingEventsViewTable;

--- a/console/src/components/Services/EventTrigger/ProcessedEvents/ViewTable.js
+++ b/console/src/components/Services/EventTrigger/ProcessedEvents/ViewTable.js
@@ -5,6 +5,7 @@ import { setTrigger } from '../EventActions';
 import TableHeader from '../TableCommon/TableHeader';
 import ViewRows from './ViewRows';
 import { NotFoundError } from '../../../Error/PageNotFound';
+import { connect } from 'react-redux';
 
 /* Functions are unused
 const genHeadings = headings => {
@@ -220,6 +221,5 @@ const mapStateToProps = (state, ownProps) => {
   };
 };
 
-const processedEventsConnector = connect => connect(mapStateToProps)(ViewTable);
-
-export default processedEventsConnector;
+const ConnectedProcessedEventsViewTable = connect(mapStateToProps)(ViewTable);
+export default ConnectedProcessedEventsViewTable;

--- a/console/src/components/Services/EventTrigger/RunningEvents/ViewTable.js
+++ b/console/src/components/Services/EventTrigger/RunningEvents/ViewTable.js
@@ -5,6 +5,7 @@ import { setTrigger } from '../EventActions';
 import TableHeader from '../TableCommon/TableHeader';
 import ViewRows from './ViewRows';
 import { NotFoundError } from '../../../Error/PageNotFound';
+import { connect } from 'react-redux';
 
 /* Functions are unused
 const genHeadings = headings => {
@@ -212,6 +213,5 @@ const mapStateToProps = (state, ownProps) => {
   };
 };
 
-const runningEventsConnector = connect => connect(mapStateToProps)(ViewTable);
-
-export default runningEventsConnector;
+const ConnectedRunningEventsViewTable = connect(mapStateToProps)(ViewTable);
+export default ConnectedRunningEventsViewTable;

--- a/console/src/components/Services/EventTrigger/StreamingLogs/Logs.js
+++ b/console/src/components/Services/EventTrigger/StreamingLogs/Logs.js
@@ -29,6 +29,7 @@ import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import { convertDateTimeToLocale } from '../utils';
 import Button from '../../../Common/Button/Button';
 import { NotFoundError } from '../../../Error/PageNotFound';
+import { connect } from 'react-redux';
 
 class StreamingLogs extends Component {
   constructor(props) {
@@ -468,7 +469,5 @@ const mapStateToProps = (state, ownProps) => {
   };
 };
 
-const streamingLogsConnector = connect =>
-  connect(mapStateToProps)(StreamingLogs);
-
-export default streamingLogsConnector;
+const ConnectedStreamingLogs = connect(mapStateToProps)(StreamingLogs);
+export default ConnectedStreamingLogs;

--- a/console/src/components/Services/EventTrigger/index.js
+++ b/console/src/components/Services/EventTrigger/index.js
@@ -1,13 +1,3 @@
-export eventPageConnector from './EventPageContainer';
 export eventRouterUtils from './EventRouter';
 
 export eventReducer from './EventReducer';
-export addTriggerConnector from './Add/AddTrigger';
-
-export modifyTriggerConnector from './Modify/Connector';
-
-export processedEventsConnector from './ProcessedEvents/ViewTable';
-export pendingEventsConnector from './PendingEvents/ViewTable';
-export runningEventsConnector from './RunningEvents/ViewTable';
-export streamingLogsConnector from './StreamingLogs/Logs';
-export landingConnector from './Landing/EventTrigger';

--- a/console/src/components/Services/RemoteSchema/Add/Add.js
+++ b/console/src/components/Services/RemoteSchema/Add/Add.js
@@ -6,6 +6,7 @@ import Helmet from 'react-helmet';
 import Button from '../../../Common/Button/Button';
 
 import { pageTitle } from '../constants';
+import { connect } from 'react-redux';
 
 class Add extends React.Component {
   componentWillUnmount() {
@@ -55,4 +56,5 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect => connect(mapStateToProps)(Add);
+const ConnectedAdd = connect(mapStateToProps)(Add);
+export default ConnectedAdd;

--- a/console/src/components/Services/RemoteSchema/Edit/Edit.js
+++ b/console/src/components/Services/RemoteSchema/Edit/Edit.js
@@ -22,6 +22,7 @@ import { NotFoundError } from '../../../Error/PageNotFound';
 
 import globals from '../../../../Globals';
 import { getConfirmation } from '../../../Common/utils/jsUtils';
+import { connect } from 'react-redux';
 
 const prefixUrl = globals.urlPrefix + appPrefix;
 
@@ -257,4 +258,5 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect => connect(mapStateToProps)(Edit);
+const ConnectedEdit = connect(mapStateToProps)(Edit);
+export default ConnectedEdit;

--- a/console/src/components/Services/RemoteSchema/Edit/View.js
+++ b/console/src/components/Services/RemoteSchema/Edit/View.js
@@ -20,6 +20,7 @@ import { appPrefix } from '../constants';
 import { NotFoundError } from '../../../Error/PageNotFound';
 
 import globals from '../../../../Globals';
+import { connect } from 'react-redux';
 
 const prefixUrl = globals.urlPrefix + appPrefix;
 
@@ -213,4 +214,5 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect => connect(mapStateToProps)(ViewStitchedSchema);
+const ConnectedView = connect(mapStateToProps)(ViewStitchedSchema);
+export default ConnectedView;

--- a/console/src/components/Services/RemoteSchema/Landing/RemoteSchema.js
+++ b/console/src/components/Services/RemoteSchema/Landing/RemoteSchema.js
@@ -7,6 +7,7 @@ import globals from '../../../../Globals';
 import Button from '../../../Common/Button/Button';
 import TopicDescription from '../../Common/Landing/TopicDescription';
 import TryItOut from '../../Common/Landing/TryItOut';
+import { connect } from 'react-redux';
 
 class RemoteSchema extends React.Component {
   render() {
@@ -86,6 +87,5 @@ const mapStateToProps = state => {
   };
 };
 
-const remoteSchemaConnector = connect => connect(mapStateToProps)(RemoteSchema);
-
-export default remoteSchemaConnector;
+const ConnectedRemoteSchemaLanding = connect(mapStateToProps)(RemoteSchema);
+export default ConnectedRemoteSchemaLanding;

--- a/console/src/components/Services/RemoteSchema/RemoteSchemaPageContainer.js
+++ b/console/src/components/Services/RemoteSchema/RemoteSchemaPageContainer.js
@@ -5,11 +5,14 @@ import PropTypes from 'prop-types';
 import LeftContainer from '../../Common/Layout/LeftContainer/LeftContainer';
 import PageContainer from '../../Common/Layout/PageContainer/PageContainer';
 import RemoteSchemaSubSidebar from './RemoteSchemaSubSidebar';
+import { appPrefix } from './constants';
+import { filterItem } from './utils';
+import { connect } from 'react-redux';
 
 class RemoteSchemaPageContainer extends React.Component {
   render() {
     const styles = require('../../Common/TableCommon/Table.scss');
-    const { appPrefix, children } = this.props;
+    const { children } = this.props;
 
     const currentLocation = location.pathname;
 
@@ -47,5 +50,27 @@ RemoteSchemaPageContainer.propTypes = {
   appPrefix: PropTypes.string.isRequired,
 };
 
-export default (connect, mapStateToProps, mapDispatchToProps) =>
-  connect(mapStateToProps, mapDispatchToProps)(RemoteSchemaPageContainer);
+const mapStateToProps = state => {
+  return {
+    ...state,
+    dataList: [...state.remoteSchemas.listData.remoteSchemas],
+    isError: state.remoteSchemas.listData.isError,
+    isRequesting: state.remoteSchemas.listData.isRequesting,
+    filtered: [...state.remoteSchemas.listData.filtered],
+    searchQuery: state.remoteSchemas.listData.searchQuery,
+    viewRemoteSchema: state.remoteSchemas.listData.viewRemoteSchema,
+    appPrefix,
+  };
+};
+
+const mapDispatchToProps = dispatch => {
+  return {
+    filterItem: filterItem(dispatch),
+  };
+};
+
+const ConnectedRemoteSchemaPageContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(RemoteSchemaPageContainer);
+export default ConnectedRemoteSchemaPageContainer;

--- a/console/src/components/Services/RemoteSchema/RemoteSchemaRouter.js
+++ b/console/src/components/Services/RemoteSchema/RemoteSchemaRouter.js
@@ -1,62 +1,19 @@
 import React from 'react';
 
 import { Route, IndexRedirect } from 'react-router';
-import { rightContainerConnector } from '../../Common/Layout';
+import { ConnectedRightContainer } from '../../Common/Layout';
 import globals from '../../../Globals';
-import {
-  remoteSchemaPageConnector,
-  landingConnector,
-  addConnector,
-  editConnector,
-  viewConnector,
-} from '.';
-import { fetchRemoteSchemas, FILTER_REMOTE_SCHEMAS } from './Actions';
+import { fetchRemoteSchemas } from './Actions';
+import ConnectedRemoteSchemaPageContainer from './RemoteSchemaPageContainer';
+import ConnectedRemoteSchemaLanding from './Landing/RemoteSchema';
+import ConnectedAdd from './Add/Add';
+import ConnectedView from './Edit/View';
+import ConnectedEdit from './Edit/Edit';
 
 // Objective is to render list of custom remoteSchemas on the
 // left nav bar.
 // Custom remoteSchemas list is fetched from hdb_catalog/custom_remoteSchema
 // Whenever any operation happens like add remoteSchema/delete remoteSchema, this state should update automatically.
-
-import { appPrefix } from './constants';
-
-const filterItem = dispatch => {
-  return (dataList, searchVal) => {
-    // form new schema
-    const matchedTables = dataList.filter(data => {
-      return (
-        data.name
-          .toLowerCase()
-          .indexOf(searchVal ? searchVal.toLowerCase() : '') !== -1
-      );
-    });
-    dispatch({
-      type: FILTER_REMOTE_SCHEMAS,
-      data: {
-        filtered: matchedTables,
-        searchQuery: searchVal,
-      },
-    });
-  };
-};
-
-const leftNavMapStateToProps = state => {
-  return {
-    ...state,
-    dataList: [...state.remoteSchemas.listData.remoteSchemas],
-    isError: state.remoteSchemas.listData.isError,
-    isRequesting: state.remoteSchemas.listData.isRequesting,
-    filtered: [...state.remoteSchemas.listData.filtered],
-    searchQuery: state.remoteSchemas.listData.searchQuery,
-    viewRemoteSchema: state.remoteSchemas.listData.viewRemoteSchema,
-    appPrefix,
-  };
-};
-
-const leftNavMapDispatchToProps = dispatch => {
-  return {
-    filterItem: filterItem(dispatch),
-  };
-};
 
 const fetchInitialData = ({ dispatch }) => {
   return (nextState, replaceState, cb) => {
@@ -82,35 +39,24 @@ const fetchInitialData = ({ dispatch }) => {
   };
 };
 
-const getRemoteSchemaRouter = (connect, store, composeOnEnterHooks) => {
+const getRemoteSchemaRouter = (store, composeOnEnterHooks) => {
   return (
     <Route
       path="remote-schemas"
-      component={remoteSchemaPageConnector(
-        connect,
-        leftNavMapStateToProps,
-        leftNavMapDispatchToProps
-      )}
+      component={ConnectedRemoteSchemaPageContainer}
       onEnter={composeOnEnterHooks([fetchInitialData(store)])}
       onChange={fetchInitialData(store)}
     >
       <IndexRedirect to="manage" />
-      <Route path="manage" component={rightContainerConnector(connect)}>
+      <Route path="manage" component={ConnectedRightContainer}>
         <IndexRedirect to="schemas" />
-        <Route path="schemas" component={landingConnector(connect)} />
-        <Route path="add" component={addConnector(connect)} />
-        <Route
-          path=":remoteSchemaName/details"
-          component={viewConnector(connect)}
-        />
-        <Route
-          path=":remoteSchemaName/modify"
-          component={editConnector(connect)}
-        />
+        <Route path="schemas" component={ConnectedRemoteSchemaLanding} />
+        <Route path="add" component={ConnectedAdd} />
+        <Route path=":remoteSchemaName/details" component={ConnectedView} />
+        <Route path=":remoteSchemaName/modify" component={ConnectedEdit} />
       </Route>
     </Route>
   );
 };
 
 export default getRemoteSchemaRouter;
-export { appPrefix };

--- a/console/src/components/Services/RemoteSchema/index.js
+++ b/console/src/components/Services/RemoteSchema/index.js
@@ -1,9 +1,3 @@
-export remoteSchemaPageConnector from './RemoteSchemaPageContainer';
-export landingConnector from './Landing/RemoteSchema';
-export addConnector from './Add/Add';
-export editConnector from './Edit/Edit';
-export viewConnector from './Edit/View';
-
 export getRemoteSchemaRouter from './RemoteSchemaRouter';
 
 export remoteSchemaReducer from './remoteSchemaReducer';

--- a/console/src/components/Services/RemoteSchema/utils.js
+++ b/console/src/components/Services/RemoteSchema/utils.js
@@ -1,3 +1,25 @@
+import { FILTER_REMOTE_SCHEMAS } from './Actions';
+
 export const getAllRemoteSchemas = getState => {
   return getState().remoteSchemas.listData.remoteSchemas;
+};
+
+export const filterItem = dispatch => {
+  return (dataList, searchVal) => {
+    // form new schema
+    const matchedTables = dataList.filter(data => {
+      return (
+        data.name
+          .toLowerCase()
+          .indexOf(searchVal ? searchVal.toLowerCase() : '') !== -1
+      );
+    });
+    dispatch({
+      type: FILTER_REMOTE_SCHEMAS,
+      data: {
+        filtered: matchedTables,
+        searchQuery: searchVal,
+      },
+    });
+  };
 };

--- a/console/src/components/Services/Settings/AllowedQueries/AllowedQueries.js
+++ b/console/src/components/Services/Settings/AllowedQueries/AllowedQueries.js
@@ -7,6 +7,7 @@ import AllowedQueriesList from './AllowedQueriesList';
 import styles from './AllowedQueries.scss';
 
 import { loadAllowedQueries } from '../Actions';
+import { connect } from 'react-redux';
 
 class AllowedQueries extends React.Component {
   constructor(props) {
@@ -53,7 +54,5 @@ const mapStateToProps = state => {
   };
 };
 
-const allowedQueriesConnector = connect =>
-  connect(mapStateToProps)(AllowedQueries);
-
-export default allowedQueriesConnector;
+const ConnectedAllowedQueries = connect(mapStateToProps)(AllowedQueries);
+export default ConnectedAllowedQueries;

--- a/console/src/components/Services/Settings/Container.js
+++ b/console/src/components/Services/Settings/Container.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Sidebar from './Sidebar';
 import PageContainer from '../../Common/Layout/PageContainer/PageContainer';
+import { connect } from 'react-redux';
 
 const Container = ({ location, children, metadata }) => {
   const helmet = 'Settings | Hasura';
@@ -25,6 +26,5 @@ const mapStateToProps = state => {
   };
 };
 
-const connector = connect => connect(mapStateToProps)(Container);
-
-export default connector;
+const ConnectedSettings = connect(mapStateToProps)(Container);
+export default ConnectedSettings;

--- a/console/src/components/Services/Settings/Logout/Logout.js
+++ b/console/src/components/Services/Settings/Logout/Logout.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ClearAdminSecret from './ClearAdminSecret';
+import { connect } from 'react-redux';
 
 const Logout = props => {
   const styles = require('../Settings.scss');
@@ -39,6 +40,5 @@ const mapStateToProps = state => {
   };
 };
 
-const logoutConnector = connect => connect(mapStateToProps)(Logout);
-
-export default logoutConnector;
+const ConnectedLogout = connect(mapStateToProps)(Logout);
+export default ConnectedLogout;

--- a/console/src/components/Services/Settings/MetadataOptions/MetadataOptions.js
+++ b/console/src/components/Services/Settings/MetadataOptions/MetadataOptions.js
@@ -3,6 +3,7 @@ import ExportMetadata from './ExportMetadata';
 import ImportMetadata from './ImportMetadata';
 import ReloadMetadata from './ReloadMetadata';
 import ResetMetadata from './ResetMetadata';
+import { connect } from 'react-redux';
 
 const MetadataOptions = props => {
   const styles = require('../Settings.scss');
@@ -97,7 +98,5 @@ const mapStateToProps = state => {
   };
 };
 
-const metadataOptsConnector = connect =>
-  connect(mapStateToProps)(MetadataOptions);
-
-export default metadataOptsConnector;
+const ConnectedMetadataOptions = connect(mapStateToProps)(MetadataOptions);
+export default ConnectedMetadataOptions;

--- a/console/src/components/Services/Settings/MetadataStatus/MetadataStatus.js
+++ b/console/src/components/Services/Settings/MetadataStatus/MetadataStatus.js
@@ -8,6 +8,7 @@ import CheckIcon from '../../../Common/Icons/Check';
 import CrossIcon from '../../../Common/Icons/Cross';
 import { getConfirmation } from '../../../Common/utils/jsUtils';
 import ReloadMetadata from '../MetadataOptions/ReloadMetadata';
+import { connect } from 'react-redux';
 
 const MetadataStatus = ({ dispatch, metadata }) => {
   const [shouldShowErrorBanner, toggleErrorBanner] = useState(true);
@@ -223,6 +224,5 @@ const mapStateToProps = state => {
   };
 };
 
-const connector = connect => connect(mapStateToProps)(MetadataStatus);
-
-export default connector;
+const ConnectedMetadataStatus = connect(mapStateToProps)(MetadataStatus);
+export default ConnectedMetadataStatus;

--- a/console/src/components/Services/VoyagerView/VoyagerView.js
+++ b/console/src/components/Services/VoyagerView/VoyagerView.js
@@ -4,6 +4,7 @@ import fetch from 'isomorphic-fetch';
 import Endpoints from '../../../Endpoints';
 import '../../../../node_modules/graphql-voyager/dist/voyager.css';
 import './voyagerView.css';
+import { connect } from 'react-redux';
 
 class VoyagerView extends Component {
   introspectionProvider(query) {
@@ -28,13 +29,10 @@ class VoyagerView extends Component {
   }
 }
 
-const generatedVoyagerConnector = connect => {
-  const mapStateToProps = state => {
-    return {
-      headers: state.tables.dataHeaders,
-    };
+const ConnectedVoyagerConnector = connect(state => {
+  return {
+    headers: state.tables.dataHeaders,
   };
-  return connect(mapStateToProps)(VoyagerView);
-};
+})(VoyagerView);
 
-export default generatedVoyagerConnector;
+export default ConnectedVoyagerConnector;

--- a/console/src/routes.js
+++ b/console/src/routes.js
@@ -21,19 +21,15 @@ import { getRemoteSchemaRouter } from './components/Services/RemoteSchema';
 
 import { getActionsRouter } from './components/Services/Actions';
 
-import generatedApiExplorer from './components/Services/ApiExplorer/ApiExplorer';
-
-import generatedVoyagerConnector from './components/Services/VoyagerView/VoyagerView';
-
-import about from './components/Services/About/About';
-
-import generatedLoginConnector from './components/Login/Login';
-
-import settingsContainer from './components/Services/Settings/Container';
-import metadataOptionsContainer from './components/Services/Settings/MetadataOptions/MetadataOptions';
-import metadataStatusContainer from './components/Services/Settings/MetadataStatus/MetadataStatus';
-import allowedQueriesContainer from './components/Services/Settings/AllowedQueries/AllowedQueries';
-import logoutContainer from './components/Services/Settings/Logout/Logout';
+import ApiExplorer from './components/Services/ApiExplorer/ApiExplorer';
+import VoyagerConnector from './components/Services/VoyagerView/VoyagerView';
+import About from './components/Services/About/About';
+import Login from './components/Login/Login';
+import Settings from './components/Services/Settings/Container';
+import MetadataOptions from './components/Services/Settings/MetadataOptions/MetadataOptions';
+import MetadataStatus from './components/Services/Settings/MetadataStatus/MetadataStatus';
+import AllowedQueries from './components/Services/Settings/AllowedQueries/AllowedQueries';
+import Logout from './components/Services/Settings/Logout/Logout';
 
 import { showErrorNotification } from './components/Services/Common/Notification';
 import { CLI_CONSOLE_MODE } from './constants';
@@ -71,22 +67,14 @@ const routes = store => {
     return;
   };
 
-  const _dataRouterUtils = dataRouterUtils(connect, store, composeOnEnterHooks);
+  const _dataRouterUtils = dataRouterUtils(store, composeOnEnterHooks);
   const requireSchema = _dataRouterUtils.requireSchema;
   const dataRouter = _dataRouterUtils.makeDataRouter;
 
-  const _eventRouterUtils = eventRouterUtils(
-    connect,
-    store,
-    composeOnEnterHooks
-  );
+  const _eventRouterUtils = eventRouterUtils(store, composeOnEnterHooks);
   const eventRouter = _eventRouterUtils.makeEventRouter;
 
-  const remoteSchemaRouter = getRemoteSchemaRouter(
-    connect,
-    store,
-    composeOnEnterHooks
-  );
+  const remoteSchemaRouter = getRemoteSchemaRouter(store, composeOnEnterHooks);
 
   const actionsRouter = getActionsRouter(connect, store, composeOnEnterHooks);
 
@@ -105,38 +93,23 @@ const routes = store => {
 
   return (
     <Route path="/" component={App} onEnter={validateLogin(store)}>
-      <Route path="login" component={generatedLoginConnector(connect)} />
+      <Route path="login" component={Login} />
       <Route
         path=""
         component={Main}
         onEnter={composeOnEnterHooks([requireSchema, requireMigrationStatus])}
       >
         <Route path="">
-          <IndexRoute component={generatedApiExplorer(connect)} />
-          <Route
-            path="api-explorer"
-            component={generatedApiExplorer(connect)}
-          />
-          <Route
-            path="voyager-view"
-            component={generatedVoyagerConnector(connect)}
-          />
-          <Route path="about" component={about(connect)} />
-          <Route path="settings" component={settingsContainer(connect)}>
+          <IndexRoute component={ApiExplorer} />
+          <Route path="api-explorer" component={ApiExplorer} />
+          <Route path="voyager-view" component={VoyagerConnector} />
+          <Route path="about" component={About} />
+          <Route path="settings" component={Settings}>
             <IndexRedirect to="metadata-actions" />
-            <Route
-              path="metadata-actions"
-              component={metadataOptionsContainer(connect)}
-            />
-            <Route
-              path="metadata-status"
-              component={metadataStatusContainer(connect)}
-            />
-            <Route
-              path="allowed-queries"
-              component={allowedQueriesContainer(connect)}
-            />
-            <Route path="logout" component={logoutContainer(connect)} />
+            <Route path="metadata-actions" component={MetadataOptions} />
+            <Route path="metadata-status" component={MetadataStatus} />
+            <Route path="allowed-queries" component={AllowedQueries} />
+            <Route path="logout" component={Logout} />
           </Route>
           {dataRouter}
           {eventRouter}


### PR DESCRIPTION
### Description 

Dynamic usage of HOC is nonidiomatic React and is redundant. This PR updates all routers and _connected_ components. 

React docs: [Don’t Use HOCs Inside the render Method](
https://reactjs.org/docs/higher-order-components.html#dont-use-hocs-inside-the-render-method)

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Console

### Related issues

https://github.com/hasura/graphql-engine-internal/issues/418