### PR TITLE
use printErrJExit instead of logger

### DIFF
--- a/server/src-exec/Main.hs
+++ b/server/src-exec/Main.hs
@@ -5,7 +5,7 @@ module Main where
 import           Data.Text.Conversions      (convertText)
 
 import           Hasura.App
-import           Hasura.Logging             (Hasura)
+import           Hasura.Logging
 import           Hasura.Prelude
 import           Hasura.RQL.DDL.Metadata    (fetchMetadata)
 import           Hasura.RQL.DDL.Schema

--- a/server/src-lib/Hasura/App.hs
+++ b/server/src-lib/Hasura/App.hs
@@ -13,17 +13,14 @@ import           Data.Time.Clock                      (UTCTime)
 import           GHC.AssertNF
 import           Options.Applicative
 import           System.Environment                   (getEnvironment, lookupEnv)
-import           System.Exit                          (exitFailure)
 
 import qualified Control.Concurrent.Async.Lifted.Safe as LA
 import qualified Control.Concurrent.Extended          as C
 import qualified Data.Aeson                           as A
-import qualified Data.ByteString.Char8                as BC
 import qualified Data.ByteString.Lazy.Char8           as BLC
 import qualified Data.Set                             as Set
 import qualified Data.Text                            as T
 import qualified Data.Time.Clock                      as Clock
-import qualified Data.Yaml                            as Y
 import qualified Database.PG.Query                    as Q
 import qualified Network.HTTP.Client                  as HTTP
 import qualified Network.HTTP.Client.TLS              as HTTP
@@ -55,12 +52,6 @@ import           Hasura.Server.Telemetry
 import           Hasura.Server.Version
 import           Hasura.Session
 
-
-printErrExit :: (MonadIO m) => forall a . String -> m a
-printErrExit = liftIO . (>> exitFailure) . putStrLn
-
-printErrJExit :: (A.ToJSON a, MonadIO m) => forall b . a -> m b
-printErrJExit = liftIO . (>> exitFailure) . printJSON
 
 parseHGECommand :: EnabledLogTypes impl => Parser (RawHGECommand impl)
 parseHGECommand =
@@ -94,12 +85,6 @@ parseArgs = do
              footerDoc (Just mainCmdFooter)
            )
     hgeOpts = HGEOptionsG <$> parseRawConnInfo <*> parseHGECommand
-
-printJSON :: (A.ToJSON a, MonadIO m) => a -> m ()
-printJSON = liftIO . BLC.putStrLn . A.encode
-
-printYaml :: (A.ToJSON a, MonadIO m) => a -> m ()
-printYaml = liftIO . BC.putStrLn . Y.encode
 
 mkPGLogger :: Logger Hasura -> Q.PGLogger
 mkPGLogger (Logger logger) (Q.PLERetryMsg msg) =

--- a/server/src-lib/Hasura/Logging.hs
+++ b/server/src-lib/Hasura/Logging.hs
@@ -25,15 +25,21 @@ module Hasura.Logging
   , defaultEnabledEngineLogTypes
   , isEngineLogTypeEnabled
   , readLogTypes
+  , printErrExit
+  , printErrJExit
+  , printJSON
+  , printYaml
   ) where
 
 import           Hasura.Prelude
+import           System.Exit                (exitFailure)
 
 import qualified Control.AutoUpdate         as Auto
 import qualified Data.Aeson                 as J
 import qualified Data.Aeson.Casing          as J
 import qualified Data.Aeson.TH              as J
 import qualified Data.ByteString            as B
+import qualified Data.ByteString.Char8      as BC
 import qualified Data.ByteString.Lazy       as BL
 import qualified Data.ByteString.Lazy.Char8 as BLC
 import qualified Data.HashSet               as Set
@@ -42,6 +48,7 @@ import qualified Data.Text                  as T
 import qualified Data.Time.Clock            as Time
 import qualified Data.Time.Format           as Format
 import qualified Data.Time.LocalTime        as Time
+import qualified Data.Yaml                  as Y
 import qualified System.Log.FastLogger      as FL
 
 
@@ -273,3 +280,15 @@ eventTriggerLogType = ELTInternal ILTEventTrigger
 
 scheduledTriggerLogType :: EngineLogType Hasura
 scheduledTriggerLogType = ELTInternal ILTScheduledTrigger
+
+printErrExit :: (MonadIO m) => forall a . String -> m a
+printErrExit = liftIO . (>> exitFailure) . putStrLn
+
+printErrJExit :: (J.ToJSON a, MonadIO m) => forall b . a -> m b
+printErrJExit = liftIO . (>> exitFailure) . printJSON
+
+printJSON :: (J.ToJSON a, MonadIO m) => a -> m ()
+printJSON = liftIO . BLC.putStrLn . J.encode
+
+printYaml :: (J.ToJSON a, MonadIO m) => a -> m ()
+printYaml = liftIO . BC.putStrLn . Y.encode

--- a/server/src-lib/Hasura/Server/App.hs
+++ b/server/src-lib/Hasura/Server/App.hs
@@ -36,9 +36,11 @@ import qualified System.Metrics.Json                    as EKG
 import qualified Text.Mustache                          as M
 import qualified Web.Spock.Core                         as Spock
 
+
 import           Hasura.EncJSON
 import           Hasura.GraphQL.Resolve.Action
 import           Hasura.HTTP
+import           Hasura.Logging
 import           Hasura.Prelude                         hiding (get, put)
 import           Hasura.RQL.DDL.Schema
 import           Hasura.RQL.Types
@@ -532,12 +534,11 @@ mkWaiApp isoLevel logger sqlGenCtx enableAL pool ci httpManager mode corsCfg ena
 
       ((migrationResult, schemaCache), lastUpdateEvent) <-
         initialiseResult `onLeft` \err -> do
-          L.unLogger logger StartupLog
+          printErrJExit StartupLog
             { slLogLevel = L.LevelError
             , slKind = "db_migrate"
             , slInfo = toJSON err
             }
-          liftIO exitFailure
       L.unLogger logger migrationResult
 
       cacheLock <- liftIO $ newMVar ()


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description

Logger only writes to stdout after buffer is full. This means that some log messages might not be flushed if the system exists (especially during startup failures)

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
