### PR TITLE
flush logger on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Read more about the session argument for computed fields in the [docs](https://h
 
 - server: avoid loss of precision when passing values in scientific notation (fix #4733)
 - server: fix mishandling of GeoJSON inputs in subscriptions (fix #3239)
+- server: flush log buffer during shutdown (#4800)
 - console: avoid count queries for large tables (#4692)
 - console: add read replica support section to pro popup (#4118)
 - console: allow modifying default value for PK (fix #4075) (#4679)

--- a/server/src-lib/Hasura/App.hs
+++ b/server/src-lib/Hasura/App.hs
@@ -28,7 +28,6 @@ import qualified Database.PG.Query                    as Q
 import qualified Network.HTTP.Client                  as HTTP
 import qualified Network.HTTP.Client.TLS              as HTTP
 import qualified Network.Wai.Handler.Warp             as Warp
-import qualified System.Log.FastLogger                as FL
 import qualified System.Posix.Signals                 as Signals
 import qualified Text.Mustache.Compile                as M
 
@@ -354,9 +353,8 @@ runHGEServer ServeOptions{..} InitCtx{..} initTime = do
         closeSocket
         shutdownApp
         logShutdown
-        flushLogger
+        cleanLoggerCtx loggerCtx
 
-      flushLogger = FL.flushLogStr $ _lcLoggerSet loggerCtx
       logShutdown = logger $ mkGenericStrLog LevelInfo "server" "gracefully shutting down server"
 
 runAsAdmin


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description

The buffer needs to be flushed on termination:  https://hackage.haskell.org/package/fast-logger-3.0.1/docs/System-Log-FastLogger.html#v:flushLogStr

Currently, if you don't flush the logger, the following line (and possibly other buffered logs) are not printed:
`{"type":"startup","timestamp":"2020-05-18T09:48:02.636+0000","level":"info","detail":{"kind":"server","info":"gracefully shutting down server"}}
`

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
