### PR TITLE
install manifests: use caddy v2 for https setup

### DIFF
--- a/install-manifests/docker-compose-https/Caddyfile
+++ b/install-manifests/docker-compose-https/Caddyfile
@@ -1,6 +1,4 @@
 # replace :80 with your domain name to get automatic https via LetsEncrypt
 :80 {
-    proxy / graphql-engine:8080 {
-        websocket
-    }
+  reverse_proxy graphql-engine:8080
 }

--- a/install-manifests/docker-compose-https/docker-compose.yaml
+++ b/install-manifests/docker-compose-https/docker-compose.yaml
@@ -20,10 +20,10 @@ services:
       ## uncomment next line to set an admin secret key
       # HASURA_GRAPHQL_ADMIN_SECRET: myadminsecretkey
     command:
-    - graphql-engine 
+    - graphql-engine
     - serve
   caddy:
-    image: abiosoft/caddy:0.11.0
+    image: caddy/caddy
     depends_on:
     - "graphql-engine"
     restart: always
@@ -31,7 +31,7 @@ services:
     - "80:80"
     - "443:443"
     volumes:
-    - ./Caddyfile:/etc/Caddyfile
+    - ./Caddyfile:/etc/caddy/Caddyfile
     - caddy_certs:/root/.caddy
 volumes:
   db_data:


### PR DESCRIPTION
Experienced a problem restarting the Digital Ocean one click installer. The used version of Caddy seems to reach out to a telemetry domain (telemetry.caddyserver.com) that is unavailable and stops working. This pull request uses the new Caddy v2 docker image instead.

Restart was necessary for updates in the Dockerfile config and performed using: `docker-compose up -d --force-recreate`