### PR TITLE
console: editing permissions manually seems to have stopped working properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Read more about the session argument for computed fields in the [docs](https://h
 - server: avoid loss of precision when passing values in scientific notation (fix #4733)
 - server: fix mishandling of GeoJSON inputs in subscriptions (fix #3239)
 - server: flush log buffer during shutdown (#4800)
+- console: fix editing permissions manually seems to have stopped working properly (fix #4683)
 - console: avoid count queries for large tables (#4692)
 - console: add read replica support section to pro popup (#4118)
 - console: allow modifying default value for PK (fix #4075) (#4679)

--- a/console/src/components/Services/Data/TablePermissions/JSONEditor.tsx
+++ b/console/src/components/Services/Data/TablePermissions/JSONEditor.tsx
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from 'react';
+import AceEditor, { IAnnotation } from 'react-ace';
+import { isJsonString } from '../../../Common/utils/jsUtils';
+
+export interface JSONEditorProps {
+  initData: string;
+  onChange: (v: string) => void;
+  data: string;
+}
+
+const JSONEditor: React.FC<JSONEditorProps> = ({
+  initData,
+  onChange,
+  data,
+}) => {
+  const [value, setValue] = useState(initData || data || '');
+  const [annotations, setAnnotations] = useState([] as IAnnotation[]);
+  useEffect(() => {
+    if (value !== data) onChange(value);
+  }, [value]);
+
+  // check and set error message
+  useEffect(() => {
+    if (isJsonString(value)) {
+      setAnnotations([]);
+    } else {
+      setAnnotations([
+        { row: 0, column: 0, text: 'error.message', type: 'error' },
+      ]);
+    }
+    return () => {
+      setAnnotations([]);
+    };
+  }, [value]);
+
+  useEffect(() => {
+    // set data to editor only if the prop has a valid json string
+    // setting value from query editor will always have a valid json
+    // any invalid json means, the value is set from this component so no need to set that again
+    if (isJsonString(data)) setValue(data);
+  }, [data]);
+
+  return (
+    <AceEditor
+      mode="json"
+      onChange={setValue}
+      theme="github"
+      height="5em"
+      maxLines={15}
+      width="100%"
+      showPrintMargin={false}
+      value={value}
+      annotations={annotations}
+      debounceChangePeriod={200}
+    />
+  );
+};
+
+export default JSONEditor;

--- a/console/src/components/Services/Data/TablePermissions/JSONEditor.tsx
+++ b/console/src/components/Services/Data/TablePermissions/JSONEditor.tsx
@@ -25,7 +25,7 @@ const JSONEditor: React.FC<JSONEditorProps> = ({
       setAnnotations([]);
     } else {
       setAnnotations([
-        { row: 0, column: 0, text: 'error.message', type: 'error' },
+        { row: 0, column: 0, text: 'Invalid JSON', type: 'error' },
       ]);
     }
     return () => {

--- a/console/src/components/Services/Data/TablePermissions/Permissions.js
+++ b/console/src/components/Services/Data/TablePermissions/Permissions.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import AceEditor from 'react-ace';
+import JSONEditor from './JSONEditor';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
 import InputGroup from 'react-bootstrap/lib/InputGroup';
 import OverlayTrigger from 'react-bootstrap/es/OverlayTrigger';
@@ -9,7 +9,6 @@ import 'brace/theme/github';
 
 import { RESET } from '../TableModify/ModifyActions';
 import {
-  permChangeTypes,
   permOpenEdit,
   permSetFilter,
   permSetFilterSameAs,
@@ -18,7 +17,6 @@ import {
   permAllowAll,
   permCloseEdit,
   permSetRoleName,
-  permChangePermissions,
   // permToggleAllowUpsert,
   permToggleAllowAggregation,
   permToggleModifyLimit,
@@ -82,16 +80,15 @@ import {
   getTableSupportedQueries,
   QUERY_TYPES,
 } from '../../../Common/utils/pgUtils';
-import { showErrorNotification } from '../../Common/Notification';
 import KnowMoreLink from '../../../Common/KnowMoreLink/KnowMoreLink';
 import {
   getFilterQueries,
   replaceLegacyOperators,
-  getAllowedFilterKeys,
   updateFilterTypeLabel,
   getDefaultFilterType,
   getUpdateTooltip,
 } from './utils';
+import PermButtonSection from './molecules/PermButtonsSection';
 
 class Permissions extends Component {
   constructor() {
@@ -659,8 +656,8 @@ class Permissions extends Component {
 
           const dispatchFuncSetFilter = filter => {
             this.setState(prev => ({
-              filterString: {
-                ...prev,
+              localFilterString: {
+                ...prev.localFilterString,
                 [filterType]: filter,
               },
             }));
@@ -687,15 +684,9 @@ class Permissions extends Component {
           );
 
           const selectedValue = (
-            <AceEditor
-              mode="json"
-              value={currentFilterString || filterString[filterType]}
+            <JSONEditor
+              data={filterString[filterType] || currentFilterString}
               onChange={dispatchFuncSetFilter}
-              theme="github"
-              height="5em"
-              maxLines={15}
-              width="100%"
-              showPrintMargin={false}
               key={-3}
             />
           );
@@ -1741,93 +1732,6 @@ class Permissions extends Component {
         return clonePermissionsHtml;
       };
 
-      const getButtonsSection = () => {
-        if (readOnlyMode) {
-          return null;
-        }
-
-        const dispatchSavePermissions = () => {
-          const filterKeys = getAllowedFilterKeys(query);
-          const isInvalid = filterKeys.some(key => {
-            if (
-              localFilterString[key] &&
-              !isJsonString(localFilterString[key])
-            ) {
-              return true;
-            }
-            return false;
-          });
-
-          if (isInvalid) {
-            dispatch(
-              showErrorNotification(
-                'Saving permissions failed',
-                'Row permission is not a valid JSON'
-              )
-            );
-            return;
-          }
-
-          dispatch(permChangePermissions(permChangeTypes.save));
-        };
-
-        const dispatchRemoveAccess = () => {
-          const confirmMessage =
-            'This will permanently delete the currently set permissions';
-          const isOk = getConfirmation(confirmMessage);
-          if (isOk) {
-            dispatch(permChangePermissions(permChangeTypes.delete));
-          }
-        };
-
-        const getPermActionButton = (
-          value,
-          color,
-          onClickFn,
-          disabled,
-          title
-        ) => (
-          <Button
-            className={styles.add_mar_right}
-            color={color}
-            size="sm"
-            onClick={onClickFn}
-            disabled={disabled}
-            title={title}
-            data-test={`${value.split(' ').join('-')}-button`}
-          >
-            {value}
-          </Button>
-        );
-        const applySameSelected = permissionsState.applySamePermissions.length;
-
-        const disableSave = applySameSelected || !permsChanged;
-        const disableRemoveAccess = !currQueryPermissions;
-
-        const saveButton = getPermActionButton(
-          'Save Permissions',
-          'yellow',
-          dispatchSavePermissions,
-          disableSave,
-          !permsChanged ? 'No changes made' : ''
-        );
-
-        const removeAccessButton = getPermActionButton(
-          'Delete Permissions',
-          'red',
-          dispatchRemoveAccess,
-          disableRemoveAccess,
-          disableRemoveAccess ? 'No permissions set' : ''
-        );
-
-        return (
-          <div className={styles.add_mar_top + ' ' + styles.add_pad_left}>
-            {saveButton}
-            {removeAccessButton}
-          </div>
-        );
-      };
-
       const getBackendOnlySection = () => {
         if (!isQueryTypeBackendOnlyCompatible(permissionsState.query)) {
           return null;
@@ -1901,7 +1805,15 @@ class Permissions extends Component {
             {getPresetsSection('insert')}
             {getPresetsSection('update')}
             {getBackendOnlySection()}
-            {getButtonsSection()}
+            <PermButtonSection
+              readOnlyMode={readOnlyMode}
+              query={query}
+              localFilterString={localFilterString}
+              dispatch={dispatch}
+              permissionsState={permissionsState}
+              permsChanged={permsChanged}
+              currQueryPermissions={currQueryPermissions}
+            />
             {getClonePermsSection()}
           </div>
         </div>

--- a/console/src/components/Services/Data/TablePermissions/molecules/PermButtonsSection.tsx
+++ b/console/src/components/Services/Data/TablePermissions/molecules/PermButtonsSection.tsx
@@ -1,0 +1,98 @@
+import React, { useCallback } from 'react';
+import Button from '../../../../Common/Button';
+import {
+  isJsonString,
+  getConfirmation,
+} from '../../../../Common/utils/jsUtils';
+import { FilterState } from '../utils';
+import { showErrorNotification } from '../../../Common/Notification';
+import { permChangePermissions, permChangeTypes } from '../Actions';
+import styles from '../../../../Common/Permissions/PermissionStyles.scss';
+
+interface PermButtonSectionProps {
+  readOnlyMode: string;
+  query: string;
+  localFilterString: FilterState;
+  dispatch: (...p: any) => void;
+  permissionsState: FilterState;
+  permsChanged: string;
+  currQueryPermissions: string;
+}
+
+const PermButtonSection: React.FC<PermButtonSectionProps> = ({
+  readOnlyMode,
+  query,
+  localFilterString,
+  dispatch,
+  permissionsState,
+  permsChanged,
+  currQueryPermissions,
+}) => {
+  if (readOnlyMode) {
+    return null;
+  }
+
+  const dispatchSavePermissions = useCallback(() => {
+    console.error(localFilterString);
+    const isInvalid = Object.values(localFilterString).some(val => {
+      if (val && !isJsonString(val)) {
+        return true;
+      }
+      return false;
+    });
+
+    if (isInvalid) {
+      dispatch(
+        showErrorNotification(
+          'Saving permissions failed',
+          'Row permission is not a valid JSON'
+        )
+      );
+      return;
+    }
+
+    dispatch(permChangePermissions(permChangeTypes.save));
+  }, [readOnlyMode, query, localFilterString, dispatch]);
+
+  const dispatchRemoveAccess = useCallback(() => {
+    const confirmMessage =
+      'This will permanently delete the currently set permissions';
+    const isOk = getConfirmation(confirmMessage);
+    if (isOk) {
+      dispatch(permChangePermissions(permChangeTypes.delete));
+    }
+  }, []);
+
+  const disableSave =
+    permissionsState.applySamePermissions.length !== 0 || !permsChanged;
+  const disableRemoveAccess = !currQueryPermissions;
+
+  return (
+    <div className={`${styles.add_mar_top} ${styles.add_pad_left}`}>
+      <Button
+        className={styles.add_mar_right}
+        color="yellow"
+        size="sm"
+        onClick={dispatchSavePermissions}
+        disabled={disableSave}
+        title={!permsChanged ? 'No changes made' : ''}
+        data-test="Save-Permissions-button"
+      >
+        Save Permissions
+      </Button>
+      <Button
+        className={styles.add_mar_right}
+        color="red"
+        size="sm"
+        onClick={dispatchRemoveAccess}
+        disabled={disableRemoveAccess}
+        title={disableRemoveAccess ? 'No permissions set' : ''}
+        data-test="Delete-Permissions-button"
+      >
+        Delete Permissions
+      </Button>
+    </div>
+  );
+};
+
+export default PermButtonSection;

--- a/console/src/components/Services/Data/TablePermissions/utils.tsx
+++ b/console/src/components/Services/Data/TablePermissions/utils.tsx
@@ -7,7 +7,10 @@ import { escapeRegExp } from '../utils';
 import { UNSAFE_keys } from '../../../Common/utils/tsUtils';
 
 type FilterType = 'check' | 'filter';
-type BaseQueryType = 'select' | 'update' | 'insert' | 'delete';
+export type BaseQueryType = 'select' | 'update' | 'insert' | 'delete';
+export interface FilterState {
+  [key: string]: BaseQueryType;
+}
 
 type DisplayQueryType =
   | Exclude<BaseQueryType, 'update'>


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->
console: editing permissions manually seems to have stopped working properly

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Raw son edit on permissions was letting the user edit the entire JSON, Now user can fully edit the JSON rule.
  
### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
close #4683
### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
> Removed editor level `isJSON` check.
> Added denounce for editor onchange event. this will prevent unwanted event triggers.
> Component separation for JSON editor, Permission Buttons etc. 

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
1. Go to the Data module
2. Select a table
3. Go to Permissions tab
4. Try to edit a `Row select permissions`
5. Try editing the JSON.

* Expected O/P 

![captured](https://user-images.githubusercontent.com/8408875/82459576-bdb9bf80-9ad5-11ea-9f64-24282404a515.gif)

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
