### PR TITLE
docs: add note to permissions about hasura roles vs. postgres roles (close #4514)

### DIFF
--- a/docs/graphql/manual/auth/authorization/index.rst
+++ b/docs/graphql/manual/auth/authorization/index.rst
@@ -27,6 +27,11 @@ session variables. Other session variables can be passed by your auth service as
    :width: 80 %
    :alt: Create a permission rule
 
+.. note::
+
+  Hasura roles and permissions are implemented at the Hasura layer.
+  They have nothing to do with Postgres roles and users.
+
 Trying out access control
 -------------------------
 


### PR DESCRIPTION
### Description

Add a note to the permissions docs to say that Hasura roles & permissions have nothing to do with Postgres roles & users.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components

- [x] Docs

### Related Issues

https://github.com/hasura/graphql-engine/issues/4514

### Steps to test and verify

https://deploy-preview-4834--hasura-docs.netlify.app/graphql/manual/auth/authorization/index.html#overview