### PR TITLE
[WIP] Resolve[#4818] : Error Boundary for VoyagerView component

### DIFF
--- a/console/src/components/Error/VoyagerBoundary.js
+++ b/console/src/components/Error/VoyagerBoundary.js
@@ -1,0 +1,72 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import globals from '../../Globals';
+
+// #4818 Issue
+
+class VoyagerBoundary extends Component {
+  constructor() {
+    super();
+    this.state = {
+      error: false,
+      errorInfo: null,
+    };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({
+      error,
+      errorInfo,
+    });
+  }
+
+  render() {
+    const errorImage = `${globals.assetsPath}/common/img/hasura_icon_green.svg`;
+    const styles = require('./ErrorPage.scss');
+
+    if (this.state.errorInfo) {
+      return (
+        <div className={styles.viewContainer}>
+          <div className={'container ' + styles.centerContent}>
+            <div className={'row ' + styles.message}>
+              <div className="col-xs-8">
+                <h1>Error</h1>
+                <br />
+                <div>
+                  Something went wrong.
+                  <details>
+                    <summary>Error Summary</summary>
+                    {this.state.error && this.state.error.toString()}
+                    <br />
+                    <div>
+                      <pre className={styles.errorStack}>
+                        {this.state.errorInfo.componentStack}
+                      </pre>
+                    </div>
+                  </details>
+                </div>
+                <br />
+              </div>
+              <div className="col-xs-4">
+                <img
+                  src={errorImage}
+                  className="img-responsive"
+                  name="hasura"
+                  title="Something went wrong!"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+VoyagerBoundary.propTypes = {
+  dispatch: PropTypes.func.isRequired,
+};
+
+export default VoyagerBoundary;

--- a/console/src/components/Error/VoyagerErrBoundary.tsx
+++ b/console/src/components/Error/VoyagerErrBoundary.tsx
@@ -1,20 +1,28 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import React, { Component, ReactNode } from 'react';
 import globals from '../../Globals';
 
-// #4818 Issue
+type State = {
+  error: object | null;
+  // FIXME: remove any
+  // fix type for 'componentStack'
+  errorInfo: any;
+  hasError: boolean;
+};
 
-class VoyagerBoundary extends Component {
-  constructor() {
-    super();
-    this.state = {
-      error: false,
-      errorInfo: null,
-    };
+type Props = {
+  children: ReactNode
+};
+
+class VoyagerErrBoundary extends Component<Props, State> {
+  readonly state : State = {
+    hasError: false,
+    error: null,
+    errorInfo: null,
   }
 
-  componentDidCatch(error, errorInfo) {
+  componentDidCatch(error: object, errorInfo: object) {
     this.setState({
+      hasError: true,
       error,
       errorInfo,
     });
@@ -24,7 +32,7 @@ class VoyagerBoundary extends Component {
     const errorImage = `${globals.assetsPath}/common/img/hasura_icon_green.svg`;
     const styles = require('./ErrorPage.scss');
 
-    if (this.state.errorInfo) {
+    if (this.state.hasError) {
       return (
         <div className={styles.viewContainer}>
           <div className={'container ' + styles.centerContent}>
@@ -51,7 +59,6 @@ class VoyagerBoundary extends Component {
                 <img
                   src={errorImage}
                   className="img-responsive"
-                  name="hasura"
                   title="Something went wrong!"
                 />
               </div>
@@ -65,8 +72,4 @@ class VoyagerBoundary extends Component {
   }
 }
 
-VoyagerBoundary.propTypes = {
-  dispatch: PropTypes.func.isRequired,
-};
-
-export default VoyagerBoundary;
+export default VoyagerErrBoundary;

--- a/console/src/components/Services/VoyagerView/VoyagerView.tsx
+++ b/console/src/components/Services/VoyagerView/VoyagerView.tsx
@@ -2,8 +2,8 @@ import React, { Component } from 'react';
 import { Connect } from 'react-redux';
 import { GraphQLVoyager } from 'graphql-voyager';
 import fetch from 'isomorphic-fetch';
-
 import Endpoints from '../../../Endpoints';
+import VoyagerErrBoundary from './../../Error/VoyagerErrBoundary';
 import '../../../../node_modules/graphql-voyager/dist/voyager.css';
 import './voyagerView.css';
 
@@ -35,10 +35,12 @@ class VoyagerView extends Component<Props, State> {
 
   render() {
     return (
-      <GraphQLVoyager
-        introspection={this.introspectionProvider}
-        workerURI="https://cdn.jsdelivr.net/npm/graphql-voyager@1.0.0-rc.27/dist/voyager.worker.min.js"
-      />
+      <VoyagerErrBoundary>
+        <GraphQLVoyager
+          introspection={this.introspectionProvider}
+          workerURI="https://cdn.jsdelivr.net/npm/graphql-voyager@1.0.0-rc.27/dist/voyager.worker.min.js"
+        />
+      </VoyagerErrBoundary>
     );
   }
 }


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#3023, #4818 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
The design is the same as the `RuntimeError` component, as suggested in #4818  The solution is a Error Boundary specifically for the `VoyagerView` component

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
- First make 40+ tables on the `GraphQL console`
- You should see the fallback mentioned in the `VoyagerErrBoundary` component if an error does occur. 

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->
For the state `errorInfo` I've annotated it with the type of `any` which isn't a clean solution. This because of the `componentStack` property I require from the `errorInfo` object. I'd probably need some help to clean this up.

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
