### PR TITLE
Fixes dead link in docs - close #4914

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,22 +12,19 @@ It works similar to table relationships. Head to the `Relationship` tab in your 
 2. select the remote schema
 3. give the join configuration from table columns to remote schema fields.
 
-[Add docs links]
-[Add console screenshot]
+[Add docs links][add console screenshot]
 
 ### Scheduled Triggers
 
 A scheduled trigger can be used to execute custom business logic based on time. There are two types of timing events: cron based or timestamp based.
 
-A cron trigger will be useful when something needs to be done periodically. For example, you can create a cron trigger to  generate an end-of-day sales report every weekday at 9pm.
+A cron trigger will be useful when something needs to be done periodically. For example, you can create a cron trigger to generate an end-of-day sales report every weekday at 9pm.
 
 You can also schedule one-off events based on a timestamp. For example, a new scheduled event can be created for 2 weeks from when a user signs up to send them an email about their experience.
 
-[Add docs links]
-[Add console screenshot]
+[Add docs links][add console screenshot]
 
 (close #1914)
-
 
 ### Allow access to session variables by computed fields (fix #3846)
 
@@ -63,6 +60,7 @@ Read more about the session argument for computed fields in the [docs](https://h
 ### Bug fixes and improvements
 
 (Add entries here in the order of: server, console, cli, docs, others)
+
 - server: fix explain queries with role permissions (fix #4816)
 - server: compile with GHC 8.10.1, closing a space leak with subscriptions. (close #4517) (#3388)
 
@@ -93,6 +91,7 @@ Read more about the session argument for computed fields in the [docs](https://h
 - docs: update troubleshooting section with reference on debugging errors (close #4052) (#4825)
 - docs: add page for procuring custom docker images and binaries (#4828)
 - docs: add content on how to secure action handlers and other actions docs improvements (#4743)
+- docs: fix dead link in page on authentication with webhooks (#4915)
 
 ## `v1.2.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,6 @@ Read more about the session argument for computed fields in the [docs](https://h
 - docs: update troubleshooting section with reference on debugging errors (close #4052) (#4825)
 - docs: add page for procuring custom docker images and binaries (#4828)
 - docs: add content on how to secure action handlers and other actions docs improvements (#4743)
-- docs: fix dead link in page on authentication with webhooks (#4915)
 
 ## `v1.2.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,19 +12,22 @@ It works similar to table relationships. Head to the `Relationship` tab in your 
 2. select the remote schema
 3. give the join configuration from table columns to remote schema fields.
 
-[Add docs links][add console screenshot]
+[Add docs links]
+[Add console screenshot]
 
 ### Scheduled Triggers
 
 A scheduled trigger can be used to execute custom business logic based on time. There are two types of timing events: cron based or timestamp based.
 
-A cron trigger will be useful when something needs to be done periodically. For example, you can create a cron trigger to generate an end-of-day sales report every weekday at 9pm.
+A cron trigger will be useful when something needs to be done periodically. For example, you can create a cron trigger to  generate an end-of-day sales report every weekday at 9pm.
 
 You can also schedule one-off events based on a timestamp. For example, a new scheduled event can be created for 2 weeks from when a user signs up to send them an email about their experience.
 
-[Add docs links][add console screenshot]
+[Add docs links]
+[Add console screenshot]
 
 (close #1914)
+
 
 ### Allow access to session variables by computed fields (fix #3846)
 
@@ -60,7 +63,6 @@ Read more about the session argument for computed fields in the [docs](https://h
 ### Bug fixes and improvements
 
 (Add entries here in the order of: server, console, cli, docs, others)
-
 - server: fix explain queries with role permissions (fix #4816)
 - server: compile with GHC 8.10.1, closing a space leak with subscriptions. (close #4517) (#3388)
 

--- a/docs/graphql/manual/auth/authentication/webhook.rst
+++ b/docs/graphql/manual/auth/authentication/webhook.rst
@@ -173,7 +173,7 @@ You can deploy these samples using `glitch <https://glitch.com/>`__:
 Once deployed, you can use any of the following endpoints as your auth webhook in the GraphQL engine:
 
 - ``/simple/webhook``  (`View source <https://github.com/hasura/graphql-engine/blob/master/community/boilerplates/auth-webhooks/nodejs-express/server.js>`__)
-- ``/firebase/webhook`` (`View source <https://github.com/hasura/graphql-engine/blob/master/community/boilerplates/auth-webhooks/nodejs-express/firebase/firebaseHandler.js>`__)
+- ``/firebase/webhook`` (`View source <https://github.com/hasura/graphql-engine/blob/master/community/boilerplates/auth-webhooks/nodejs-firebase/firebase/firebaseHandler.js>`__)
 
 .. note::
 


### PR DESCRIPTION
### Description

After #4885, the link to `/firebase/webhook` example is no longer working - this PR updates the link [on this page](https://hasura.io/docs/1.0/graphql/manual/auth/authentication/webhook.html#auth-webhook-samples).


### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR.

### Affected components

- [x] Docs

### Related Issues
#4914

#### Metadata

Does this PR add a new Metadata feature?
- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No Breaking changes
