### PR TITLE
server development related fixes

### DIFF
--- a/server/cabal.project
+++ b/server/cabal.project
@@ -15,7 +15,7 @@
 packages: .
 
 constraints:
-  -- ensure we don’t end up with a freeze file that forces an incompatible 
+  -- ensure we don’t end up with a freeze file that forces an incompatible
   -- version in CI for Setup.hs scripts.
   setup.Cabal <3.4
 
@@ -41,9 +41,9 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/hasura/graphql-parser-hs.git
-  tag: 561580ac5e7945fe431c3552207d7d481b2f2172
+  tag: ba2379640248ce67cdfe700cbb79acd91c644bdb
 
 source-repository-package
   type: git
   location: https://github.com/hasura/ci-info-hs.git
-  tag: 6af5a68450347a02295a9cd050d05a8b2f5c06ab
+  tag: f0b9c67ac385abc117821fa1dfd37e75e5817de6

--- a/server/src-lib/Hasura/RQL/DDL/Action.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Action.hs
@@ -102,8 +102,8 @@ resolveAction
   -> ActionDefinitionInput
   -> m ( ResolvedActionDefinition
        , AnnotatedObjectType
-       , HashSet PGScalarType -- ^ see Note [Postgres scalars in action input arguments].
-       )
+       , HashSet PGScalarType
+       ) -- ^ see Note [Postgres scalars in action input arguments].
 resolveAction customTypes allPGScalars actionDefinition = do
   let responseType = unGraphQLType $ _adOutputType actionDefinition
       responseBaseType = G.getBaseType responseType


### PR DESCRIPTION
This doesn't affect our users in anyway, two things:
1. Fixes a haddock comment so that tools like ghcide won't choke.
2. For some reason, occasionally a change in graphql-engine will trigger the recompilation of 'Paths' module in upstream 'graphql-parser' and 'ci-info' packages, so I removed the 'Paths' module from these above packages in their upstream repos and bumped the dependencies (I don't know why this was happening but these changes "fixed" it). 