### PR TITLE
Disables optimizations on Hasura.Server.Init module

### DIFF
--- a/server/src-lib/Hasura/Server/Init.hs
+++ b/server/src-lib/Hasura/Server/Init.hs
@@ -1,5 +1,6 @@
 -- | Types and functions related to the server initialisation
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP    #-}
+{-# OPTIONS_GHC -O0 #-}
 module Hasura.Server.Init
   ( DbUid(..)
   , getDbId


### PR DESCRIPTION
When compiling graphql-engine binary with `-O2`, ghc-8.10 seems to be stuck at the module `Server.Init` while consuming `17G` of RAM (for 5 minutes at least before I forcefully terminated the compilation). With this pragma, ghc-8.10 now takes under `12G` to compile graphql-engine binary.

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->


### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [x] Build System
- [ ] Tests
- [ ] Other (list it)

