### PR TITLE
allow logging details of a live query polling thread

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Plan.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Plan.hs
@@ -30,6 +30,7 @@ import           Hasura.Session
 import qualified Data.Aeson.Casing                      as J
 import qualified Data.Aeson.Extended                    as J
 import qualified Data.Aeson.TH                          as J
+import qualified Data.ByteString                        as B
 import qualified Data.HashMap.Strict                    as Map
 import qualified Data.Text                              as T
 import qualified Data.UUID.V4                           as UUID
@@ -53,7 +54,6 @@ import qualified Hasura.GraphQL.Validate.Types          as GV
 import qualified Hasura.SQL.DML                         as S
 
 import           Hasura.Db
-import           Hasura.EncJSON
 import           Hasura.GraphQL.Utils
 import           Hasura.RQL.Types
 import           Hasura.Server.Version                  (HasVersion)
@@ -183,7 +183,7 @@ instance Q.ToPrepArg CohortVariablesArray where
       encoder = PE.array 114 . PE.dimensionArray foldl' (PE.encodingArray . PE.json_ast)
 
 executeMultiplexedQuery
-  :: (MonadTx m) => MultiplexedQuery -> [(CohortId, CohortVariables)] -> m [(CohortId, EncJSON)]
+  :: (MonadTx m) => MultiplexedQuery -> [(CohortId, CohortVariables)] -> m [(CohortId, B.ByteString)]
 executeMultiplexedQuery (MultiplexedQuery query) = executeQuery query
 
 -- | Internal; used by both 'executeMultiplexedQuery' and 'explainLiveQueryPlan'.

--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Plan.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Plan.hs
@@ -5,6 +5,7 @@
 module Hasura.GraphQL.Execute.LiveQuery.Plan
   ( MultiplexedQuery
   , mkMultiplexedQuery
+  , unMultiplexedQuery
   , resolveMultiplexedValue
 
   , CohortId
@@ -55,10 +56,10 @@ import           Hasura.Db
 import           Hasura.EncJSON
 import           Hasura.GraphQL.Utils
 import           Hasura.RQL.Types
+import           Hasura.Server.Version                  (HasVersion)
 import           Hasura.SQL.Error
 import           Hasura.SQL.Types
 import           Hasura.SQL.Value
-import           Hasura.Server.Version             (HasVersion)
 
 -- -------------------------------------------------------------------------------------------------
 -- Multiplexed queries

--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Poll.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Poll.hs
@@ -360,7 +360,7 @@ data PollDetail
 $(J.deriveToJSON (J.aesonDrop 3 J.snakeCase) ''PollDetail)
 
 instance L.ToEngineLog PollDetail L.Hasura where
-  toEngineLog pl = (L.LevelInfo, L.ELTInternal L.ILTPollerLog, J.toJSON pl)
+  toEngineLog pl = (L.LevelInfo, L.ELTLivequeryPollerLog, J.toJSON pl)
 
 -- | Where the magic happens: the top-level action run periodically by each
 -- active 'Poller'. This needs to be async exception safe.

--- a/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
@@ -332,9 +332,11 @@ onStart serverEnv wsConn (StartMsg opId q) = catchAndIgnore $ do
       E.ExOpSubs lqOp -> do
         -- log the graphql query
         L.unLogger logger $ QueryLog query Nothing reqId
+        let wsId = WS.getWSId wsConn
+            uniqSubId = LQ.UniqueSubscriberId wsId opId
         -- NOTE!: we mask async exceptions higher in the call stack, but it's
         -- crucial we don't lose lqId after addLiveQuery returns successfully.
-        !lqId <- liftIO $ LQ.addLiveQuery logger lqMap lqOp liveQOnChange
+        !lqId <- liftIO $ LQ.addLiveQuery logger uniqSubId lqMap lqOp liveQOnChange
         let !opName = _grOperationName q
         liftIO $ $assertNFHere $! (lqId, opName)  -- so we don't write thunks to mutable vars
 

--- a/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
@@ -332,11 +332,10 @@ onStart serverEnv wsConn (StartMsg opId q) = catchAndIgnore $ do
       E.ExOpSubs lqOp -> do
         -- log the graphql query
         L.unLogger logger $ QueryLog query Nothing reqId
-        let wsId = WS.getWSId wsConn
-            uniqSubId = LQ.UniqueSubscriberId wsId opId
+        subscriberId <- liftIO $ LQ.mkSubscriberId (WS.getWSId wsConn) opId
         -- NOTE!: we mask async exceptions higher in the call stack, but it's
         -- crucial we don't lose lqId after addLiveQuery returns successfully.
-        !lqId <- liftIO $ LQ.addLiveQuery logger uniqSubId lqMap lqOp liveQOnChange
+        !lqId <- liftIO $ LQ.addLiveQuery logger subscriberId lqMap lqOp liveQOnChange
         let !opName = _grOperationName q
         liftIO $ $assertNFHere $! (lqId, opName)  -- so we don't write thunks to mutable vars
 

--- a/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
@@ -332,10 +332,13 @@ onStart serverEnv wsConn (StartMsg opId q) = catchAndIgnore $ do
       E.ExOpSubs lqOp -> do
         -- log the graphql query
         L.unLogger logger $ QueryLog query Nothing reqId
-        subscriberId <- liftIO $ LQ.mkSubscriberId (WS.getWSId wsConn) opId
+        let subscriberMetadata = LQ.mkSubscriberMetadata $ J.object
+                                 [ "websocket_id" J..= WS.getWSId wsConn
+                                 , "operation_id" J..= opId
+                                 ]
         -- NOTE!: we mask async exceptions higher in the call stack, but it's
         -- crucial we don't lose lqId after addLiveQuery returns successfully.
-        !lqId <- liftIO $ LQ.addLiveQuery logger subscriberId lqMap lqOp liveQOnChange
+        !lqId <- liftIO $ LQ.addLiveQuery logger subscriberMetadata lqMap lqOp liveQOnChange
         let !opName = _grOperationName q
         liftIO $ $assertNFHere $! (lqId, opName)  -- so we don't write thunks to mutable vars
 

--- a/server/src-lib/Hasura/Logging.hs
+++ b/server/src-lib/Hasura/Logging.hs
@@ -67,6 +67,7 @@ data instance EngineLogType Hasura
   | ELTWebhookLog
   | ELTQueryLog
   | ELTStartup
+  | ELTLivequeryPollerLog
   -- internal log types
   | ELTInternal !InternalLogTypes
   deriving (Show, Eq, Generic)
@@ -75,22 +76,24 @@ instance Hashable (EngineLogType Hasura)
 
 instance J.ToJSON (EngineLogType Hasura) where
   toJSON = \case
-    ELTHttpLog      -> "http-log"
+    ELTHttpLog -> "http-log"
     ELTWebsocketLog -> "websocket-log"
-    ELTWebhookLog   -> "webhook-log"
-    ELTQueryLog     -> "query-log"
-    ELTStartup      -> "startup"
-    ELTInternal t   -> J.toJSON t
+    ELTWebhookLog -> "webhook-log"
+    ELTQueryLog -> "query-log"
+    ELTStartup -> "startup"
+    ELTLivequeryPollerLog -> "livequery-poller-log"
+    ELTInternal t -> J.toJSON t
 
 instance J.FromJSON (EngineLogType Hasura) where
   parseJSON = J.withText "log-type" $ \s -> case T.toLower $ T.strip s of
-    "startup"       -> return ELTStartup
-    "http-log"      -> return ELTHttpLog
-    "webhook-log"   -> return ELTWebhookLog
+    "startup" -> return ELTStartup
+    "http-log" -> return ELTHttpLog
+    "webhook-log" -> return ELTWebhookLog
     "websocket-log" -> return ELTWebsocketLog
-    "query-log"     -> return ELTQueryLog
-    _               -> fail $ "Valid list of comma-separated log types: "
-                       <> BLC.unpack (J.encode userAllowedLogTypes)
+    "query-log" -> return ELTQueryLog
+    "livequery-poller-log" -> return ELTLivequeryPollerLog
+    _ -> fail $ "Valid list of comma-separated log types: "
+         <> BLC.unpack (J.encode userAllowedLogTypes)
 
 data InternalLogTypes
  = ILTUnstructured
@@ -105,7 +108,6 @@ data InternalLogTypes
  | ILTJwkRefreshLog
  | ILTTelemetry
  | ILTSchemaSyncThread
- | ILTPollerLog
  deriving (Show, Eq, Generic)
 
 instance Hashable InternalLogTypes
@@ -121,7 +123,6 @@ instance J.ToJSON InternalLogTypes where
     ILTJwkRefreshLog -> "jwk-refresh-log"
     ILTTelemetry -> "telemetry-log"
     ILTSchemaSyncThread -> "schema-sync-thread"
-    ILTPollerLog -> "poller-log"
 
 -- the default enabled log-types
 defaultEnabledEngineLogTypes :: Set.HashSet (EngineLogType Hasura)
@@ -151,6 +152,7 @@ userAllowedLogTypes =
   , ELTWebhookLog
   , ELTWebsocketLog
   , ELTQueryLog
+  , ELTLivequeryPollerLog
   ]
 
 data LogLevel

--- a/server/src-lib/Hasura/Logging.hs
+++ b/server/src-lib/Hasura/Logging.hs
@@ -105,6 +105,7 @@ data InternalLogTypes
  | ILTJwkRefreshLog
  | ILTTelemetry
  | ILTSchemaSyncThread
+ | ILTPollerLog
  deriving (Show, Eq, Generic)
 
 instance Hashable InternalLogTypes
@@ -120,6 +121,7 @@ instance J.ToJSON InternalLogTypes where
     ILTJwkRefreshLog -> "jwk-refresh-log"
     ILTTelemetry -> "telemetry-log"
     ILTSchemaSyncThread -> "schema-sync-thread"
+    ILTPollerLog -> "poller-log"
 
 -- the default enabled log-types
 defaultEnabledEngineLogTypes :: Set.HashSet (EngineLogType Hasura)

--- a/server/src-lib/Hasura/RQL/DDL/RemoteSchema.hs
+++ b/server/src-lib/Hasura/RQL/DDL/RemoteSchema.hs
@@ -156,7 +156,7 @@ runIntrospectRemoteSchema (RemoteSchemaNameQuery rsName) = do
         throw400 NotExists $
         "remote schema: " <> remoteSchemaNameToTxt rsName <> " not found"
       Just rCtx -> mergeGCtx (rscGCtx rCtx) GC.emptyGCtx
-      -- ^ merge with emptyGCtx to get default query fields
+      -- merge with emptyGCtx to get default query fields
   queryParts <- flip runReaderT rGCtx $ VQ.getQueryParts introspectionQuery
   (rootSelSet, _) <- flip runReaderT rGCtx $ VT.runReusabilityT $ VQ.validateGQ queryParts
   schemaField <-


### PR DESCRIPTION
Currently we don't log any metrics related to the polling that happens in the background to serve live queries. These metrics are captured and summarized internally using datatypes from ekg-core (which can be dumped by `/dev/subscriptions` endpoint). This PR changes this behaviour, the metrics can now be logged by enabling a new log type `livequery-poller-log`. They are not summarized internally anymore. This opens up options to pipe the poller logs into a metric collection system where they can be analyzed further. 

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server

### Steps to test and verify
Add `livequery-poller-log` to `HASURA_GRAPHQL_ENABLED_LOG_TYPES` and you'll see logs of type: 
```json
{"type":"livequery-poller-log","timestamp":"2020-06-01T20:58:58.565+0530","level":"info","detail":{"poller_id":"4ec1aab0-43e0-4978-bc33-36a4f642ae12","total_time":1.872028e-3,"snapshot_time":2.2264e-5,"batches":[{"pg_execution_time":1.71155e-3,"push_time":9.8706e-5}]}}
```
<!-- If this is a feature, what are the steps to try them out? -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No

## Notes to the reviewer:

Module dependency tree:

![image](https://user-images.githubusercontent.com/6562944/83425645-9c4cc200-a44b-11ea-92bc-4c90f10b10a7.png)