### PR TITLE
console: replace remote schema url in tests

### DIFF
--- a/console/cypress/helpers/remoteSchemaHelpers.ts
+++ b/console/cypress/helpers/remoteSchemaHelpers.ts
@@ -6,7 +6,7 @@ export const getRemoteSchemaName = (i: number, schemaName: string) =>
   `test-remote-schema-${schemaName}-${i}`;
 
 export const getRemoteGraphQLURL = () =>
-  'https://realtime-poll.demo.hasura.app/v1/graphql';
+  'https://hasura-sample-remote-schema.glitch.me/';
 
 export const getRemoteGraphQLURLFromEnv = () => 'GRAPHQL_URL';
 


### PR DESCRIPTION
### Description

This PR replaces remote schema used in Cypress tests and fixes failing tests. 

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Console