### PR TITLE
console: fix "Cannot read property 'foldable'" runtime error in `Browse Rows` page (fix #4907)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ Read more about the session argument for computed fields in the [docs](https://h
 - console: fix visiting view modify page overwriting raw sql content (fix #4798) (#4810)
 - console: add help button and move about page to settings (#4848)
 - console: add new sidebar icon that separates enums from tables (fix #4984) (#4992)
-- console: fix runtime error when accessing a table in `Browse Rows` page (fix #4907) (#5016)
+- console: fix "Cannot read property 'foldable'" runtime error in `Browse Rows` page (fix #4907) (#5016)
 - cli: list all available commands in root command help (fix #4623) (#4628)
 - cli: fix bug with squashing event triggers (close #4883)
 - cli: add support for skipping execution while generating migrations through the migrate REST API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ Read more about the session argument for computed fields in the [docs](https://h
 - console: fix visiting view modify page overwriting raw sql content (fix #4798) (#4810)
 - console: add help button and move about page to settings (#4848)
 - console: add new sidebar icon that separates enums from tables (fix #4984) (#4992)
-- console: fix runtime error in `Browse Rows` page (fix #4907) (#5016)
+- console: fix runtime error when accessing a table in `Browse Rows` page (fix #4907) (#5016)
 - cli: list all available commands in root command help (fix #4623) (#4628)
 - cli: fix bug with squashing event triggers (close #4883)
 - cli: add support for skipping execution while generating migrations through the migrate REST API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Read more about the session argument for computed fields in the [docs](https://h
 - console: fix visiting view modify page overwriting raw sql content (fix #4798) (#4810)
 - console: add help button and move about page to settings (#4848)
 - console: add new sidebar icon that separates enums from tables (fix #4984) (#4992)
+- console: fix runtime error in `Browse Rows` page (fix #4907) (##5016)
 - cli: list all available commands in root command help (fix #4623) (#4628)
 - cli: fix bug with squashing event triggers (close #4883)
 - cli: add support for skipping execution while generating migrations through the migrate REST API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ Read more about the session argument for computed fields in the [docs](https://h
 - console: fix visiting view modify page overwriting raw sql content (fix #4798) (#4810)
 - console: add help button and move about page to settings (#4848)
 - console: add new sidebar icon that separates enums from tables (fix #4984) (#4992)
-- console: fix runtime error in `Browse Rows` page (fix #4907) (##5016)
+- console: fix runtime error in `Browse Rows` page (fix #4907) (#5016)
 - cli: list all available commands in root command help (fix #4623) (#4628)
 - cli: fix bug with squashing event triggers (close #4883)
 - cli: add support for skipping execution while generating migrations through the migrate REST API

--- a/console/src/components/Common/TableCommon/foldableTable/index.jsx
+++ b/console/src/components/Common/TableCommon/foldableTable/index.jsx
@@ -194,7 +194,7 @@ export default ReactTable => {
     };
 
     applyFoldableForColumns = columns => {
-      return columns.map((col, index) => {
+      return columns.filter(Boolean).map((col, index) => {
         if (!col.foldable) return col;
 
         //If col don't have id then generate id based on index

--- a/console/src/components/Common/Tooltip/Tooltip.tsx
+++ b/console/src/components/Common/Tooltip/Tooltip.tsx
@@ -2,14 +2,20 @@ import React from 'react';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
 import styles from './Tooltip.scss';
+
 const tooltipGen = (message: string) => {
   return <Tooltip id={message}>{message}</Tooltip>;
-};export interface TooltipProps extends React.ComponentProps<'i'> {
+};
+export interface TooltipProps extends React.ComponentProps<'i'> {
   message: string;
   placement?: 'right' | 'left' | 'top' | 'bottom';
   className?: string;
 }
-const ToolTip: React.FC<TooltipProps> = ({ message, placement = 'right', children }) => (
+const ToolTip: React.FC<TooltipProps> = ({
+  message,
+  placement = 'right',
+  children,
+}) => (
   <OverlayTrigger placement={placement} overlay={tooltipGen(message)}>
     {children || (
       <i


### PR DESCRIPTION
Solves https://github.com/hasura/graphql-engine/issues/4907

### Description
This PR filters columns list for truthy values. 

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Console
