### PR TITLE
console: fix handling inconsistent objects (close #5072)

### DIFF
--- a/console/src/components/Services/Settings/MetadataStatus/MetadataStatus.js
+++ b/console/src/components/Services/Settings/MetadataStatus/MetadataStatus.js
@@ -42,12 +42,10 @@ const MetadataStatus = ({ dispatch, metadata }) => {
                 ico.definition.table
               )}"`;
             } else if (ico.type === 'remote_relationship') {
-              name = ico.definition.configuration.name;
+              name = ico.definition.name;
               definition = `relationship between table "${getTableNameFromDef(
                 ico.definition.table
-              )}" and remote schema "${
-                ico.definition.configuration.remote_schema
-              }"`;
+              )}" and remote schema "${ico.definition.remote_schema}"`;
             } else if (permissionTypes.includes(ico.type)) {
               name = `${ico.definition.role}-permission`;
               definition = `${ico.type} on table "${getTableNameFromDef(


### PR DESCRIPTION
Solves https://github.com/hasura/graphql-engine/issues/5072

### Description

The console was trying to access ` ico.definition.configuration` which was undefined and would result in runtime errors and crashing the console. All the information needed is in `ico.definition`. 

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components

- [x] Console
