### PR TITLE
server: upgrade pg-client-hs to avoid loss of precision (fix #5092)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Read more about the session argument for computed fields in the [docs](https://h
 - server: compile with GHC 8.10.1, closing a space leak with subscriptions. (close #4517) (#3388)
 - server: fixes an issue where introspection queries with variables would fail because of caching (fix #4547)
 - server: avoid loss of precision when passing values in scientific notation (fix #4733)
+- server: avoid loss of precision when retrieving floats (fix #5092) (#5104)
 - server: raise error on startup when `--unauthorized-role` is ignored (#4736)
 - server: fix mishandling of GeoJSON inputs in subscriptions (fix #3239)
 - server: fix importing of allow list query from metadata (fix #4687)

--- a/server/cabal.project
+++ b/server/cabal.project
@@ -35,8 +35,8 @@ package graphql-engine
 
 source-repository-package
   type: git
-  location: https://github.com/hasura/pg-client-hs.git
-  tag: 70a849d09bea9461e72c5a5bbde06df65aab61c0
+  location: https://github.com/abooij/pg-client-hs.git
+  tag: 6b5443b8850586f67b5bc2af95635abe431075cd
 
 source-repository-package
   type: git

--- a/server/src-lib/Hasura/Server/API/PGDump.hs
+++ b/server/src-lib/Hasura/Server/API/PGDump.hs
@@ -81,6 +81,7 @@ execPGDump b ci = do
       , "SET default_tablespace = '';"
       , "SET default_with_oids = false;"
       , "SET default_table_access_method = heap;"
+      , "SET extra_float_digits = 3;"
       , "CREATE SCHEMA public;"
       , "COMMENT ON SCHEMA public IS 'standard public schema';"
       ]

--- a/server/tests-py/queries/graphql_mutation/update/basic/numerics_inc.yaml
+++ b/server/tests-py/queries/graphql_mutation/update/basic/numerics_inc.yaml
@@ -1,4 +1,3 @@
-# NB: Don't test for the returned num_real, since the precision depends on the PG version.
 description: Updated numerics data using _inc operator
 url: /v1/graphql
 status: 200
@@ -11,8 +10,8 @@ query:
              num_smallint: -1
              num_integer: -1
              num_bigint: -1
-             num_real: -1.1
-             num_double: -1.1
+             num_real: -1.5
+             num_double: -1.5
              num_money: -1.1
              num_numeric: -1.1
           }
@@ -23,6 +22,7 @@ query:
             num_smallint
             num_integer
             num_bigint
+            num_real
             num_double
             num_money
             num_numeric
@@ -32,9 +32,10 @@ query:
   - query: |
       mutation {
         update_numerics(
-          where: {id: {_eq: 1}},
+          where: {id: {_eq: 2}},
           _inc: {
-             num_double: -3E-4
+             num_real: -15E-1
+             num_double: -15E-1
              num_money: -2E-2
              num_numeric: -1E-30
           }
@@ -42,6 +43,7 @@ query:
           affected_rows
           returning {
             id
+            num_real
             num_double
             num_money
             num_numeric
@@ -57,14 +59,16 @@ response:
           num_smallint: 12344
           num_integer: 12344
           num_bigint: '12344'
-          num_double: '12344.57'
+          num_real: 500000.5
+          num_double: '500000000000000.5'
           num_money: $12,344.57
           num_numeric: '12344.5700'
   - data:
       update_numerics:
         affected_rows: 1
         returning:
-        - id: 1
-          num_double: '12344.5697'
-          num_money: $12,344.55
-          num_numeric: '12344.5699999999999999999999999999990'
+        - id: 2
+          num_real: 500000.5
+          num_double: '500000000000000.5'
+          num_money: $12,345.65
+          num_numeric: '12345.6699999999999999999999999999990'

--- a/server/tests-py/queries/graphql_mutation/update/basic/values_setup.yaml
+++ b/server/tests-py/queries/graphql_mutation/update/basic/values_setup.yaml
@@ -35,7 +35,14 @@ args:
     - num_smallint: 12345
       num_integer: 12345
       num_bigint: 12345
-      num_real: 12345.67
-      num_double: 12345.67
+      num_real: 500002
+      num_double: 500000000000002
+      num_money: 12345.67
+      num_numeric: 12345.67
+    - num_smallint: 12345
+      num_integer: 12345
+      num_bigint: 12345
+      num_real: 500002
+      num_double: 500000000000002
       num_money: 12345.67
       num_numeric: 12345.67


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

#5092 reported a loss of precision when reading floats from the database. This was caused by odd default behavior by old versions of PostgreSQL.

The origin is that in PostgreSQL 11 and older, by default, floating point values are returned with a fixed decimal precision - in the case of `float4`, this is 6 digits. Using the option [`extra_float_digits`](https://www.postgresql.org/docs/11/runtime-config-client.html#GUC-EXTRA-FLOAT-DIGITS) (important: compare with the [v12 docs](https://www.postgresql.org/docs/12/runtime-config-client.html#GUC-EXTRA-FLOAT-DIGITS), which seems to claim some changed behavior alongside a change in the default value of `extra_float_digits`!), we can output the float with full precision. However, by default it is set to 0, which in this case means loss of precision.

This PR sets `extra_float_digits` to 3 globally to avoid this problem. But this introduces some platform dependent behavior when printing floats, so we make sure to modify our CI test suite to be resilient against this, by picking smartly chosen values that test the precision of floats, while at the same time being independent of the PostgreSQL version.

Additionally, we ask `pg_dump` to output floats with adequate precision using `extra_float_digits`.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [x] Tests

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
We've had a variety of number precision issues before, such as #4429 and #4435.

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No Breaking changes
