### PR TITLE
generalize query execution logic on Postgres

### DIFF
--- a/server/src-exec/Main.hs
+++ b/server/src-exec/Main.hs
@@ -28,15 +28,15 @@ runApp (HGEOptionsG rci hgeCmd) =
     HCServe serveOptions -> do
       (initCtx, initTime) <- initialiseCtx hgeCmd rci
       -- Catches the SIGTERM signal and initiates a graceful shutdown.
-      -- Graceful shutdown for regular HTTP requests is already implemented in 
+      -- Graceful shutdown for regular HTTP requests is already implemented in
       -- Warp, and is triggered by invoking the 'closeSocket' callback.
-      -- We only catch the SIGTERM signal once, that is, if the user hits CTRL-C 
+      -- We only catch the SIGTERM signal once, that is, if the user hits CTRL-C
       -- once again, we terminate the process immediately.
       _ <- liftIO $ Signals.installHandler
         Signals.sigTERM
         (Signals.CatchOnce (shutdownGracefully initCtx))
         Nothing
-      runHGEServer serveOptions initCtx initTime
+      runHGEServer serveOptions initCtx Nothing initTime
     HCExport -> do
       (initCtx, _) <- initialiseCtx hgeCmd rci
       res <- runTx' initCtx fetchMetadata Q.ReadCommitted

--- a/server/src-lib/Hasura/App.hs
+++ b/server/src-lib/Hasura/App.hs
@@ -221,9 +221,10 @@ runHGEServer
   -- ^ start time
   -> m ()
 runHGEServer ServeOptions{..} InitCtx{..} initTime = do
-  -- Comment this to enable expensive assertions from "GHC.AssertNF". These will log lines to
-  -- STDOUT containing "not in normal form". In the future we could try to integrate this into
-  -- our tests. For now this is a development tool.
+  -- Comment this to enable expensive assertions from "GHC.AssertNF". These
+  -- will log lines to STDOUT containing "not in normal form". In the future we
+  -- could try to integrate this into our tests. For now this is a development
+  -- tool.
   --
   -- NOTE: be sure to compile WITHOUT code coverage, for this to work properly.
   liftIO disableAssertNF
@@ -236,8 +237,9 @@ runHGEServer ServeOptions{..} InitCtx{..} initTime = do
 
   authMode <- either (printErrExit . T.unpack) return authModeRes
 
-  -- If an exception is encountered in 'mkWaiApp', flush the log buffer and rethrow
-  -- If we do not flush the log buffer on exception, then log lines written in 'mkWaiApp' may be missed
+  -- If an exception is encountered in 'mkWaiApp', flush the log buffer and
+  -- rethrow If we do not flush the log buffer on exception, then log lines
+  -- written in 'mkWaiApp' may be missed
   -- See: https://github.com/hasura/graphql-engine/issues/4772
   let flushLogger = liftIO $ FL.flushLogStr $ _lcLoggerSet loggerCtx
   HasuraApp app cacheRef cacheInitTime shutdownApp <- flip onException flushLogger $
@@ -387,7 +389,7 @@ runAsAdmin
   -> m (Either QErr a)
 runAsAdmin pool sqlGenCtx httpManager m = do
   let runCtx = RunCtx adminUserInfo httpManager sqlGenCtx
-      pgCtx = PGExecCtx pool Q.Serializable
+      pgCtx = mkPGExecCtx Q.Serializable pool
   runExceptT $ peelRun runCtx pgCtx Q.ReadWrite m
 
 execQuery

--- a/server/src-lib/Hasura/App.hs
+++ b/server/src-lib/Hasura/App.hs
@@ -217,10 +217,13 @@ runHGEServer
      )
   => ServeOptions impl
   -> InitCtx
+  -> Maybe PGExecCtx
+  -- ^ An optional specialized pg exection context for executing queries
+  -- and mutations
   -> UTCTime
   -- ^ start time
   -> m ()
-runHGEServer ServeOptions{..} InitCtx{..} initTime = do
+runHGEServer ServeOptions{..} InitCtx{..} pgExecCtx initTime = do
   -- Comment this to enable expensive assertions from "GHC.AssertNF". These
   -- will log lines to STDOUT containing "not in normal form". In the future we
   -- could try to integrate this into our tests. For now this is a development
@@ -248,6 +251,7 @@ runHGEServer ServeOptions{..} InitCtx{..} initTime = do
              sqlGenCtx
              soEnableAllowlist
              _icPgPool
+             pgExecCtx
              _icConnInfo
              _icHttpManager
              authMode

--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Plan.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Plan.hs
@@ -224,15 +224,15 @@ validateVariables
   -> m (ValidatedVariables f)
 validateVariables pgExecCtx variableValues = do
   let valSel = mkValidationSel $ toList variableValues
-  Q.Discard () <- runTx' $ liftTx $
+  Q.Discard () <- runQueryTx_ $ liftTx $
     Q.rawQE dataExnErrHandler (Q.fromBuilder $ toSQL valSel) [] False
   pure . ValidatedVariables $ fmap (txtEncodedPGVal . pstValue) variableValues
   where
     mkExtrs = map (flip S.Extractor Nothing . toTxtValue)
     mkValidationSel vars =
       S.mkSelect { S.selExtr = mkExtrs vars }
-    runTx' tx = do
-      res <- liftIO $ runExceptT (runLazyTx' pgExecCtx tx)
+    runQueryTx_ tx = do
+      res <- liftIO $ runExceptT (runQueryTx pgExecCtx tx)
       liftEither res
 
     -- Explicitly look for the class of errors raised when the format of a value provided

--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Poll.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Poll.hs
@@ -408,7 +408,7 @@ pollQuery logger pollerId lqOpts pgExecCtx pgQuery cohortMap = do
     -- concurrently process each batch
     batchesDetails <- A.forConcurrently cohortBatches $ \cohorts -> do
       (queryExecutionTime, mxRes) <- withElapsedTime $
-        runExceptT $ runLazyTx' pgExecCtx $
+        runExceptT $ runQueryTx pgExecCtx $
           executeMultiplexedQuery pgQuery $ over (each._2) _csVariables cohorts
 
       let lqMeta = LiveQueryMetadata $ convertDuration queryExecutionTime

--- a/server/src-lib/Hasura/GraphQL/Transport/HTTP.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/HTTP.hs
@@ -129,7 +129,7 @@ runHasuraGQ reqId query userInfo resolvedOp = do
     E.ExOpQuery tx genSql -> do
       -- log the generated SQL and the graphql query
       L.unLogger logger $ QueryLog query genSql reqId
-      ([],) <$> runLazyTx' pgExecCtx tx
+      ([],) <$> runQueryTx pgExecCtx tx
 
     E.ExOpMutation respHeaders tx -> do
       -- log the graphql query

--- a/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
@@ -342,7 +342,7 @@ onStart serverEnv wsConn (StartMsg opId q) = catchAndIgnore $ do
                 -> ExceptT () m ()
     runHasuraGQ timerTot telemCacheHit reqId query userInfo = \case
       E.ExOpQuery opTx genSql ->
-        execQueryOrMut Telem.Query genSql $ runLazyTx' pgExecCtx opTx
+        execQueryOrMut Telem.Query genSql $ runQueryTx pgExecCtx opTx
       -- Response headers discarded over websockets
       E.ExOpMutation _ opTx ->
         execQueryOrMut Telem.Mutation Nothing $

--- a/server/src-lib/Hasura/Server/SchemaUpdate.hs
+++ b/server/src-lib/Hasura/Server/SchemaUpdate.hs
@@ -2,9 +2,9 @@ module Hasura.Server.SchemaUpdate
   (startSchemaSyncThreads)
 where
 
+import           Hasura.Db
 import           Hasura.Prelude
 import           Hasura.Session
-
 import           Hasura.Logging
 import           Hasura.RQL.DDL.Schema       (runCacheRWT)
 import           Hasura.RQL.Types
@@ -228,7 +228,7 @@ refreshSchemaCache sqlGenCtx pool logger httpManager cacheRef invalidations thre
     Right () -> logInfo logger threadType $ object ["message" .= msg]
  where
   runCtx = RunCtx adminUserInfo httpManager sqlGenCtx
-  pgCtx = PGExecCtx pool PG.Serializable
+  pgCtx = mkPGExecCtx PG.Serializable pool
 
 logInfo :: Logger Hasura -> ThreadType -> Value -> IO ()
 logInfo logger threadType val = unLogger logger $

--- a/server/src-test/Main.hs
+++ b/server/src-test/Main.hs
@@ -17,7 +17,7 @@ import qualified Network.HTTP.Client          as HTTP
 import qualified Network.HTTP.Client.TLS      as HTTP
 import qualified Test.Hspec.Runner            as Hspec
 
-import           Hasura.Db                    (PGExecCtx (..))
+import           Hasura.Db                    (mkPGExecCtx)
 import           Hasura.RQL.Types             (SQLGenCtx (..))
 import           Hasura.RQL.Types.Run
 import           Hasura.Server.Init           (RawConnInfo, mkConnInfo, mkRawConnInfo,
@@ -79,7 +79,7 @@ buildPostgresSpecs pgConnOptions = do
 
         httpManager <- HTTP.newManager HTTP.tlsManagerSettings
         let runContext = RunCtx adminUserInfo httpManager (SQLGenCtx False)
-            pgContext = PGExecCtx pgPool Q.Serializable
+            pgContext = mkPGExecCtx Q.Serializable pgPool
 
             runAsAdmin :: Run a -> IO a
             runAsAdmin =


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
Currently, all our Postgres execution logic is written to work against a single Postgres pool. This PR brings in an abstraction where this can be customized - in OSS the implementation will use a single Postgres pool but this enables pro to offer more options.

### Changelog
- No changelog required.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server

### Server checklist
<!-- A checklist for server code -->

#### Breaking changes

- [x] No Breaking changes
