### PR TITLE
drop catalog dependencies when parent column/table is dropped containing a remote relationship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ hasura seed apply --file 1234_add_some_seed_data.sql
 - server: fix importing of allow list query from metadata (fix #4687)
 - server: flush log buffer during shutdown (#4800)
 - server: fix edge case with printing logs on startup failure (fix #4772)
+- server: fix bug which arises when dropping a column with a remote relationship dependency (fix #5103)
 - console: provide option to cascade metadata on dependency conflicts on console (fix #1593)
 - console: fix enum tables reload data button UI (#4647)
 - console: allow entering big int values in the console (close #3667) (#4775)

--- a/server/src-lib/Hasura/RQL/DDL/Schema/Catalog.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Catalog.hs
@@ -21,6 +21,7 @@ import           Hasura.RQL.DDL.ComputedField
 import           Hasura.RQL.DDL.EventTrigger
 import           Hasura.RQL.DDL.Permission.Internal
 import           Hasura.RQL.DDL.Relationship
+import           Hasura.RQL.DDL.RemoteRelationship
 import           Hasura.RQL.DDL.Schema.Function
 import           Hasura.RQL.Types
 import           Hasura.RQL.Types.Catalog
@@ -38,6 +39,7 @@ purgeDependentObject = \case
   SOFunction qf -> liftTx $ delFunctionFromCatalog qf
   SOTableObj _ (TOTrigger trn) -> liftTx $ delEventTriggerFromCatalog trn
   SOTableObj qt (TOComputedField ccn) -> dropComputedFieldFromCatalog qt ccn
+  SOTableObj qt (TORemoteRel remoteRelName) -> liftTx $ delRemoteRelFromCatalog qt remoteRelName
   schemaObjId -> throw500 $ "unexpected dependent object: " <> reportSchemaObj schemaObjId
 
 saveTableToCatalog

--- a/server/tests-py/queries/remote_schemas/remote_relationships/drop_col_with_remote_rel_dependency.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/drop_col_with_remote_rel_dependency.yaml
@@ -1,0 +1,44 @@
+- description: Add a new column to the table and create a remote relationship using this column
+  url: /v1/query
+  status: 200
+  query:
+    type: run_sql
+    args:
+      sql: ALTER TABLE profiles add column profile_id int
+
+- description: Create a remote relationship with the new column
+  url: /v1/query
+  status: 200
+  query:
+    type: create_remote_relationship
+    args:
+      name: messagesNestedArgs
+      table: profiles
+      hasura_fields:
+        - profile_id
+      remote_schema: my-remote-schema
+      remote_field:
+        messages:
+          arguments:
+            where:
+              id:
+                eq: "$profile_id"
+
+- description: Drop the column which was used to create the remote relationship, it should drop the column along with the dependent remote relationship when cascaded
+  url: /v1/query
+  status: 200
+  query:
+    type: run_sql
+    args:
+      sql: ALTER TABLE profiles drop column profile_id
+      cascade: true
+
+- description: Check if the remote relationship was dropped
+  url: /v1/query
+  status: 200
+  query:
+    type: run_sql
+    args:
+      sql: SELECT * from hdb_catalog.hdb_remote_relationship
+           where table_schema = 'public' and table_name = 'profiles' and remote_relationship_name = 'messagesNestedArgs'
+  response: []

--- a/server/tests-py/queries/remote_schemas/remote_relationships/drop_table_with_remote_rel_dependency.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/drop_table_with_remote_rel_dependency.yaml
@@ -1,0 +1,36 @@
+- description: Create a remote relationship with the new column
+  url: /v1/query
+  status: 200
+  query:
+    type: create_remote_relationship
+    args:
+      name: messagesNestedArgs
+      table: profiles
+      hasura_fields:
+        - id
+      remote_schema: my-remote-schema
+      remote_field:
+        messages:
+          arguments:
+            where:
+              id:
+                eq: "$id"
+
+- description: Drop the table, which has a remote relationship dependency
+  url: /v1/query
+  status: 200
+  query:
+    type: run_sql
+    args:
+      sql: DROP TABLE profiles
+      cascade: true
+
+- description: Check if the remote relationship was dropped
+  url: /v1/query
+  status: 200
+  query:
+    type: run_sql
+    args:
+      sql: SELECT * from hdb_catalog.hdb_remote_relationship
+           where table_schema = 'public' and table_name = 'profiles' and remote_relationship_name = 'messagesNestedArgs'
+  response: []

--- a/server/tests-py/test_remote_relationships.py
+++ b/server/tests-py/test_remote_relationships.py
@@ -113,6 +113,12 @@ class TestDeleteRemoteRelationship:
         st_code, resp = hge_ctx.v1q_f(self.dir() + 'delete_remote_rel.yaml')
         assert st_code == 200, resp
 
+    def test_deleting_column_with_remote_relationship_dependency(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + 'drop_col_with_remote_rel_dependency.yaml')
+
+    def test_deleting_table_with_remote_relationship_dependency(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + 'drop_table_with_remote_rel_dependency.yaml')
+
 @use_test_fixtures
 class TestUpdateRemoteRelationship:
     @classmethod


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

fixes #5103 

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [x] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
