### PR TITLE
fix introspection faling when multiple actions defined with PG scalar types (fix #5166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 (Add entries here in the order of: server, console, cli, docs, others)
 
-- server: fix introspection failing multiple actions using Postgres scalar types (fix #5166)
+- server: fix introspection when multiple actions defined with Postgres scalar types (fix #5166) (#5173)
 - console: allow manual edit of column types and handle array data types (close #2544, #3335, #2583) (#4546)
 - console: add the ability to delete a role in permissions summary page (close #3353) (#4987)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 (Add entries here in the order of: server, console, cli, docs, others)
 
+- server: fix introspection failing multiple actions using Postgres scalar types (fix #5166)
 - console: allow manual edit of column types and handle array data types (close #2544, #3335, #2583) (#4546)
 - console: add the ability to delete a role in permissions summary page (close #3353) (#4987)
 
@@ -97,7 +98,7 @@ Read more about the session argument for computed fields in the [docs](https://h
 A new `seeds` command is introduced in CLI, this will allow managing seed migrations as SQL files
 
 #### Creating seed
-```                                                        
+```
 # create a new seed file and use editor to add SQL content
 hasura seed create new_table_seed
 

--- a/server/tests-py/queries/actions/introspection/introspection_query.yaml
+++ b/server/tests-py/queries/actions/introspection/introspection_query.yaml
@@ -1,0 +1,105 @@
+# Test case for bug reported at https://github.com/hasura/graphql-engine/issues/5166
+description: GraphQL introspection query
+url: /v1/graphql
+status: 200
+query:
+  query: |
+    query IntrospectionQuery {
+      __schema {
+        queryType {
+          name
+          }
+        mutationType {
+          name
+          }
+        subscriptionType {
+          name
+          }
+          types {
+          ...FullType
+          }
+        directives {
+          name
+          description
+          locations
+          args {
+          ...InputValue
+          }
+        }
+      }
+    }
+
+    fragment FullType on __Type {
+      kind
+      name
+      description
+      fields(includeDeprecated: true) {
+        name
+        description
+        args {
+        ...InputValue
+        }
+        type {
+        ...TypeRef
+        }
+        isDeprecated
+        deprecationReason
+      }
+      inputFields {
+        ...InputValue
+      }
+      interfaces {
+        ...TypeRef
+      }
+      enumValues(includeDeprecated: true) {
+          name
+          description
+          isDeprecated
+          deprecationReason
+      }
+      possibleTypes {
+        ...TypeRef
+      }
+    }
+
+    fragment InputValue on __InputValue {
+    name
+    description
+    type {
+    ...TypeRef
+    }
+    defaultValue
+    }
+
+    fragment TypeRef on __Type {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }

--- a/server/tests-py/queries/actions/introspection/setup.yaml
+++ b/server/tests-py/queries/actions/introspection/setup.yaml
@@ -1,0 +1,46 @@
+type: bulk
+args:
+- type: replace_metadata
+  args:
+    version: 2
+    tables: []
+    actions:
+    - name: actionName
+      definition:
+        handler: http://localhost:3000
+        output_type: SampleOutput
+        arguments:
+        - name: text
+          type: jsonb!
+        - name: attributes
+          type: String!
+        type: mutation
+        kind: synchronous
+    - name: actionName2
+      definition:
+        handler: http://localhost:3000
+        output_type: SampleOutput2
+        arguments:
+        - name: a
+          type: ID!
+        - name: b
+          type: ID!
+        type: mutation
+        kind: synchronous
+    custom_types:
+      input_objects:
+      - name: SampleInput
+        fields:
+        - name: username
+          type: String!
+        - name: password
+          type: String!
+      objects:
+      - name: SampleOutput
+        fields:
+        - name: id
+          type: String!
+      - name: SampleOutput2
+        fields:
+        - name: id
+          type: String!

--- a/server/tests-py/queries/actions/introspection/teardown.yaml
+++ b/server/tests-py/queries/actions/introspection/teardown.yaml
@@ -1,0 +1,5 @@
+type: bulk
+args:
+- type: replace_metadata
+  args:
+    tables: []

--- a/server/tests-py/test_actions.py
+++ b/server/tests-py/test_actions.py
@@ -454,3 +454,21 @@ class TestActionsMetadata:
 
     def test_recreate_permission(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + '/recreate_permission.yaml')
+
+# Test case for bug reported at https://github.com/hasura/graphql-engine/issues/5166
+@pytest.mark.usefixtures('per_class_tests_db_state')
+class TestActionIntrospection:
+
+    @classmethod
+    def dir(cls):
+        return 'queries/actions/introspection'
+
+    def test_introspection_query(self, hge_ctx):
+        conf = get_conf_f(self.dir() + '/introspection_query.yaml')
+        headers = {}
+        admin_secret = hge_ctx.hge_key
+        if admin_secret:
+            headers['X-Hasura-Admin-Secret'] = admin_secret
+        code, resp, _ = hge_ctx.anyq(conf['url'], conf['query'], headers)
+        assert code == 200, resp
+        assert 'data' in resp, resp


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Introspection query is failing with `type info not found for xxxx` error message if multiple actions are defined with reused PG scalars. The PR fixes the same.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [x] Tests

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
Fix #5166 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
See the in line diff [comment](https://github.com/hasura/graphql-engine/pull/5173#discussion_r443657562). 

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Define more than one actions with PG scalars. The introspection query should go through and schema should be shown in the graphiql docs.

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->
NA

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes

#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes

<!-- Explain briefly about your breaking changes below -->
