### PR TITLE
docs: clarify unauthenticated access docs (close #2528)

### DIFF
--- a/docs/graphql/manual/auth/authentication/index.rst
+++ b/docs/graphql/manual/auth/authentication/index.rst
@@ -61,4 +61,4 @@ Here's how a GraphQL query is processed in JWT mode:
 
   Using webhooks <webhook>
   Using JWT <jwt>
-  Unauthenticated access <unauthenticated-access>
+  Unauthenticated / Public access <unauthenticated-access>

--- a/docs/graphql/manual/auth/authentication/unauthenticated-access.rst
+++ b/docs/graphql/manual/auth/authentication/unauthenticated-access.rst
@@ -1,11 +1,11 @@
 .. meta::
-   :description: Manage unauthenticated access in Hasura
-   :keywords: hasura, docs, authentication, auth, unauthenticated access
+   :description: Manage unauthenticated / public access in Hasura
+   :keywords: hasura, docs, authentication, auth, unauthenticated access, public access
 
 .. _unauthenticated_access:
 
-Unauthenticated access
-======================
+Unauthenticated / Public access
+===============================
 
 .. contents:: Table of contents
   :backlinks: none
@@ -21,8 +21,8 @@ It is a common requirement to have requests which are accessible to all users wi
 You can configure Hasura GraphQL engine to allow access to unauthenticated users by defining a specific role
 which will be set for all unauthenticated requests.
 
-Configuring unauthenticated access
-----------------------------------
+Configuring unauthenticated / public access
+-------------------------------------------
 
 Once you have configured authentication, by default Hasura GraphQL engine will reject any unauthenticated request it
 receives.
@@ -32,7 +32,7 @@ Webhooks
 
 For :ref:`webhook authentication <auth_webhooks>`, an unauthenticated request is any request for which the webhook returns a ``401 Unauthorized`` response.
 
-For unauthenticated access, you can return a ``200`` status response with your defined anonymous role, e.g: ``{ "x-hasura-role": "<anonymous role>" }``.
+For unauthenticated access, you can return a ``200`` status response with your defined unauthenticated role, e.g: ``{ "x-hasura-role": "<anonymous-role>" }``.
 
 Once an unauthenticated role is configured, unaunthenticated requests will not be rejected and instead the request will
 be made with the configured role.

--- a/docs/graphql/manual/auth/authentication/unauthenticated-access.rst
+++ b/docs/graphql/manual/auth/authentication/unauthenticated-access.rst
@@ -21,8 +21,32 @@ It is a common requirement to have requests which are accessible to all users wi
 You can configure Hasura GraphQL engine to allow access to unauthenticated users by defining a specific role
 which will be set for all unauthenticated requests.
 
+How it works
+------------
+
+Once you have configured authentication, by default Hasura GraphQL engine will reject any unauthenticated request it
+receives.
+
+Webhooks
+^^^^^^^^
+
+For :ref:`webhook authentication <auth_webhooks>`, an unauthenticated request is any request for which the webhook returns a ``401 Unauthorized`` response.
+
 Configuring unauthenticated access
-----------------------------------
+**********************************
+
+For unauthenticated access, you can return a ``200`` status response with your defined anonymous role, e.g: ``{ "x-hasura-role": "<anonymous role>" }``.
+
+Once an unauthenticated role is configured, unaunthenticated requests will not be rejected and instead the request will
+be made with the configured role.
+
+JWT
+^^^
+
+For :ref:`JWT authentication <auth_jwt>`, an unauthenticated request is any request which does not contain a JWT token.
+
+Configuring unauthenticated access
+**********************************
 
 You can use the env variable ``HASURA_GRAPHQL_UNAUTHORIZED_ROLE`` or ``--unauthorized-role`` flag to set a role
 for unauthenticated (non-logged in) users. See :ref:`server_flag_reference` for more details
@@ -30,17 +54,6 @@ on setting this flag/env var.
 
 This role can then be used to define the permissions for unauthenticated users as described in :ref:`authorization`.
 A guide on setting up unauthenticated user permissions can be found :ref:`here <anonymous_users_example>`.
-
-How it works
-------------
-
-Once you have configured authentication, by default Hasura GraphQL engine will reject any unauthenticated request it
-receives.
-
-Based on your authentication setup, an unauthenticated request is any request:
-
-- for which the webhook returns a ``401 Unauthorized`` response in case of :ref:`webhook authentication <auth_webhooks>`.
-- which does not contain a JWT token in case of :ref:`JWT authentication <auth_jwt>`.
 
 Once an unauthenticated role is configured, unaunthenticated requests will not be rejected and instead the request will
 be made with the configured role.

--- a/docs/graphql/manual/auth/authentication/unauthenticated-access.rst
+++ b/docs/graphql/manual/auth/authentication/unauthenticated-access.rst
@@ -9,7 +9,7 @@ Unauthenticated access
 
 .. contents:: Table of contents
   :backlinks: none
-  :depth: 1
+  :depth: 2
   :local:
 
 Use case
@@ -21,8 +21,8 @@ It is a common requirement to have requests which are accessible to all users wi
 You can configure Hasura GraphQL engine to allow access to unauthenticated users by defining a specific role
 which will be set for all unauthenticated requests.
 
-How it works
-------------
+Configuring unauthenticated access
+----------------------------------
 
 Once you have configured authentication, by default Hasura GraphQL engine will reject any unauthenticated request it
 receives.
@@ -31,9 +31,6 @@ Webhooks
 ^^^^^^^^
 
 For :ref:`webhook authentication <auth_webhooks>`, an unauthenticated request is any request for which the webhook returns a ``401 Unauthorized`` response.
-
-Configuring unauthenticated access
-**********************************
 
 For unauthenticated access, you can return a ``200`` status response with your defined anonymous role, e.g: ``{ "x-hasura-role": "<anonymous role>" }``.
 
@@ -44,9 +41,6 @@ JWT
 ^^^
 
 For :ref:`JWT authentication <auth_jwt>`, an unauthenticated request is any request which does not contain a JWT token.
-
-Configuring unauthenticated access
-**********************************
 
 You can use the env variable ``HASURA_GRAPHQL_UNAUTHORIZED_ROLE`` or ``--unauthorized-role`` flag to set a role
 for unauthenticated (non-logged in) users. See :ref:`server_flag_reference` for more details

--- a/docs/graphql/manual/auth/authentication/unauthenticated-access.rst
+++ b/docs/graphql/manual/auth/authentication/unauthenticated-access.rst
@@ -12,20 +12,26 @@ Unauthenticated / Public access
   :depth: 2
   :local:
 
-Use case
---------
+Introduction
+------------
 
 It is a common requirement to have requests which are accessible to all users without the need for any authentication
 (logging in). For example, to display a public feed of events.
 
+Once you have configured authentication, by default Hasura GraphQL engine will reject any unauthenticated request it
+receives. 
+
 You can configure Hasura GraphQL engine to allow access to unauthenticated users by defining a specific role
-which will be set for all unauthenticated requests.
+which will be set for all unauthenticated requests. Once an unauthenticated role is configured, unaunthenticated requests will 
+not be rejected and instead the request will be made with the configured role.
+
+This role can then be used to define the permissions for unauthenticated users as described in :ref:`authorization`.
+A guide on setting up unauthenticated user permissions can be found :ref:`here <anonymous_users_example>`.
 
 Configuring unauthenticated / public access
 -------------------------------------------
 
-Once you have configured authentication, by default Hasura GraphQL engine will reject any unauthenticated request it
-receives.
+Depending on your auth setup an unauthenticated role can be configured as follows:
 
 Webhooks
 ^^^^^^^^
@@ -33,9 +39,6 @@ Webhooks
 For :ref:`webhook authentication <auth_webhooks>`, an unauthenticated request is any request for which the webhook returns a ``401 Unauthorized`` response.
 
 For unauthenticated access, you can return a ``200`` status response with your defined unauthenticated role, e.g: ``{ "x-hasura-role": "<anonymous-role>" }``.
-
-Once an unauthenticated role is configured, unaunthenticated requests will not be rejected and instead the request will
-be made with the configured role.
 
 JWT
 ^^^
@@ -45,11 +48,4 @@ For :ref:`JWT authentication <auth_jwt>`, an unauthenticated request is any requ
 You can use the env variable ``HASURA_GRAPHQL_UNAUTHORIZED_ROLE`` or ``--unauthorized-role`` flag to set a role
 for unauthenticated (non-logged in) users. See :ref:`server_flag_reference` for more details
 on setting this flag/env var.
-
-This role can then be used to define the permissions for unauthenticated users as described in :ref:`authorization`.
-A guide on setting up unauthenticated user permissions can be found :ref:`here <anonymous_users_example>`.
-
-Once an unauthenticated role is configured, unaunthenticated requests will not be rejected and instead the request will
-be made with the configured role.
-
 


### PR DESCRIPTION
### Description

Clarify unauthenticated access for webhook & JWT authentication.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components

- [x] Docs

### Related Issues

https://github.com/hasura/graphql-engine/issues/2528

### Affected page

https://deploy-preview-5217--hasura-docs.netlify.app/graphql/manual/auth/authentication/unauthenticated-access.html