### PR TITLE
console: add eslint-plugin-react-hooks

### DIFF
--- a/console/.eslintrc
+++ b/console/.eslintrc
@@ -72,6 +72,8 @@
     "react/no-unescaped-entities": 0,
     "react/sort-comp": 0,
     "react/jsx-indent": 0,
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
     "jsx-a11y/click-events-have-key-events": 0,
     "jsx-a11y/no-static-element-interactions": 0,
     "jsx-a11y/no-noninteractive-element-interactions": 0,
@@ -86,7 +88,12 @@
     "eqeqeq": 0,
     "no-nested-ternary": 0
   },
-  "plugins": ["react", "import", "@typescript-eslint/eslint-plugin"],
+  "plugins": [
+    "react",
+    "import",
+    "@typescript-eslint/eslint-plugin",
+    "react-hooks"
+  ],
   "settings": {
     "import/resolve": {
       "moduleDirectory": ["node_modules", "src"]

--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -7653,6 +7653,12 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.4.tgz",
+      "integrity": "sha512-equAdEIsUETLFNCmmCkiCGq6rkSK5MoJhXFPFYeUebcjKgBmWWcgVOqZyQC8Bv1BwVCnTq9tBxgJFgAJTWoJtA==",
+      "dev": true
+    },
     "eslint-restricted-globals": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",

--- a/console/package.json
+++ b/console/package.json
@@ -167,6 +167,7 @@
     "eslint-plugin-import": "2.18.2",
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-react": "7.19.0",
+    "eslint-plugin-react-hooks": "^4.0.4",
     "express": "4.17.1",
     "extract-hoc": "0.0.5",
     "extract-text-webpack-plugin": "3.0.2",

--- a/console/src/client.js
+++ b/console/src/client.js
@@ -100,20 +100,24 @@ if (__DEVELOPMENT__ && module.hot) {
   */
   module.hot.accept();
 }
-
 // Main routes and rendering
-const main = (
-  <Router
-    history={useBasename(() => history)({ basename: globals.urlPrefix })}
-    routes={getRoutes(store)}
-    onUpdate={hashLinkScroll}
-  />
-);
+const Main = () => {
+  const routeHistory = useBasename(() => history)({
+    basename: globals.urlPrefix,
+  });
+  return (
+    <Router
+      history={routeHistory}
+      routes={getRoutes(store)}
+      onUpdate={hashLinkScroll}
+    />
+  );
+};
 
 const dest = document.getElementById('content');
 ReactDOM.render(
   <Provider store={store} key="provider">
-    {main}
+    <Main />
   </Provider>,
   dest
 );

--- a/console/src/components/Common/Layout/LeftSubSidebar/LeftSidebarSection.tsx
+++ b/console/src/components/Common/Layout/LeftSubSidebar/LeftSidebarSection.tsx
@@ -13,7 +13,7 @@ interface LeftSidebarSectionProps extends React.ComponentProps<'div'> {
   service: string;
 }
 
-const getLeftSidebarSection = ({
+const LeftSidebarSection = ({
   items = [],
   currentItem,
   service,
@@ -96,4 +96,4 @@ const getLeftSidebarSection = ({
   };
 };
 
-export default getLeftSidebarSection;
+export default LeftSidebarSection;

--- a/console/src/components/Services/Data/TablePermissions/PermButtonsSection.tsx
+++ b/console/src/components/Services/Data/TablePermissions/PermButtonsSection.tsx
@@ -26,10 +26,6 @@ const PermButtonSection: React.FC<PermButtonSectionProps> = ({
   permsChanged,
   currQueryPermissions,
 }) => {
-  if (readOnlyMode) {
-    return null;
-  }
-
   const dispatchSavePermissions = useCallback(() => {
     const isInvalid = Object.values(localFilterString).some(val => {
       if (val && !isJsonString(val)) {
@@ -59,6 +55,10 @@ const PermButtonSection: React.FC<PermButtonSectionProps> = ({
       dispatch(permChangePermissions(permChangeTypes.delete));
     }
   }, [dispatch]);
+
+  if (readOnlyMode) {
+    return null;
+  }
 
   return (
     <div className={`${styles.add_mar_top} ${styles.add_pad_left}`}>


### PR DESCRIPTION
This PR will add `eslint-plugin-react-hooks` to the project as suggested here https://reactjs.org/docs/hooks-rules.html.

### Description
By adding this eslint plugin, now developer will start getting the errors if there is any violation of `Rules of React Hooks`.
https://reactjs.org/docs/hooks-rules.html.

### Changelog
- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
- [x] Console

### Related Issues

close https://github.com/hasura/graphql-engine-internal/issues/465

### Solution and Design
For now, I have turned off the strict check for exhausted dependencies, gradually we will move towards this goal.
```json
    "react-hooks/rules-of-hooks": "error",
    "react-hooks/exhaustive-deps": "warn",

```


### Steps to test and verify
run `npm run lint` and now we get warnings from eslint to react hook rule.

### Limitations, known bugs & workarounds
we have got more eslint warnings by enabling this, we need to slowly get rid of this. 

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No Breaking changes
