### PR TITLE
add section for managed databases and related perms (close #1677, close #3783)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Next release
 
+### Bug fixes and improvements
+
+(Add entries here in the order of: server, console, cli, docs, others)
+
+- docs: add note for managed databases in postgres requirements (close #1677, #3783) (#5228)
+
+
+## `v1.3.0-beta.3`
+
 
 ### Bug fixes and improvements
 

--- a/docs/graphql/manual/deployment/postgres-requirements.rst
+++ b/docs/graphql/manual/deployment/postgres-requirements.rst
@@ -67,13 +67,13 @@ Here's a sample SQL block that you can run on your database (as a **superuser**)
     ALTER SCHEMA hdb_views OWNER TO hasurauser;
 
     -- grant select permissions on information_schema and pg_catalog. This is
-    -- required for hasura to query list of available tables.
+    -- required for hasura to query the list of available tables.
     -- NOTE: these permissions are usually available by default to all users via PUBLIC grant
     GRANT SELECT ON ALL TABLES IN SCHEMA information_schema TO hasurauser;
     GRANT SELECT ON ALL TABLES IN SCHEMA pg_catalog TO hasurauser;
 
-    -- Below permissions are optional. This is dependent on what access to your
-    -- tables/schemas - you want give to hasura. If you want expose the public
+    -- The below permissions are optional. This is dependent on what access to your
+    -- tables/schemas you want give to hasura. If you want expose the public
     -- schema for GraphQL query then give permissions on public schema to the
     -- hasura user.
     -- Be careful to use these in your production db. Consult the postgres manual or
@@ -88,13 +88,13 @@ Here's a sample SQL block that you can run on your database (as a **superuser**)
     GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO hasurauser;
 
     -- Similarly add this for other schemas, if you have any.
-    -- GRANT USAGE ON SCHEMA <schema-name> TO hasurauser;
-    -- GRANT ALL ON ALL TABLES IN SCHEMA <schema-name> TO hasurauser;
-    -- GRANT ALL ON ALL SEQUENCES IN SCHEMA <schema-name> TO hasurauser;
-    -- GRANT ALL ON ALL FUNCTIONS IN SCHEMA <schema-name> TO hasurauser;
+    GRANT USAGE ON SCHEMA <schema-name> TO hasurauser;
+    GRANT ALL ON ALL TABLES IN SCHEMA <schema-name> TO hasurauser;
+    GRANT ALL ON ALL SEQUENCES IN SCHEMA <schema-name> TO hasurauser;
+    GRANT ALL ON ALL FUNCTIONS IN SCHEMA <schema-name> TO hasurauser;
 
-Note for managed databases (AWS RDS, GCP Cloud SQL, etc)
---------------------------------------------------------
+Note for managed databases (AWS RDS, GCP Cloud SQL, etc.)
+---------------------------------------------------------
 
 Hasura works out of the box with the default superuser, usually called "postgres", created by most managed cloud database providers. But if you are creating a new user and giving the :ref:`above <postgres_permissions>` privileges, then you may notice that the following commands may throw warnings/errors:
 

--- a/docs/graphql/manual/deployment/postgres-requirements.rst
+++ b/docs/graphql/manual/deployment/postgres-requirements.rst
@@ -9,7 +9,7 @@ Postgres requirements
 
 .. contents:: Table of contents
   :backlinks: none
-  :depth: 1
+  :depth: 2
   :local:
 
 .. _postgres_version_support:
@@ -86,16 +86,19 @@ Here's a sample SQL block that you can run on your database (as a **superuser**)
     GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO hasurauser;
     GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO hasurauser;
 
-    -- Similarly add this for other schemas, if you have any.
+    -- Similarly add these for other schemas as well, if you have any.
     -- GRANT USAGE ON SCHEMA <schema-name> TO hasurauser;
     -- GRANT ALL ON ALL TABLES IN SCHEMA <schema-name> TO hasurauser;
     -- GRANT ALL ON ALL SEQUENCES IN SCHEMA <schema-name> TO hasurauser;
     -- GRANT ALL ON ALL FUNCTIONS IN SCHEMA <schema-name> TO hasurauser;
 
-Note for managed databases (AWS RDS, GCP Cloud SQL, etc.)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Notes for managed databases (AWS RDS, GCP Cloud SQL, etc.)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Hasura works out of the box with the default superuser, usually called "postgres", created by most managed cloud database providers. On some cloud providers like **Google Cloud SQL**, if you are creating a new user and giving the :ref:`above <postgres_permissions>` privileges, then you may notice that the following commands may throw warnings/errors:
+Hasura works out of the box with the default superuser, usually called "postgres", created by most managed cloud database providers.
+
+On some cloud providers, like **Google Cloud SQL**, if you are creating a new user and giving the :ref:`above <postgres_permissions>` privileges, 
+then you may notice that the following commands may throw warnings/errors:
 
 .. code-block:: sql
 

--- a/docs/graphql/manual/deployment/postgres-requirements.rst
+++ b/docs/graphql/manual/deployment/postgres-requirements.rst
@@ -36,6 +36,7 @@ The Hasura GraphQL engine needs access to your Postgres database with the follow
 
 - (required) Read & write access on 2 schemas: ``hdb_catalog`` and ``hdb_views``.
 - (required) Read access to the ``information_schema`` and ``pg_catalog`` schemas, to query for list of tables.
+  Note that these permissions are usually available by default to all postgres users via `PUBLIC <https://www.postgresql.org/docs/current/sql-grant.html>`_ grant.
 - (required) Read access to the schemas (public or otherwise) if you only want to support queries.
 - (optional) Write access to the schemas if you want to support mutations as well.
 - (optional) To create tables and views via the Hasura console (the admin UI) you'll need the privilege to create
@@ -67,7 +68,7 @@ Here's a sample SQL block that you can run on your database (as a **superuser**)
 
     -- grant select permissions on information_schema and pg_catalog. This is
     -- required for hasura to query list of available tables.
-    -- NOTE: these permissions are usually available by default to all users via PUBLIC role
+    -- NOTE: these permissions are usually available by default to all users via PUBLIC grant
     GRANT SELECT ON ALL TABLES IN SCHEMA information_schema TO hasurauser;
     GRANT SELECT ON ALL TABLES IN SCHEMA pg_catalog TO hasurauser;
 
@@ -95,7 +96,7 @@ Here's a sample SQL block that you can run on your database (as a **superuser**)
 Note for managed databases (AWS RDS, GCP Cloud SQL, etc)
 --------------------------------------------------------
 
-Hasura works out of the box with the default superuser, usually called "postgres", created by most managed cloud database providers. But if you are creating a new user and giving the above privileges, then you may notice that the following commands may throw warnings/errors:
+Hasura works out of the box with the default superuser, usually called "postgres", created by most managed cloud database providers. But if you are creating a new user and giving the :ref:`above <postgres_permissions>` privileges, then you may notice that the following commands may throw warnings/errors:
 
 
 .. code-block:: sql
@@ -110,11 +111,11 @@ Hasura works out of the box with the default superuser, usually called "postgres
   ERROR:  permission denied for table pg_statistic
 
 
-You can choose to **ignore** these warnings/errors or skip granting these permission as all users have relevant access to ``information_schema`` and ``pg_catalog`` schemas by default (see keyword `PUBLIC <https://www.postgresql.org/docs/current/sql-grant.html>`__) .
+You can **ignore** these warnings/errors or skip granting these permission as all users have relevant access to ``information_schema`` and ``pg_catalog`` schemas by default (see keyword `PUBLIC <https://www.postgresql.org/docs/current/sql-grant.html>`_) .
 
 .. admonition:: Google Cloud SQL
 
-   On Google Cloud SQL, running ``ALTER SCHEMA hdb_catalog OWNER TO hasurauser;`` may give you an error ``ERROR:  must be member of role "hasurauser"``. You can fix this by running ``GRANT hasurauser to postgres;`` first, assuming "postgres" is the superuser. 
+   On Google Cloud SQL, running ``ALTER SCHEMA hdb_catalog OWNER TO hasurauser;`` may give you an error ``ERROR:  must be member of role "hasurauser"``. You can fix this by running ``GRANT hasurauser to postgres;`` first, assuming "postgres" is the superuser that you are running the commands with. 
 
 
 **pgcrypto** in PG search path

--- a/docs/graphql/manual/deployment/postgres-requirements.rst
+++ b/docs/graphql/manual/deployment/postgres-requirements.rst
@@ -87,15 +87,31 @@ Here's a sample SQL block that you can run on your database (as a **superuser**)
     GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO hasurauser;
 
     -- Similarly add this for other schemas, if you have any.
-    GRANT USAGE ON SCHEMA <schema-name> TO hasurauser;
-    GRANT ALL ON ALL TABLES IN SCHEMA <schema-name> TO hasurauser;
-    GRANT ALL ON ALL SEQUENCES IN SCHEMA <schema-name> TO hasurauser;
-    GRANT ALL ON ALL FUNCTIONS IN SCHEMA <schema-name> TO hasurauser;
+    -- GRANT USAGE ON SCHEMA <schema-name> TO hasurauser;
+    -- GRANT ALL ON ALL TABLES IN SCHEMA <schema-name> TO hasurauser;
+    -- GRANT ALL ON ALL SEQUENCES IN SCHEMA <schema-name> TO hasurauser;
+    -- GRANT ALL ON ALL FUNCTIONS IN SCHEMA <schema-name> TO hasurauser;
 
 Note for managed databases (AWS RDS, GCP Cloud SQL, etc.)
----------------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Hasura works out of the box with the default superuser, usually called "postgres", created by most managed cloud database providers. But if you are creating a new user and giving the :ref:`above <postgres_permissions>` privileges, then you may notice that the following commands may throw warnings/errors:
+Hasura works out of the box with the default superuser, usually called "postgres", created by most managed cloud database providers. On some cloud providers like **Google Cloud SQL**, if you are creating a new user and giving the :ref:`above <postgres_permissions>` privileges, then you may notice that the following commands may throw warnings/errors:
+
+.. code-block:: sql
+
+   postgres=> ALTER SCHEMA hdb_catalog OWNER TO hasurauser;
+   ERROR:  must be member of role "hasurauser"
+
+This happens because the superuser created by the cloud provider sometimes has different permissions. To fix this, you can run the following command first:
+
+.. code-block:: sql
+
+   -- assuming "postgres" is the superuser that you are running the commands with.
+   postgres=> GRANT hasurauser to postgres;
+   GRANT
+   postgres=> ALTER SCHEMA hdb_catalog OWNER TO hasurauser;
+
+You may also notice the following commands throw warnings/errors:
 
 .. code-block:: sql
 
@@ -108,11 +124,7 @@ Hasura works out of the box with the default superuser, usually called "postgres
   postgres=> GRANT SELECT ON ALL TABLES IN SCHEMA pg_catalog TO hasurauser;
   ERROR:  permission denied for table pg_statistic
 
-You can **ignore** these warnings/errors or skip granting these permission as all users have relevant access to ``information_schema`` and ``pg_catalog`` schemas by default (see keyword `PUBLIC <https://www.postgresql.org/docs/current/sql-grant.html>`_) .
-
-.. admonition:: Google Cloud SQL
-
-   On Google Cloud SQL, running ``ALTER SCHEMA hdb_catalog OWNER TO hasurauser;`` may give you an error ``ERROR:  must be member of role "hasurauser"``. You can fix this by running ``GRANT hasurauser to postgres;`` first, assuming "postgres" is the superuser that you are running the commands with. 
+You can **ignore** these warnings/errors or skip granting these permission as usually all users have relevant access to ``information_schema`` and ``pg_catalog`` schemas by default (see keyword `PUBLIC <https://www.postgresql.org/docs/current/sql-grant.html>`_).
 
 **pgcrypto** in PG search path
 ------------------------------

--- a/docs/graphql/manual/deployment/postgres-requirements.rst
+++ b/docs/graphql/manual/deployment/postgres-requirements.rst
@@ -42,7 +42,6 @@ The Hasura GraphQL engine needs access to your Postgres database with the follow
 - (optional) To create tables and views via the Hasura console (the admin UI) you'll need the privilege to create
   tables/views. This might not be required when you're working with an existing database.
 
-
 Here's a sample SQL block that you can run on your database (as a **superuser**) to create the right credentials for a sample Hasura user:
 
 .. code-block:: sql
@@ -98,7 +97,6 @@ Note for managed databases (AWS RDS, GCP Cloud SQL, etc.)
 
 Hasura works out of the box with the default superuser, usually called "postgres", created by most managed cloud database providers. But if you are creating a new user and giving the :ref:`above <postgres_permissions>` privileges, then you may notice that the following commands may throw warnings/errors:
 
-
 .. code-block:: sql
 
   postgres=> GRANT SELECT ON ALL TABLES IN SCHEMA information_schema TO hasurauser;
@@ -110,13 +108,11 @@ Hasura works out of the box with the default superuser, usually called "postgres
   postgres=> GRANT SELECT ON ALL TABLES IN SCHEMA pg_catalog TO hasurauser;
   ERROR:  permission denied for table pg_statistic
 
-
 You can **ignore** these warnings/errors or skip granting these permission as all users have relevant access to ``information_schema`` and ``pg_catalog`` schemas by default (see keyword `PUBLIC <https://www.postgresql.org/docs/current/sql-grant.html>`_) .
 
 .. admonition:: Google Cloud SQL
 
    On Google Cloud SQL, running ``ALTER SCHEMA hdb_catalog OWNER TO hasurauser;`` may give you an error ``ERROR:  must be member of role "hasurauser"``. You can fix this by running ``GRANT hasurauser to postgres;`` first, assuming "postgres" is the superuser that you are running the commands with. 
-
 
 **pgcrypto** in PG search path
 ------------------------------


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description

Postgres by default has a PUBLIC keyword used for grants: https://www.postgresql.org/docs/current/sql-grant.html.  PUBLIC has SELECT permission on many tables in pg_catalog and information_schema by default and hence all users have select access to these (unless specifically revoked?)

We can check table access for all users via:

```
SELECT grantee, table_catalog, table_schema, table_name, privilege_type
FROM   information_schema.table_privileges group by grantee, table_catalog, table_schema, table_name, privilege_type;
```

This means on AWS RDS (and others), we expect to not give any special privileges to pg_catalog or information_schema. I have tested on few major versions on AWS RDS and GCP as well and indeed this is the case.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Docs
