### PR TITLE
Cascade delete on Postgres dependency errors #5109

### DIFF
--- a/console/src/components/Services/Data/DataActions.js
+++ b/console/src/components/Services/Data/DataActions.js
@@ -582,7 +582,7 @@ const makeMigrationCall = (
     }
     customOnSuccess(data, globals.consoleMode, currMigrationMode);
   };
-  const retryMigration = (err = {}, errMsg = '') => {
+  const retryMigration = (err = {}, errMsg = '', isPgCascade = false) => {
     dispatch(
       showNotification(
         {
@@ -603,7 +603,7 @@ const makeMigrationCall = (
               makeMigrationCall(
                 dispatch,
                 getState,
-                cascadeUpQueries(upQueries), // cascaded new up queries
+                cascadeUpQueries(upQueries, isPgCascade), // cascaded new up queries
                 downQueries,
                 migrationName,
                 customOnSuccess,
@@ -623,8 +623,10 @@ const makeMigrationCall = (
 
   const onError = err => {
     if (!isRetry) {
-      const dependecyError = getDependencyError(err);
-      if (dependecyError) return retryMigration(dependecyError, errorMsg);
+      const { dependencyError, pgDependencyError } = getDependencyError(err);
+      if (dependencyError) return retryMigration(dependencyError, errorMsg);
+      if (pgDependencyError)
+        return retryMigration(pgDependencyError, errorMsg, true);
     }
 
     dispatch(handleMigrationErrors(errorMsg, err));


### PR DESCRIPTION
### Description
This PR adds a user prompt when the user gets postgress error  [`dependent_objects_still_exist-2BP01` ](https://www.postgresql.org/docs/12/errcodes-appendix.html)

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
- [x] Console

### Related Issues
closes #5109 

### Solution and Design
This PR will add an on error listener at `makeMigrationCall` which makes sure that 
> if there is a Postgres dependency error, the user will get a prompt that allows the user to make a decision whether to continue the operation with cascading dependent modules or to cancel the operation. 

### Steps to test and verify
* create a 2 tables which have foreign key relationships.
* Try deleting the table where the foreign key relationship.
* check the network response, if this contains postgress error '2BP01' now the user will see an error prompt.
* click on continue, now check the network query.
* compare with the previous query, this should contain the cascade in the up query.

### Limitations, known bugs & workarounds
* possibility of inconsistent down migration after the cascade operations.


Does this PR add a new Metadata feature?
- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No Breaking changes
