### PR TITLE
do not use prepared statements for mutations, close #2012

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - server: add new `--conn-lifetime` and `HASURA_GRAPHQL_PG_CONN_LIFETIME` options for expiring connections after some amount of active time (#5087)
 - server: shrink libpq connection request/response buffers back to 1MB if they grow beyond 2MB, fixing leak-like behavior on active servers (#5087)
+- server: disable prepared statements for mutations as we end up with single-use objects which result in excessive memory consumption for mutation heavy workloads (#5255)
 - console: allow configuring statement timeout on console RawSQL page (close #4998) (#5045)
 - docs: add note for managed databases in postgres requirements (close #1677, #3783) (#5228)
 - docs: add 1-click deployment to Nhost page to the deployment guides (#5180)
@@ -119,7 +120,7 @@ Read more about the session argument for computed fields in the [docs](https://h
 A new `seeds` command is introduced in CLI, this will allow managing seed migrations as SQL files
 
 #### Creating seed
-```                                                        
+```
 # create a new seed file and use editor to add SQL content
 hasura seed create new_table_seed
 


### PR DESCRIPTION
This PR introduces changes that should reduce memory consumption (which could result in a leak) on both graphql-engine and Postgres for a mutation heavy workload. 

### Description
With mutations we end up with several 'single-use' prepared SQL statements, i.e, statements which cannot be reused for multiple mutations. The underlying reason for ending up with 'single-use' prepared statements is we embed values inside the statement instead of parameterizing them to reduce the complexity around handling relationships in `returning` clause. The problem with single-use prepared statements is that we end up leaking memory both on graphql-engine (we store a mapping of "SQL prepared statement" to "postgres's prepared statement id" in each `PGConn`) and on Postgres (no limits on number of prepared statements per connection).

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server

### Related Issues
#2012 
#3388
#4077 

<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
Prepared statements are not used for mutations any more. We *might* potentially end up with slightly slower but the benefit of predictable memory usage outweighs the potential degradation. 

### Steps to test and verify
@tirumaraiselvan has been running some benchmarks with a mutation heavy workload. This PR will be updated with the findings from those benchmarks.

Does this PR add a new Metadata feature?
- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated

#### Breaking changes
- [x] No Breaking changes