### PR TITLE
allow array relation connection fields regardless of aggregation permission & change relay endpoint to '/v1beta1/relay' (fix #5218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 (Add entries here in the order of: server, console, cli, docs, others)
 
+- server: change relay endpoint to `/v1beta1/relay` (#5257)
+- server: relay connection fields are exposed regardless of allow aggregation permission (fix #5218) (#5257)
 - server: add new `--conn-lifetime` and `HASURA_GRAPHQL_PG_CONN_LIFETIME` options for expiring connections after some amount of active time (#5087)
 - server: shrink libpq connection request/response buffers back to 1MB if they grow beyond 2MB, fixing leak-like behavior on active servers (#5087)
 - server: unlock locked scheduled events on graceful shutdown (#4928)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
 
 The Hasura GraphQL Engine serves [Relay](https://relay.dev/en/) schema for Postgres tables which has a primary key defined.
 
-The Relay schema can be accessed through `/v1/relay` endpoint.
+The Relay schema can be accessed through `/v1beta1/relay` endpoint.
 
 [Add docs links][add console screenshot for relay toggle]
 

--- a/community/sample-apps/react-relay/README.md
+++ b/community/sample-apps/react-relay/README.md
@@ -11,7 +11,7 @@ This app demonstrates pagination using Hasura with Relay. It's for demo purposes
     - columns: `id`, `name`, `cuisine`
 - Create a [one-to-many relationship](https://hasura.io/docs/1.0/graphql/manual/schema/relationships/database-modelling/one-to-many.html) between the tables.
 - Using the Hasura console, add some rows to both tables. Add at least four reviews since the sample code loads three reviews at a time.
-- Using your Relay endpoint from Hasura (`/v1/relay`), export your GraphQL schema by following the instructions [here](https://hasura.io/docs/1.0/graphql/manual/schema/export-graphql-schema.html) (to replace `schema.graphql` at the root of this project).
+- Using your Relay endpoint from Hasura (`/v1beta1/relay`), export your GraphQL schema by following the instructions [here](https://hasura.io/docs/1.0/graphql/manual/schema/export-graphql-schema.html) (to replace `schema.graphql` at the root of this project).
 - In `fetchGraphQL.js`, set the GraphQL endpoint to your Relay endpoint.
 - In `App.js`, replace `MY_RESTAURANT_ID` with a restaurant `id` from your database (This is for demo purposes; normally you'd pass in the `id` via routing).
 - In your Terminal, at the root of the app:

--- a/community/sample-apps/react-relay/src/fetchGraphQL.js
+++ b/community/sample-apps/react-relay/src/fetchGraphQL.js
@@ -1,6 +1,6 @@
 async function fetchGraphQL(text, variables) {
   const response = await fetch(
-    "https://[MY_HASURA_ENDPOINT_ROOT]/v1/relay",
+    "https://[MY_HASURA_ENDPOINT_ROOT]/v1beta1/relay",
     {
       method: "POST",
       headers: {

--- a/console/src/Endpoints.ts
+++ b/console/src/Endpoints.ts
@@ -10,7 +10,7 @@ const Endpoints = {
   getSchema: `${baseUrl}/v1/query`,
   serverConfig: `${baseUrl}/v1alpha1/config`,
   graphQLUrl: `${baseUrl}/v1/graphql`,
-  relayURL: `${baseUrl}/v1/relay`,
+  relayURL: `${baseUrl}/v1beta1/relay`,
   schemaChange: `${baseUrl}/v1/query`,
   query: `${baseUrl}/v1/query`,
   rawSQL: `${baseUrl}/v1/query`,

--- a/console/src/components/Services/ApiExplorer/ApiRequest/ApiRequest.js
+++ b/console/src/components/Services/ApiExplorer/ApiRequest/ApiRequest.js
@@ -286,7 +286,7 @@ class ApiRequest extends Component {
                 id="relay-mode-toggle"
                 placement="left"
                 message={
-                  'Toggle to point this GraphiQL to a relay-compliant GraphQL API served at /v1/relay'
+                  'Toggle to point this GraphiQL to a relay-compliant GraphQL API served at /v1beta1/relay'
                 }
               />
             </div>

--- a/docs/graphql/manual/api-reference/index.rst
+++ b/docs/graphql/manual/api-reference/index.rst
@@ -20,7 +20,7 @@ Available APIs
 +=================+=========================================+==================+
 | GraphQL         | :ref:`/v1/graphql <graphql_api>`        | Permission rules |
 +-----------------+-----------------------------------------+------------------+
-| Relay           | :ref:`/v1/relay <relay_api>`            | Permission rules |
+| Relay           | :ref:`/v1beta1/relay <relay_api>`       | Permission rules |
 +-----------------+-----------------------------------------+------------------+
 | Legacy GraphQL  | :ref:`/v1alpha1/graphql <graphql_api>`  | Permission rules |
 +-----------------+-----------------------------------------+------------------+

--- a/docs/graphql/manual/schema/relay-schema.rst
+++ b/docs/graphql/manual/schema/relay-schema.rst
@@ -15,17 +15,17 @@ Relay schema
 Introduction
 ------------
 
-The Hasura GraphQL engine serves a `Relay <https://relay.dev/>`__ schema for Postgres tables which have a primary key defined. The Relay schema can be accessed through the ``/v1/relay`` endpoint.
+The Hasura GraphQL engine serves a `Relay <https://relay.dev/>`__ schema for Postgres tables which have a primary key defined. The Relay schema can be accessed through the ``/v1beta1/relay`` endpoint.
 
 .. thumbnail:: /img/graphql/manual/schema/relay.png
    :alt: Relay API toggle
 
 .. admonition:: Supported from
-  
+
   Relay is supported from versions ``v1.3.0-beta.1`` and above.
 
 .. .. admonition:: Supported from
-  
+
 ..   Relay is supported from versions ``v.1.3.0`` and above.
 
 What is Relay?

--- a/server/src-lib/Hasura/GraphQL/Schema/Function.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema/Function.hs
@@ -107,7 +107,7 @@ mkFuncQueryConnectionFld funInfo descM =
            <<> " which returns " <>> retTable
     fldName = qualObjectToName funcName <> "_connection"
 
-    ty = G.toGT $ G.toNT $ G.toLT $ G.toNT $ mkTableConnectionTy retTable
+    ty = G.toGT $ G.toNT $ mkTableConnectionTy retTable
 
 {-
 

--- a/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
@@ -262,9 +262,9 @@ onConn (L.Logger logger) corsPolicy wsId requestHead ipAdress = do
     checkPath = case WS.requestPath requestHead of
       "/v1alpha1/graphql" -> return (ERTLegacy, E.QueryHasura)
       "/v1/graphql"       -> return (ERTGraphqlCompliant, E.QueryHasura)
-      "/v1/relay"         -> return (ERTGraphqlCompliant, E.QueryRelay)
+      "/v1beta1/relay"    -> return (ERTGraphqlCompliant, E.QueryRelay)
       _                   ->
-        throw404 "only '/v1/graphql', '/v1alpha1/graphql' are supported on websockets"
+        throw404 "only '/v1/graphql', '/v1alpha1/graphql' and '/v1beta1/relay' are supported on websockets"
 
     getOrigin =
       find ((==) "Origin" . fst) (WS.requestHeaders requestHead)

--- a/server/src-lib/Hasura/Server/App.hs
+++ b/server/src-lib/Hasura/Server/App.hs
@@ -639,7 +639,7 @@ httpApp corsCfg serverCtx enableConsole consoleAssetsDir enableTelemetry = do
       Spock.post "v1/graphql" $ spockAction GH.encodeGQErr allMod200 $
         mkPostHandler $ mkAPIRespHandler v1GQHandler
 
-      Spock.post "v1/relay" $ spockAction GH.encodeGQErr allMod200 $
+      Spock.post "v1beta1/relay" $ spockAction GH.encodeGQErr allMod200 $
         mkPostHandler $ mkAPIRespHandler v1GQRelayHandler
 
     when (isDeveloperAPIEnabled serverCtx) $ do

--- a/server/tests-py/queries/graphql_query/relay/basic/article_connection.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/article_connection.yaml
@@ -1,5 +1,5 @@
 description: Query articles connection with pageInfo and edges
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/article_pagination_no_orderby/backward/page_1.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/article_pagination_no_orderby/backward/page_1.yaml
@@ -1,5 +1,5 @@
 description: Get last page of articles with 3 items
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/article_pagination_no_orderby/backward/page_2.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/article_pagination_no_orderby/backward/page_2.yaml
@@ -1,5 +1,5 @@
 description: Get last page of articles with 2 items before 'Article 4'
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/article_pagination_no_orderby/backward/page_3.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/article_pagination_no_orderby/backward/page_3.yaml
@@ -1,5 +1,5 @@
 description: Get last page of articles before 'Article 2'
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/article_pagination_no_orderby/forward/page_1.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/article_pagination_no_orderby/forward/page_1.yaml
@@ -1,5 +1,5 @@
 description: Get 1st page of articles with 3 items
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/article_pagination_no_orderby/forward/page_2.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/article_pagination_no_orderby/forward/page_2.yaml
@@ -1,5 +1,5 @@
 description: Get 2nd page of articles with 2 items
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/article_pagination_no_orderby/forward/page_3.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/article_pagination_no_orderby/forward/page_3.yaml
@@ -1,5 +1,5 @@
 description: Get 3rd page of articles
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/author_connection.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/author_connection.yaml
@@ -1,5 +1,5 @@
 description: Query author connection with edges
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/author_pagination_articles_aggregate_orderby/backward/page_1.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/author_pagination_articles_aggregate_orderby/backward/page_1.yaml
@@ -1,5 +1,5 @@
 description: Fetch 1st page from last of articles ordered by their article count
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/author_pagination_articles_aggregate_orderby/backward/page_2.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/author_pagination_articles_aggregate_orderby/backward/page_2.yaml
@@ -1,5 +1,5 @@
 description: Fetch 2nd page from last of articles ordered by their article count
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/author_pagination_articles_aggregate_orderby/backward/page_3.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/author_pagination_articles_aggregate_orderby/backward/page_3.yaml
@@ -1,5 +1,5 @@
 description: Fetch 3rd page from last of articles ordered by their article count
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/author_pagination_articles_aggregate_orderby/forward/page_1.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/author_pagination_articles_aggregate_orderby/forward/page_1.yaml
@@ -1,5 +1,5 @@
 description: Fetch 1st page of articles ordered by their article count
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/author_pagination_articles_aggregate_orderby/forward/page_2.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/author_pagination_articles_aggregate_orderby/forward/page_2.yaml
@@ -1,5 +1,5 @@
 description: Fetch 2nd page of articles ordered by their article count
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/author_with_articles_view_connection.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/author_with_articles_view_connection.yaml
@@ -1,6 +1,6 @@
 # https://github.com/hasura/graphql-engine/issues/5020
 description: Query author connection with edges
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/node.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/node.yaml
@@ -1,5 +1,5 @@
 description: Query the relay Node interface
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   variables:

--- a/server/tests-py/queries/graphql_query/relay/basic/node_id_errors/insufficient_data.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/node_id_errors/insufficient_data.yaml
@@ -1,5 +1,5 @@
 description: Query node interface with insufficient items in node id json array
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/node_id_errors/invalid_column_value.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/node_id_errors/invalid_column_value.yaml
@@ -1,5 +1,5 @@
 description: Query node interface with an invalid column value in node id json array
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/node_id_errors/invalid_id.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/node_id_errors/invalid_id.yaml
@@ -1,5 +1,5 @@
 description: Query node interface with an invalid node id
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/node_id_errors/invalid_node_id_version.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/node_id_errors/invalid_node_id_version.yaml
@@ -1,5 +1,5 @@
 description: Query node interface with invalid node id version
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/node_id_errors/missing_columns.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/node_id_errors/missing_columns.yaml
@@ -1,5 +1,5 @@
 description: Query node interface with a missing column value in node id json array
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/node_id_errors/non_array_id.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/node_id_errors/non_array_id.yaml
@@ -1,5 +1,5 @@
 description: Query node interface with id as non array JSON string
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/node_id_errors/non_integer_version.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/node_id_errors/non_integer_version.yaml
@@ -1,5 +1,5 @@
 description: Query node interface with a non-integer GUID version
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/node_id_errors/unexpected_columns.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/node_id_errors/unexpected_columns.yaml
@@ -1,5 +1,5 @@
 description: Query node interface with an unexpected column value in node id json array
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/only_pageinfo.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/only_pageinfo.yaml
@@ -1,5 +1,5 @@
 description: Query the article connection with only pageInfo
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/pagination_errors/after_and_before.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/pagination_errors/after_and_before.yaml
@@ -1,5 +1,5 @@
 description: Use after and before arguments in the same query
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/pagination_errors/first_and_last.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/pagination_errors/first_and_last.yaml
@@ -1,5 +1,5 @@
 description: Use first and last arguments in the same query
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/basic/search_articles_connection.yaml
+++ b/server/tests-py/queries/graphql_query/relay/basic/search_articles_connection.yaml
@@ -1,5 +1,5 @@
 description: Query search_articles function with edges
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/queries/graphql_query/relay/permissions/article_pagination/backward/page_1.yaml
+++ b/server/tests-py/queries/graphql_query/relay/permissions/article_pagination/backward/page_1.yaml
@@ -1,5 +1,5 @@
 description: Get last page of articles with 3 items
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 headers:
   X-Hasura-Role: user

--- a/server/tests-py/queries/graphql_query/relay/permissions/article_pagination/backward/page_2.yaml
+++ b/server/tests-py/queries/graphql_query/relay/permissions/article_pagination/backward/page_2.yaml
@@ -1,5 +1,5 @@
 description: Get last page of articles with 2 items before 'Article 4'
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 headers:
   X-Hasura-Role: user

--- a/server/tests-py/queries/graphql_query/relay/permissions/article_pagination/forward/page_1.yaml
+++ b/server/tests-py/queries/graphql_query/relay/permissions/article_pagination/forward/page_1.yaml
@@ -1,5 +1,5 @@
 description: Get 1st page of articles with 3 items as user role
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 headers:
   X-Hasura-Role: user

--- a/server/tests-py/queries/graphql_query/relay/permissions/article_pagination/forward/page_2.yaml
+++ b/server/tests-py/queries/graphql_query/relay/permissions/article_pagination/forward/page_2.yaml
@@ -1,5 +1,5 @@
 description: Get 2nd page of articles with 3 items as user role
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 headers:
   X-Hasura-Role: user

--- a/server/tests-py/queries/graphql_query/relay/permissions/author_connection.yaml
+++ b/server/tests-py/queries/graphql_query/relay/permissions/author_connection.yaml
@@ -19,6 +19,14 @@ query:
           node{
             id
             name
+            articles_connection{
+              edges{
+                node{
+                  id
+                  title
+                }
+              }
+            }
           }
         }
       }
@@ -36,3 +44,11 @@ response:
         node:
           id: WzEsICJwdWJsaWMiLCAiYXV0aG9yIiwgMl0=
           name: Author 2
+          articles_connection:
+            edges:
+            - node:
+                id: WzEsICJwdWJsaWMiLCAiYXJ0aWNsZSIsIDRd
+                title: Article 4
+            - node:
+                id: WzEsICJwdWJsaWMiLCAiYXJ0aWNsZSIsIDVd
+                title: Article 5

--- a/server/tests-py/queries/graphql_query/relay/permissions/author_connection.yaml
+++ b/server/tests-py/queries/graphql_query/relay/permissions/author_connection.yaml
@@ -1,5 +1,5 @@
 description: Query author connection with edges and pageinfo as user role
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 headers:
   X-Hasura-Role: user

--- a/server/tests-py/queries/graphql_query/relay/permissions/author_node.yaml
+++ b/server/tests-py/queries/graphql_query/relay/permissions/author_node.yaml
@@ -1,5 +1,5 @@
 description: Query author node with id belongs to same user id
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 headers:
   X-Hasura-Role: user

--- a/server/tests-py/queries/graphql_query/relay/permissions/author_node_null.yaml
+++ b/server/tests-py/queries/graphql_query/relay/permissions/author_node_null.yaml
@@ -1,5 +1,5 @@
 description: Query author node with id belongs to another user id
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 headers:
   X-Hasura-Role: user

--- a/server/tests-py/queries/remote_schemas/remote_relationships/with_relay.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/with_relay.yaml
@@ -1,6 +1,6 @@
 # https://github.com/hasura/graphql-engine/issues/5144
 description: Test remote relationships via relay endpoint
-url: /v1/relay
+url: /v1beta1/relay
 status: 200
 query:
   query: |

--- a/server/tests-py/test_graphql_queries.py
+++ b/server/tests-py/test_graphql_queries.py
@@ -752,7 +752,6 @@ class TestRelayQueriesPermissions:
     def test_article_pagination_backward(self, hge_ctx, transport):
         _test_relay_pagination(hge_ctx, transport, self.dir() + '/article_pagination/backward', 2)
 
-
 def _test_relay_pagination(hge_ctx, transport, test_file_prefix, no_of_pages):
     for i in range(no_of_pages):
         page_no = i + 1

--- a/server/tests-py/validate.py
+++ b/server/tests-py/validate.py
@@ -65,7 +65,7 @@ def check_event(hge_ctx, evts_webhook, trig_name, table, operation, exp_ev_data,
 
 
 def test_forbidden_when_admin_secret_reqd(hge_ctx, conf):
-    if conf['url'] == '/v1/graphql' or conf['url'] == '/v1/relay':
+    if conf['url'] == '/v1/graphql' or conf['url'] == '/v1beta1/relay':
         if conf['status'] == 404:
             status = [404]
         else:
@@ -104,7 +104,7 @@ def test_forbidden_when_admin_secret_reqd(hge_ctx, conf):
 
 
 def test_forbidden_webhook(hge_ctx, conf):
-    if conf['url'] == '/v1/graphql' or conf['url'] == '/v1/relay':
+    if conf['url'] == '/v1/graphql' or conf['url'] == '/v1beta1/relay':
         if conf['status'] == 404:
             status = [404]
         else:
@@ -226,8 +226,8 @@ def validate_gql_ws_q(hge_ctx, conf, headers, retry=False, via_subscription=Fals
 
     if endpoint == '/v1alpha1/graphql':
         ws_client = GQLWsClient(hge_ctx, '/v1alpha1/graphql')
-    elif endpoint == '/v1/relay':
-        ws_client = GQLWsClient(hge_ctx, '/v1/relay')
+    elif endpoint == '/v1beta1/relay':
+        ws_client = GQLWsClient(hge_ctx, '/v1beta1/relay')
     else:
         ws_client = hge_ctx.ws_client
     print(ws_client.ws_url)


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Initial decision was to discard the array connection fields if aggregations aren't enabled in the select permission. It was because, the connection may have support for querying "aggregate" field in future iteration. In this PR, the change is made to include the connection field regardless of aggregation permission. However, if we were to support the "aggregate" field in the connection object, we can alone include that field only if aggregations are allowed. 

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.
No changelog entry is being added. The existing change log is modified to replace /v1beta/relay in place of /v1/relay. 

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [x] Console
- [x] Docs
- [x] Tests


### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
Fix #5218 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
A single line change to include the array connection field regardless of `allowAgg` check.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes

#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated

#### Breaking changes

- [ ] No Breaking changes
- [x] There are breaking changes with previous 1.3.0-beta releases. The relay endpoint is changed to `/v1beta1/relay`. 
