### PR TITLE
bump pg-client-hs version (fixes a build issue on some environments)

### DIFF
--- a/server/cabal.project
+++ b/server/cabal.project
@@ -35,8 +35,8 @@ package graphql-engine
 
 source-repository-package
   type: git
-  location: https://github.com/hasura/pg-client-hs.git
-  tag: cbfc69b935d19dc40be8cdcc73a70b81cf511d34
+  location: https://github.com/0x777/pg-client-hs.git
+  tag: 4011ab5214a4699ef2a5210f9a8d3be65104b1b6
 
 source-repository-package
   type: git

--- a/server/cabal.project
+++ b/server/cabal.project
@@ -35,8 +35,8 @@ package graphql-engine
 
 source-repository-package
   type: git
-  location: https://github.com/0x777/pg-client-hs.git
-  tag: 4011ab5214a4699ef2a5210f9a8d3be65104b1b6
+  location: https://github.com/hasura/pg-client-hs.git
+  tag: 049015e042d107d8ededc943a64f7fabd3690a35
 
 source-repository-package
   type: git


### PR DESCRIPTION
Bumps the pg-client library version without which master can't be built on Arch Linux and masOS 10:
```
error: In file included from ExtraBindings.hsc:12:
cbits/libpq-bindings.h:1:10: fatal error: internal/postgres_fe.h: No such file or directory
    1 | #include <internal/postgres_fe.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```