### PR TITLE
Add --disable-delayed-os-memory-return to default rtsopts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - server: relay connection fields are exposed regardless of allow aggregation permission (fix #5218) (#5257)
 - server: add new `--conn-lifetime` and `HASURA_GRAPHQL_PG_CONN_LIFETIME` options for expiring connections after some amount of active time (#5087)
 - server: shrink libpq connection request/response buffers back to 1MB if they grow beyond 2MB, fixing leak-like behavior on active servers (#5087)
+- server: have haskell runtime release blocks of memory back to the OS eagerly (related to #3388)
 - server: unlock locked scheduled events on graceful shutdown (#4928)
 - server: disable prepared statements for mutations as we end up with single-use objects which result in excessive memory consumption for mutation heavy workloads (#5255)
 - server: include scheduled event metadata (`created_at`,`scheduled_time`,`id`, etc) along with the configured payload in the request body to the webhook. 

--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -54,7 +54,11 @@ common common-exe
     -- `-kc8K` helps limit memory consumption in websockets (perhaps elsewhere) by making the 
     -- cost of a thread's first (and probably only) stack overflow less severe. 
     -- See:https://github.com/hasura/graphql-engine/issues/5190 
-    "-with-rtsopts=-N -I2 -qn2 -kc8K"
+    --
+    -- `--disable-delayed-os-memory-return` seems to help lower reported residency, in particular 
+    -- in situations where we seem to be dealing with haskell heap fragmentation. This is more a 
+    -- workaround for limitations in monitoring tools than anything...
+    "-with-rtsopts=-N -I2 -qn2 -kc8K --disable-delayed-os-memory-return"
 
 library
   import: common-all


### PR DESCRIPTION
https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/runtime_control.html#rts-flag---disable-delayed-os-memory-return

Referencing canonical memory issue #3388

This is a bit of a mystery. It didn't seem to have any effect in early
repros we had. But now, running an introspection query benchmark I see:

  Running 400 concurrent connections:
    before this change: max residency ~450M
    after: ~140M
    No difference in latency was observed.

  ...BUT: if I give graphql-engine a warmup of 10 requests with 1
  connection (i.e. no concurrency): I see both have a max residency of
  ~140M (i.e. the flag doesn't help)

  ...also interestingly: a single warmup request doesn't seem to have
  any effect (ending RES is still high), 2 requests gets max RES down to
  ~180M.

I suspect many concurrent connections are spraying pinned data over a
bunch of blocks which are then not released to the OS barring memory
pressure. Whatever this is is maybe thread-local or "per-capability" in
some sense...
