### PR TITLE
console: fix creating migrations from Raw SQL page (close #5296)

### DIFF
--- a/console/src/components/Services/Data/RawSQL/Actions.js
+++ b/console/src/components/Services/Data/RawSQL/Actions.js
@@ -40,17 +40,18 @@ const executeSQL = (isMigration, migrationName, statementTimeout) => (
   dispatch(showSuccessNotification('Executing the Query...'));
 
   const { isTableTrackChecked, isCascadeChecked } = getState().rawSQL;
-  const { currMigrationMode, readOnlyMode } = getState().main;
+  const { migrationMode, readOnlyMode } = getState().main;
 
-  const migrateUrl = returnMigrateUrl(currMigrationMode);
+  const migrateUrl = returnMigrateUrl(migrationMode);
 
   let url = Endpoints.rawSQL;
 
   const schemaChangesUp = [];
 
-  const sql = statementTimeout
-    ? `${getStatementTimeoutSql(statementTimeout)} ${getState().rawSQL.sql}`
-    : getState().rawSQL.sql;
+  const sql =
+    statementTimeout && !isMigration
+      ? `${getStatementTimeoutSql(statementTimeout)} ${getState().rawSQL.sql}`
+      : getState().rawSQL.sql;
 
   schemaChangesUp.push(getRunSqlQuery(sql, isCascadeChecked, readOnlyMode));
   // check if track view enabled

--- a/console/src/components/Services/Data/RawSQL/RawSQL.js
+++ b/console/src/components/Services/Data/RawSQL/RawSQL.js
@@ -97,7 +97,7 @@ const RawSQL = ({
     return () => {
       localStorage.setItem(LS_RAW_SQL_SQL, sqlRef.current);
     };
-  }, []);
+  }, [dispatch, sql]);
   // set SQL to sqlRef
   useEffect(() => {
     sqlRef.current = sql;

--- a/console/src/components/Services/Data/RawSQL/State.js
+++ b/console/src/components/Services/Data/RawSQL/State.js
@@ -1,11 +1,3 @@
-import {
-  getLocalStorageItem,
-  LS_RAW_SQL_STATEMENT_TIMEOUT,
-} from '../../../Common/utils/localStorageUtils';
-
-const persistedStatementTimeout = Number(
-  getLocalStorageItem(LS_RAW_SQL_STATEMENT_TIMEOUT)
-);
 const defaultState = {
   sql: '',
   ongoingRequest: false,
@@ -19,7 +11,6 @@ const defaultState = {
   isMigrationChecked: false,
   isTableTrackChecked: false,
   showTrackTable: false,
-  statementTimeout: persistedStatementTimeout || 10,
 };
 
 export default defaultState;


### PR DESCRIPTION
close https://github.com/hasura/graphql-engine/issues/5296

### Description

One of the variables was renamed in recent PR and caused this issue. This PR fixes it.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components

- [x] Console
