### PR TITLE
Note libkrb5-dev dependency on Debian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - docs: add note for managed databases in postgres requirements (close #1677, #3783) (#5228)
 - docs: add 1-click deployment to Nhost page to the deployment guides (#5180)
 - docs: add hasura cloud to getting started section (close #5206) (#5208)
+- docs: add libkrb5-dev to Debian dependencies (#5321)
 
 
 ## `v1.3.0-beta.3`

--- a/server/CONTRIBUTING.md
+++ b/server/CONTRIBUTING.md
@@ -5,7 +5,7 @@ own machine and how to contribute.
 
 ## Pre-requisites
 
-- [GHC](https://www.haskell.org/ghc/) 8.6.5 and [cabal-install](https://cabal.readthedocs.io/en/latest/)
+- [GHC](https://www.haskell.org/ghc/) 8.10.1 and [cabal-install](https://cabal.readthedocs.io/en/latest/)
   - There are various ways these can be installed, but [ghcup](https://www.haskell.org/ghcup/) is a good choice if you’re not sure.
 - [Node.js](https://nodejs.org/en/) (>= v8.9)
 - npm >= 5.7

--- a/server/CONTRIBUTING.md
+++ b/server/CONTRIBUTING.md
@@ -11,11 +11,12 @@ own machine and how to contribute.
 - npm >= 5.7
 - [gsutil](https://cloud.google.com/storage/docs/gsutil)
 - libpq-dev
+- libkrb5-dev
 - python >= 3.5 with pip3
 
-The last two prerequisites can be installed on Debian with:
+The last two prerequisites can be installed on Debian or Ubuntu with:
 
-    $ sudo apt install libpq-dev python3 python3-pip python3-venv
+    $ sudo apt install libpq-dev libkrb5-dev python3 python3-pip python3-venv
 
 Additionally, you will need a way to run a Postgres database server. The `dev.sh` script (described below) can set up a Postgres instance for you via [Docker](https://www.docker.com), but if you want to run it yourself, you’ll need:
 


### PR DESCRIPTION
On Debian, failing to install `libkrb5-dev` causes `libpq-client` to fail to compile (it can't find the `<gssapi/gssapi.h>` include in one of the `cbits/` files), which causes the entire `graphql-engine` build to fail.

## Changelog

No user-facing changes.

### Affected components
- [x] Docs
