### PR TITLE
docs: update links in docs

### DIFF
--- a/docs/graphql/manual/actions/codegen.rst
+++ b/docs/graphql/manual/actions/codegen.rst
@@ -113,7 +113,7 @@ As of now, Hasura provides codegen for a few frameworks (``nodejs-express``,
 ``typescript-zeit``, etc).
 
 If you wish to build a code generator for your framework
-`read the contrib guide <https://github.com/hasura/codegen-builder-contrib/>`_.
+`read the contrib guide <https://github.com/hasura/codegen-assets/blob/master/builder-kit/README.md>`__.
 
 
   

--- a/docs/graphql/manual/api-reference/graphql-api/query.rst
+++ b/docs/graphql/manual/api-reference/graphql-api/query.rst
@@ -158,7 +158,7 @@ Simple object
    * - path
      - false
      - Value
-     - ``path`` argument of ``json``/``jsonb`` follows simple `JSONPath specification <https://github.com/json-path/JsonPath>`_. However, prefix symbol ``$.`` is optional.
+     - ``path`` argument of ``json``/``jsonb`` follows simple `JSONPath specification <https://github.com/json-path/JsonPath>`__. However, prefix symbol ``$.`` is optional.
 
 *Example*
 
@@ -582,7 +582,7 @@ Operator
    * - ``_nin``
      - ``NOT IN``  
 
-(For more details, refer to the Postgres docs for `comparison operators <https://www.postgresql.org/docs/current/functions-comparison.html>`__ and `list based search operators <https://www.postgresql.org/docs/current/functions-comparisons.html>`_.)
+(For more details, refer to the Postgres docs for `comparison operators <https://www.postgresql.org/docs/current/functions-comparison.html>`__ and `list based search operators <https://www.postgresql.org/docs/current/functions-comparisons.html>`__.)
 
 .. _text_operators:
 

--- a/docs/graphql/manual/api-reference/health.rst
+++ b/docs/graphql/manual/api-reference/health.rst
@@ -53,7 +53,7 @@ Depending on the server health status any of the following responses can be retu
 .. note::
 
   If there are metadata inconsistencies, you should use the Hasura console or the
-  `get_inconsistent_metadata <schema-metadata-api/manage-metadata.html#get-inconsistent-metadata>`_ API to find out what
+  `get_inconsistent_metadata <schema-metadata-api/manage-metadata.html#get-inconsistent-metadata>`__ API to find out what
   the inconsistent objects are and resolve them.
 
 

--- a/docs/graphql/manual/api-reference/health.rst
+++ b/docs/graphql/manual/api-reference/health.rst
@@ -52,8 +52,7 @@ Depending on the server health status any of the following responses can be retu
 
 .. note::
 
-  If there are metadata inconsistencies, you should use the Hasura console or the
-  `get_inconsistent_metadata <schema-metadata-api/manage-metadata.html#get-inconsistent-metadata>`__ API to find out what
+  If there are metadata inconsistencies, you should use the Hasura console or the :ref:`get_inconsistent_metadata <get_inconsistent_metadata>` API to find out what
   the inconsistent objects are and resolve them.
 
 

--- a/docs/graphql/manual/api-reference/schema-metadata-api/syntax-defs.rst
+++ b/docs/graphql/manual/api-reference/schema-metadata-api/syntax-defs.rst
@@ -312,7 +312,7 @@ Operator
    * - ``"$nin"``
      - ``NOT IN``
 
-(For more details, refer to the Postgres docs for `comparison operators <https://www.postgresql.org/docs/current/functions-comparison.html>`__ and `list based search operators <https://www.postgresql.org/docs/current/functions-comparisons.html>`_.)
+(For more details, refer to the Postgres docs for `comparison operators <https://www.postgresql.org/docs/current/functions-comparison.html>`__ and `list based search operators <https://www.postgresql.org/docs/current/functions-comparisons.html>`__.)
 
 **Text related operators :**
 

--- a/docs/graphql/manual/auth/authentication/jwt.rst
+++ b/docs/graphql/manual/auth/authentication/jwt.rst
@@ -267,7 +267,7 @@ This is to indicate whether the Hasura specific claims are a regular JSON object
 or a stringified JSON.
 
 This is required because providers like AWS Cognito only allow strings in the
-JWT claims. `See #1176 <https://github.com/hasura/graphql-engine/issues/1176>`_.
+JWT claims. `See #1176 <https://github.com/hasura/graphql-engine/issues/1176>`__.
 
 Example:-
 

--- a/docs/graphql/manual/auth/authorization/roles-variables.rst
+++ b/docs/graphql/manual/auth/authorization/roles-variables.rst
@@ -38,6 +38,7 @@ See :ref:`this page <permission_rules>` on how to configure permission rules.
   For every role that you create, Hasura automatically publishes a different GraphQL schema that represents the
   right queries, fields, and mutations that are available to that role.
 
+.. _dynamic_session_variables:
 
 Dynamic session variables
 -------------------------

--- a/docs/graphql/manual/auth/authorization/roles-variables.rst
+++ b/docs/graphql/manual/auth/authorization/roles-variables.rst
@@ -93,7 +93,7 @@ Examples:
 
 .. admonition:: ABAC
 
-  Session variables are analogous to *attributes* in a typical `attribute-based access control <https://en.wikipedia.org/wiki/Attribute-based_access_control>`_ (ABAC) system.
+  Session variables are analogous to *attributes* in a typical `attribute-based access control <https://en.wikipedia.org/wiki/Attribute-based_access_control>`__ (ABAC) system.
 
 
 Modelling Roles in Hasura
@@ -236,9 +236,9 @@ type ``integer``, then the values of ``X-Hasura-User-Id`` and  ``X-Hasura-Allowe
 be of type ``integer`` and ``integer[]`` (an integer array) respectively. To pass say a value ``1`` for
 ``X-Hasura-User-Id``, it'll be "``1``" and if the allowed organisations are ``1``, ``2`` and ``3``, then
 ``X-Hasura-Allowed-Organisations`` will be "``{1,2,3}``". ``{}`` is the syntax for specifying
-`arrays in Postgres <https://www.postgresql.org/docs/current/arrays.html#ARRAYS-INPUT>`_.
+`arrays in Postgres <https://www.postgresql.org/docs/current/arrays.html#ARRAYS-INPUT>`__.
 
-The types and their formats are detailed `here <https://www.postgresql.org/docs/current/datatype.html>`_. When
+The types and their formats are detailed `here <https://www.postgresql.org/docs/current/datatype.html>`__. When
 in doubt about the Postgres format for a type, you can always test it in the SQL window. To check
 if ``s`` is a valid literal for type ``t`` then, you can check it as follows:
 

--- a/docs/graphql/manual/deployment/custom-docker-images.rst
+++ b/docs/graphql/manual/deployment/custom-docker-images.rst
@@ -14,10 +14,10 @@ Custom Docker images or binaries for Hasura GraphQL engine
 
 If you need a binary for Hasura GraphQL engine to run in a non-Docker environment or you require
 custom Docker images, we can make them available via a support plan. A possible use case could be that the default base image *(alpine)* is not compatible with your security scanning tool
-(`Anchore <https://anchore.com/>`_, `Sysdig Secure <https://sysdig.com/products/kubernetes-security/image-scanning/>`_, etc.).
+(`Anchore <https://anchore.com/>`__, `Sysdig Secure <https://sysdig.com/products/kubernetes-security/image-scanning/>`__, etc.).
 
 To set up such a support plan, please contact us using the form on our
-`contact page <https://hasura.io/contact-us/>`_ and make sure to include the Linux flavor
+`contact page <https://hasura.io/contact-us/>`__ and make sure to include the Linux flavor
 (*CentOS, Debian slim, etc.*) or the target architecture for the binary you'd be
 interested in.
 

--- a/docs/graphql/manual/deployment/heroku/index.rst
+++ b/docs/graphql/manual/deployment/heroku/index.rst
@@ -13,7 +13,7 @@ Run Hasura GraphQL engine on Heroku
   :local:
 
 This guide will help you get the Hasura GraphQL engine running as a "git push to deploy" app on
-`Heroku <https://www.heroku.com/platform>`_ and connecting it to a `Heroku Postgres <https://www.heroku.com/postgres>`_
+`Heroku <https://www.heroku.com/platform>`__ and connecting it to a `Heroku Postgres <https://www.heroku.com/postgres>`__
 instance. If you want a simple, quick deployment on Heroku, follow this :ref:`Heroku one-click
 guide <heroku_one_click>`.
 
@@ -59,7 +59,7 @@ These are some sample deployment instructions while creating a new app.
 Step 1: Create an app with **--stack=container**
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Use the `Heroku CLI <https://devcenter.heroku.com/articles/heroku-cli>`_ to create a new Heroku app. Let's call
+Use the `Heroku CLI <https://devcenter.heroku.com/articles/heroku-cli>`__ to create a new Heroku app. Let's call
 the app ``graphql-on-postgres``.
 
 .. code-block:: bash

--- a/docs/graphql/manual/deployment/heroku/logging.rst
+++ b/docs/graphql/manual/deployment/heroku/logging.rst
@@ -12,7 +12,7 @@ Hasura GraphQL engine server logs (Heroku)
   :depth: 1
   :local:
 
-You can use the `Heroku CLI <https://devcenter.heroku.com/articles/heroku-cli>`_ to check the logs
+You can use the `Heroku CLI <https://devcenter.heroku.com/articles/heroku-cli>`__ to check the logs
 of the Hasura GraphQL engine deployed on Heroku:
 
 .. code-block:: bash

--- a/docs/graphql/manual/deployment/heroku/updating.rst
+++ b/docs/graphql/manual/deployment/heroku/updating.rst
@@ -43,7 +43,7 @@ Step 2: Attach your Heroku app
 
 Let's say your Heroku app is called ``hasura-heroku`` and is running on ``https://hasura-heroku.herokuapp.com``.
 
-Navigate to your project directory, use the `Heroku CLI <https://devcenter.heroku.com/articles/heroku-cli>`_ to configure the git repo you cloned in Step 1
+Navigate to your project directory, use the `Heroku CLI <https://devcenter.heroku.com/articles/heroku-cli>`__ to configure the git repo you cloned in Step 1
 to be able to push to this app.
 
 .. code-block:: bash

--- a/docs/graphql/manual/deployment/kubernetes/index.rst
+++ b/docs/graphql/manual/deployment/kubernetes/index.rst
@@ -19,7 +19,7 @@ and connect it to your Postgres database.
 Step 1: Get the Kubernetes deployment and service files
 -------------------------------------------------------
 
-The `hasura/graphql-engine/install-manifests <https://github.com/hasura/graphql-engine/tree/stable/install-manifests>`_ repo
+The `hasura/graphql-engine/install-manifests <https://github.com/hasura/graphql-engine/tree/stable/install-manifests>`__ repo
 contains all installation manifests required to deploy Hasura anywhere. Get the Kubernetes deployment and service files
 from there:
 

--- a/docs/graphql/manual/deployment/postgres-requirements.rst
+++ b/docs/graphql/manual/deployment/postgres-requirements.rst
@@ -36,7 +36,7 @@ The Hasura GraphQL engine needs access to your Postgres database with the follow
 
 - (required) Read & write access on 2 schemas: ``hdb_catalog`` and ``hdb_views``.
 - (required) Read access to the ``information_schema`` and ``pg_catalog`` schemas, to query for list of tables.
-  Note that these permissions are usually available by default to all postgres users via `PUBLIC <https://www.postgresql.org/docs/current/sql-grant.html>`_ grant.
+  Note that these permissions are usually available by default to all postgres users via `PUBLIC <https://www.postgresql.org/docs/current/sql-grant.html>`__ grant.
 - (required) Read access to the schemas (public or otherwise) if you only want to support queries.
 - (optional) Write access to the schemas if you want to support mutations as well.
 - (optional) To create tables and views via the Hasura console (the admin UI) you'll need the privilege to create

--- a/docs/graphql/manual/event-triggers/samples.rst
+++ b/docs/graphql/manual/event-triggers/samples.rst
@@ -31,7 +31,7 @@ Makes a mutation based on the event payload. It helps in understanding database 
 Push Notifications
 ^^^^^^^^^^^^^^^^^^
 
-Here's a `notification demo app <https://serverless-push.demo.hasura.app/>`_ showcasing sending web
+Here's a `notification demo app <https://serverless-push.demo.hasura.app/>`__ showcasing sending web
 notifications using Hasura event triggers and FCM.
 
 * Video: https://www.youtube.com/watch?v=nuSHkzE2-zo&feature=youtu.be
@@ -39,7 +39,7 @@ notifications using Hasura event triggers and FCM.
 
 Data Transformations (ETL)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Here's a `serverless ETL demo app <https://serverless-etl.demo.hasura.app/>`_ built using Hasura event triggers and
+Here's a `serverless ETL demo app <https://serverless-etl.demo.hasura.app/>`__ built using Hasura event triggers and
 Algolia search.
 
 * Video: https://youtu.be/kWVEBWdEVAA

--- a/docs/graphql/manual/getting-started/docker-simple.rst
+++ b/docs/graphql/manual/getting-started/docker-simple.rst
@@ -29,7 +29,7 @@ Prerequisites
 Step 1: Get the docker-compose file
 ----------------------------------- 
 
-The `hasura/graphql-engine/install-manifests <https://github.com/hasura/graphql-engine/tree/stable/install-manifests>`_ repo
+The `hasura/graphql-engine/install-manifests <https://github.com/hasura/graphql-engine/tree/stable/install-manifests>`__ repo
 contains all installation manifests required to deploy Hasura anywhere. Get the docker compose file from there:
 
 .. code-block:: bash

--- a/docs/graphql/manual/guides/code-editor-integrations/visual-studio-code.rst
+++ b/docs/graphql/manual/guides/code-editor-integrations/visual-studio-code.rst
@@ -13,7 +13,7 @@ Guides: Visual Studio Code Setup
   :local:
 
 
-If you use `Visual Studio code <https://code.visualstudio.com/>`_, the `Apollo GraphQL plugin <https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo>`_ can improve your development experience significantly by enabling a lot of cool features like syntax highlighting for GraphQL, auto completion for GraphQL requests and validating your GraphQL requests against a schema or an endpoint.
+If you use `Visual Studio code <https://code.visualstudio.com/>`__, the `Apollo GraphQL plugin <https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo>`__ can improve your development experience significantly by enabling a lot of cool features like syntax highlighting for GraphQL, auto completion for GraphQL requests and validating your GraphQL requests against a schema or an endpoint.
 
 This guide helps you configure the Apollo GraphQL plugin with Hasura to make your local development easier.
 
@@ -50,6 +50,6 @@ Notes:
 - Replace ``http://localhost:8080/v1/graphql`` with your GraphQL endpoint.
 - You can also add custom headers in the headers object if you wish to emulate the schema for some specific roles or tokens.
 
-For advanced configuration, check out the `docs for the plugin <https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo>`_.
+For advanced configuration, check out the `docs for the plugin <https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo>`__.
 
-Note: The `VSCode GraphQL <https://github.com/prisma/vscode-graphql>`_ plugin by Prisma does not currently work with Hasura because it has a hard dependency on batching and Hasura does not support batching as of now. Batching as a feature in GraphQL engine is tracked `here <https://github.com/hasura/graphql-engine/issues/1812>`_.
+Note: The `VSCode GraphQL <https://github.com/prisma/vscode-graphql>`__ plugin by Prisma does not currently work with Hasura because it has a hard dependency on batching and Hasura does not support batching as of now. Batching as a feature in GraphQL engine is tracked `here <https://github.com/hasura/graphql-engine/issues/1812>`__.

--- a/docs/graphql/manual/guides/deployment/azure-container-instances-postgres.rst
+++ b/docs/graphql/manual/guides/deployment/azure-container-instances-postgres.rst
@@ -54,7 +54,7 @@ Pre-requisites
 
 - Valid Azure Subscription with billing enabled or credits (`click
   here <https://azure.microsoft.com/en-us/free/>`__ for a free trial).
-- `Azure CLI <https://docs.microsoft.com/en-us/cli/azure/install-azure-cli>`_.
+- `Azure CLI <https://docs.microsoft.com/en-us/cli/azure/install-azure-cli>`__.
 
 The actions mentioned below can be executed using the Azure Portal and the Azure CLI. But,
 for the sake of simplicity in documentation, we are going to use Azure CLI, so

--- a/docs/graphql/manual/guides/deployment/heroku-one-click.rst
+++ b/docs/graphql/manual/guides/deployment/heroku-one-click.rst
@@ -15,7 +15,7 @@ One-click deployment with Heroku
 Introduction
 ------------
 
-This guide will help you get the Hasura GraphQL engine and Postgres running on `Heroku's free tier <https://www.heroku.com/free>`_.
+This guide will help you get the Hasura GraphQL engine and Postgres running on `Heroku's free tier <https://www.heroku.com/free>`__.
 It is the easiest and fastest way of trying out Hasura.
 
 If you'd like to link this to an existing database, please head to this guide instead:

--- a/docs/graphql/manual/guides/deployment/render-one-click.rst
+++ b/docs/graphql/manual/guides/deployment/render-one-click.rst
@@ -18,7 +18,7 @@ One-Click Deploy on Render
 --------------------------
 
 .. note::
-   Make sure to `create a free Render account <https://render.com/register>`_ first.
+   Make sure to `create a free Render account <https://render.com/register>`__ first.
 
 Once you're logged into your Render account, click the button below to deploy Hasura and a
 new managed PostgreSQL database wired up to your Hasura instance.

--- a/docs/graphql/manual/guides/index.rst
+++ b/docs/graphql/manual/guides/index.rst
@@ -30,4 +30,4 @@ Guides / Tutorials / Resources
 .. note::
 
   If you are new to GraphQL you can check out some front-end and back-end tutorials for building applications using
-  GraphQL at `hasura.io/learn <https://hasura.io/learn/>`_.
+  GraphQL at `hasura.io/learn <https://hasura.io/learn/>`__.

--- a/docs/graphql/manual/guides/integrations/auth-guardian-jwt.rst
+++ b/docs/graphql/manual/guides/integrations/auth-guardian-jwt.rst
@@ -96,7 +96,7 @@ Now, you want to restrict access to some data in Hasura so that only you and you
 
 Option 4: Set a session variable
 --------------------------------
-Hasura can use **session variables** for all sorts of `powerful cases <https://docs.hasura.io/1.0/graphql/manual/auth/authorization/roles-variables.html#dynamic-session-variables>`__. AuthGuardian also supports setting these in your JWT!
+Hasura can use **session variables** for all sorts of :ref:`powerful cases <dynamic_session_variables>`. AuthGuardian also supports setting these in your JWT!
 
 Let's say we want to restrict access to some super-interesting data in our Hasura backend to users who have starred a particular GitHub repository:
 

--- a/docs/graphql/manual/guides/integrations/auth-guardian-jwt.rst
+++ b/docs/graphql/manual/guides/integrations/auth-guardian-jwt.rst
@@ -96,7 +96,7 @@ Now, you want to restrict access to some data in Hasura so that only you and you
 
 Option 4: Set a session variable
 --------------------------------
-Hasura can use **session variables** for all sorts of `powerful cases <https://docs.hasura.io/1.0/graphql/manual/auth/authorization/roles-variables.html#dynamic-session-variables>`_. AuthGuardian also supports setting these in your JWT!
+Hasura can use **session variables** for all sorts of `powerful cases <https://docs.hasura.io/1.0/graphql/manual/auth/authorization/roles-variables.html#dynamic-session-variables>`__. AuthGuardian also supports setting these in your JWT!
 
 Let's say we want to restrict access to some super-interesting data in our Hasura backend to users who have starred a particular GitHub repository:
 

--- a/docs/graphql/manual/guides/integrations/auth0-jwt.rst
+++ b/docs/graphql/manual/guides/integrations/auth0-jwt.rst
@@ -259,4 +259,4 @@ That’s it! This rule will be triggered on every successful signup/login and sy
 
 .. admonition:: Local dev with Auth0 rules
 
-   The sync step will require a reachable endpoint to Hasura and this is not possible in localhost. You can use `ngrok <https://ngrok.com/>`_ or similar services to expose your locally running Hasura with a public endpoint temporarily.
+   The sync step will require a reachable endpoint to Hasura and this is not possible in localhost. You can use `ngrok <https://ngrok.com/>`__ or similar services to expose your locally running Hasura with a public endpoint temporarily.

--- a/docs/graphql/manual/guides/telemetry.rst
+++ b/docs/graphql/manual/guides/telemetry.rst
@@ -156,4 +156,4 @@ setting.
 Privacy Policy
 --------------
 
-You can check out our privacy policy `here <https://hasura.io/legal/hasura-privacy-policy>`_.
+You can check out our privacy policy `here <https://hasura.io/legal/hasura-privacy-policy>`__.

--- a/docs/graphql/manual/hasura-cli/install-hasura-cli.rst
+++ b/docs/graphql/manual/hasura-cli/install-hasura-cli.rst
@@ -71,7 +71,7 @@ Install through npm
 
 Hasura CLI is available as an npm package that is independently maintained by some members of the community.
 It can be beneficial to use the npm package if you want a version-fixed cli dedicated to your node.js project.
-You can find usage details (e.g. flag information) in  the `original repository <https://github.com/jjangga0214/hasura-cli>`_.
+You can find usage details (e.g. flag information) in  the `original repository <https://github.com/jjangga0214/hasura-cli>`__.
 
 .. code-block:: bash
    

--- a/docs/graphql/manual/mutations/insert.rst
+++ b/docs/graphql/manual/mutations/insert.rst
@@ -537,7 +537,7 @@ Insert an object with a JSONB field
 Insert an object with an ARRAY field
 ------------------------------------
 
-To insert fields of array types, you currently have to pass them as a `Postgres array literal <https://www.postgresql.org/docs/current/arrays.html#ARRAYS-INPUT>`_.
+To insert fields of array types, you currently have to pass them as a `Postgres array literal <https://www.postgresql.org/docs/current/arrays.html#ARRAYS-INPUT>`__.
 
 **Example:** Insert a new ``author`` with a text array ``emails`` field:
 

--- a/docs/graphql/manual/queries/pagination.rst
+++ b/docs/graphql/manual/queries/pagination.rst
@@ -324,5 +324,5 @@ articles to return.
 .. admonition:: Caveat
 
   If this needs to be done over :ref:`subscriptions <subscriptions>`, two subscriptions will need to be run
-  as Hasura follows the `GraphQL spec <https://graphql.github.io/graphql-spec/June2018/#sec-Single-root-field>`_ which
+  as Hasura follows the `GraphQL spec <https://graphql.github.io/graphql-spec/June2018/#sec-Single-root-field>`__ which
   allows for only one root field in a subscription.

--- a/docs/graphql/manual/schema/views.rst
+++ b/docs/graphql/manual/schema/views.rst
@@ -16,7 +16,7 @@ Extend schema with views
 What are views?
 ---------------
 
-`Views <https://www.postgresql.org/docs/current/sql-createview.html>`_ can be used to expose the results of a custom
+`Views <https://www.postgresql.org/docs/current/sql-createview.html>`__ can be used to expose the results of a custom
 query as a virtual table. Views are not persisted physically i.e. the query defining a view is executed whenever
 data is requested from the view.
 

--- a/docs/graphql/manual/security-disclosure/index.rst
+++ b/docs/graphql/manual/security-disclosure/index.rst
@@ -22,7 +22,7 @@ This page describes the Hasura security vulnerability reporting and disclosure p
 Security announcements
 ----------------------
 
-Join the `Hasura Security Announcements <https://groups.google.com/forum/#!forum/hasura-security-announce>`_ group for emails about security announcements.
+Join the `Hasura Security Announcements <https://groups.google.com/forum/#!forum/hasura-security-announce>`__ group for emails about security announcements.
 
 Reporting vulnerabilities
 -------------------------
@@ -46,7 +46,7 @@ When should I NOT report a vulnerability?
 - You need help applying security related updates.
 - Your issue is not security related.
 
-In these cases you can join our `Discord server <https://hasura.io/discord>`_ where the community will be happy to help you out.
+In these cases you can join our `Discord server <https://hasura.io/discord>`__ where the community will be happy to help you out.
 
 Vulnerability report response
 -----------------------------

--- a/docs/graphql/manual/subscriptions/index.rst
+++ b/docs/graphql/manual/subscriptions/index.rst
@@ -32,7 +32,7 @@ By default updates are delivered to clients every **1 sec**. This interval can b
 ``--live-queries-multiplexed-refetch-interval`` flag. See the
 :ref:`server flag reference <server_flag_reference>` for info on setting the flag/env var.
 
-You can read more about the implementation of subscriptions in the `architecture doc <https://github.com/hasura/graphql-engine/blob/master/architecture/live-queries.md>`_.
+You can read more about the implementation of subscriptions in the `architecture doc <https://github.com/hasura/graphql-engine/blob/master/architecture/live-queries.md>`__.
 
 Convert a query to a subscription
 ---------------------------------
@@ -41,7 +41,7 @@ You can turn any query into a subscription by simply replacing ``query`` with ``
 
 .. admonition:: Caveat
 
-  Hasura follows the `GraphQL spec <https://graphql.github.io/graphql-spec/June2018/#sec-Single-root-field>`_ which
+  Hasura follows the `GraphQL spec <https://graphql.github.io/graphql-spec/June2018/#sec-Single-root-field>`__ which
   allows for only one root field in a subscription.
 
 Use cases
@@ -55,8 +55,8 @@ Communication protocol
 ----------------------
 
 Hasura GraphQL engine uses the `GraphQL over WebSocket Protocol
-<https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md>`_ by the
-`apollographql/subscriptions-transport-ws <https://github.com/apollographql/subscriptions-transport-ws>`_ library
+<https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md>`__ by the
+`apollographql/subscriptions-transport-ws <https://github.com/apollographql/subscriptions-transport-ws>`__ library
 for sending and receiving events.
 
 .. admonition:: Setting headers for subscriptions with Apollo client
@@ -78,7 +78,7 @@ for sending and receiving events.
       }
     });
 
-  See `this <https://www.apollographql.com/docs/react/data/subscriptions/#authentication-over-websocket>`_ for more
+  See `this <https://www.apollographql.com/docs/react/data/subscriptions/#authentication-over-websocket>`__ for more
   info on using ``connectionParams``.
 
 


### PR DESCRIPTION
### Description

This PR is doing the following changes:
- Update link to codegen contrib repo as suggested in [this PR](https://github.com/hasura/graphql-engine/pull/5323) (we can't merge it because the CLA is not signed)
- Make sure external links have a double `_`, avoiding duplicate label warnings in the docs build
- Make some links as internal references

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components

- [x] Docs

### Related PR

https://github.com/hasura/graphql-engine/pull/5323
