### PR TITLE
console: fix payload for data triggers (close #5358)

### DIFF
--- a/console/src/components/Common/utils/v1QueryUtils.ts
+++ b/console/src/components/Common/utils/v1QueryUtils.ts
@@ -496,9 +496,6 @@ export const generateCreateEventTriggerQuery = (
             columns: state.operationColumns
               .filter(c => !!c.enabled)
               .map(c => c.name),
-            payload: state.operationColumns
-              .filter(c => !!c.enabled)
-              .map(c => c.name),
           }
         : null,
       delete: state.operations.delete

--- a/console/src/components/Services/Events/ServerIO.ts
+++ b/console/src/components/Services/Events/ServerIO.ts
@@ -409,9 +409,6 @@ export const modifyEventTrigger = (
               columns: state.operationColumns
                 .filter(c => !!c.enabled)
                 .map(c => c.name),
-              payload: state.operationColumns
-                .filter(c => !!c.enabled)
-                .map(c => c.name),
             }
           : null,
         delete: state.operations.delete ? { columns: '*' } : null,


### PR DESCRIPTION
close https://github.com/hasura/graphql-engine/issues/5358

### Description

Fix regression — payload was set based on the columns selected for update. In 1.2 we weren't setting it at all.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components

- [x] Console
