### PR TITLE
Add MonadTrace and MonadExecuteQuery abstractions

### DIFF
--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -212,6 +212,10 @@ library
 
                      , directory
                      
+                     , random
+                     , mmorph
+                     , http-api-data
+                     
                      , semigroups >= 0.19.1
 
                      -- scheduled triggers
@@ -405,6 +409,7 @@ library
                      , Hasura.SQL.Time
                      , Hasura.SQL.Types
                      , Hasura.SQL.Value
+                     , Hasura.Tracing
                      , Network.URI.Extended
                      , Network.Wai.Extended
                      , Network.Wai.Handler.WebSockets.Custom

--- a/server/src-exec/Main.hs
+++ b/server/src-exec/Main.hs
@@ -20,6 +20,7 @@ import qualified Data.ByteString.Lazy       as BL
 import qualified Data.ByteString.Lazy.Char8 as BLC
 import qualified Data.Environment           as Env
 import qualified Database.PG.Query          as Q
+import qualified Hasura.Tracing             as Tracing
 import qualified System.Exit                as Sys
 import qualified System.Posix.Signals       as Signals
 
@@ -67,7 +68,8 @@ runApp env (HGEOptionsG rci hgeCmd) =
       let sqlGenCtx = SQLGenCtx False
       res <- runAsAdmin _icPgPool sqlGenCtx _icHttpManager $ do
         schemaCache <- buildRebuildableSchemaCache env
-        execQuery env queryBs
+        execQuery env queryBs 
+          & Tracing.runTraceTWithReporter Tracing.noReporter "execute"
           & runHasSystemDefinedT (SystemDefined False)
           & runCacheRWT schemaCache
           & fmap (\(res, _, _) -> res)

--- a/server/src-lib/Hasura/Db.hs
+++ b/server/src-lib/Hasura/Db.hs
@@ -38,6 +38,7 @@ import           Hasura.SQL.Error
 import           Hasura.SQL.Types
 
 import qualified Hasura.SQL.DML               as S
+import qualified Hasura.Tracing               as Tracing
 
 data PGExecCtx
   = PGExecCtx
@@ -80,6 +81,8 @@ instance (MonadTx m) => MonadTx (ReaderT s m) where
 instance (Monoid w, MonadTx m) => MonadTx (WriterT w m) where
   liftTx = lift . liftTx
 instance (MonadTx m) => MonadTx (ValidateT e m) where
+  liftTx = lift . liftTx
+instance (MonadTx m) => MonadTx (Tracing.TraceT m) where
   liftTx = lift . liftTx
 
 -- | Like 'Q.TxE', but defers acquiring a Postgres connection until the first

--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Plan.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Plan.hs
@@ -51,6 +51,7 @@ import qualified Hasura.GraphQL.Resolve                 as GR
 import qualified Hasura.GraphQL.Transport.HTTP.Protocol as GH
 import qualified Hasura.GraphQL.Validate                as GV
 import qualified Hasura.SQL.DML                         as S
+import qualified Hasura.Tracing                         as Tracing
 
 import           Hasura.Db
 import           Hasura.GraphQL.Resolve.Action
@@ -277,6 +278,7 @@ buildLiveQueryPlan
      , Has QueryCtxMap r
      , Has SQLGenCtx r
      , MonadIO m
+     , Tracing.MonadTrace m
      , HasVersion
      )
   => E.Environment

--- a/server/src-lib/Hasura/GraphQL/Explain.hs
+++ b/server/src-lib/Hasura/GraphQL/Explain.hs
@@ -30,6 +30,7 @@ import qualified Hasura.GraphQL.Transport.HTTP.Protocol as GH
 import qualified Hasura.GraphQL.Validate                as GV
 import qualified Hasura.GraphQL.Validate.SelectionSet   as GV
 import qualified Hasura.SQL.DML                         as S
+import qualified Hasura.Tracing                         as Tracing
 
 data GQLExplain
   = GQLExplain
@@ -87,7 +88,7 @@ getSessVarVal userInfo sessVar =
     sessionVariables = _uiSession userInfo
 
 explainField
-  :: (MonadError QErr m, MonadTx m, HasVersion, MonadIO m)
+  :: (MonadError QErr m, MonadTx m, HasVersion, MonadIO m, Tracing.MonadTrace m)
   => Env.Environment
   -> UserInfo
   -> GCtx
@@ -126,8 +127,10 @@ explainGQLQuery
   :: ( HasVersion
      , MonadError QErr m
      , MonadIO m
+     , Tracing.MonadTrace m
      , MonadIO tx
      , MonadTx tx
+     , Tracing.MonadTrace tx
      )
   => Env.Environment
   -> PGExecCtx

--- a/server/src-lib/Hasura/GraphQL/Logging.hs
+++ b/server/src-lib/Hasura/GraphQL/Logging.hs
@@ -14,6 +14,7 @@ import qualified Language.GraphQL.Draft.Syntax          as G
 import           Hasura.GraphQL.Transport.HTTP.Protocol (GQLReqUnparsed)
 import           Hasura.Prelude
 import           Hasura.Server.Utils                    (RequestId)
+import           Hasura.Tracing                         (TraceT)
 
 import qualified Hasura.GraphQL.Execute.Query           as EQ
 import qualified Hasura.Logging                         as L
@@ -62,4 +63,7 @@ instance MonadQueryLog m => MonadQueryLog (ExceptT e m) where
   logQueryLog l req sqlMap reqId = lift $ logQueryLog l req sqlMap reqId
 
 instance MonadQueryLog m => MonadQueryLog (ReaderT r m) where
+  logQueryLog l req sqlMap reqId = lift $ logQueryLog l req sqlMap reqId
+
+instance MonadQueryLog m => MonadQueryLog (TraceT m) where
   logQueryLog l req sqlMap reqId = lift $ logQueryLog l req sqlMap reqId

--- a/server/src-lib/Hasura/GraphQL/Resolve.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve.hs
@@ -45,6 +45,7 @@ import qualified Hasura.GraphQL.Validate           as V
 import qualified Hasura.RQL.DML.RemoteJoin         as RR
 import qualified Hasura.RQL.DML.Select             as DS
 import qualified Hasura.SQL.DML                    as S
+import qualified Hasura.Tracing                    as Tracing
 
 data QueryRootFldAST v
   = QRFNode !(DS.AnnSimpleSelG v)
@@ -108,6 +109,7 @@ queryFldToPGAST
      , Has QueryCtxMap r
      , HasVersion
      , MonadIO m
+     , Tracing.MonadTrace m
      )
   => Env.Environment
   -> V.Field
@@ -174,8 +176,10 @@ mutFldToTx
      , Has HTTP.Manager r
      , Has [HTTP.Header] r
      , MonadIO m
+     , Tracing.MonadTrace m
      , MonadIO tx
      , MonadTx tx
+     , Tracing.MonadTrace tx
      )
   => Env.Environment
   -> V.Field

--- a/server/src-lib/Hasura/GraphQL/Resolve/Insert.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/Insert.hs
@@ -23,6 +23,7 @@ import qualified Language.GraphQL.Draft.Syntax        as G
 import qualified Hasura.RQL.DML.Insert                as RI
 import qualified Hasura.RQL.DML.Returning             as RR
 import qualified Hasura.SQL.DML                       as S
+import qualified Hasura.Tracing                       as Tracing
 
 import           Hasura.GraphQL.Resolve.BoolExp
 import           Hasura.GraphQL.Resolve.Context
@@ -296,7 +297,7 @@ validateInsert insCols objRels addCols = do
 -- | insert an object relationship and return affected rows
 -- | and parent dependent columns
 insertObjRel
-  :: (HasVersion, MonadTx m, MonadIO m)
+  :: (HasVersion, MonadTx m, MonadIO m, Tracing.MonadTrace m)
   => Env.Environment
   -> Bool
   -> MutationRemoteJoinCtx
@@ -333,7 +334,7 @@ decodeEncJSON =
 
 -- | insert an array relationship and return affected rows
 insertArrRel
-  :: (HasVersion, MonadTx m, MonadIO m)
+  :: (HasVersion, MonadTx m, MonadIO m, Tracing.MonadTrace m)
   => Env.Environment
   -> Bool
   -> MutationRemoteJoinCtx
@@ -360,7 +361,7 @@ insertArrRel env strfyNum rjCtx role resCols arrRelIns =
 
 -- | insert an object with object and array relationships
 insertObj
-  :: (HasVersion, MonadTx m, MonadIO m)
+  :: (HasVersion, MonadTx m, MonadIO m, Tracing.MonadTrace m)
   => Env.Environment
   -> Bool
   -> MutationRemoteJoinCtx
@@ -423,6 +424,7 @@ insertMultipleObjects
   :: ( HasVersion
      , MonadTx m
      , MonadIO m
+     , Tracing.MonadTrace m
      )
   => Env.Environment
   -> Bool
@@ -494,6 +496,7 @@ convertInsert
      , Has InsCtxMap r
      , MonadIO tx
      , MonadTx tx
+     , Tracing.MonadTrace tx
      )
   => Env.Environment
   -> MutationRemoteJoinCtx
@@ -540,6 +543,7 @@ convertInsertOne
      , Has InsCtxMap r
      , MonadIO tx
      , MonadTx tx
+     , Tracing.MonadTrace tx
      )
   => Env.Environment
   -> MutationRemoteJoinCtx

--- a/server/src-lib/Hasura/GraphQL/Resolve/Mutation.hs
+++ b/server/src-lib/Hasura/GraphQL/Resolve/Mutation.hs
@@ -28,6 +28,7 @@ import qualified Hasura.RQL.DML.Update               as RU
 import qualified Hasura.RQL.DML.Select               as RS
 import qualified Hasura.SQL.DML                      as S
 import qualified Data.Environment                    as Env
+import qualified Hasura.Tracing                      as Tracing
 
 import           Hasura.EncJSON
 import           Hasura.GraphQL.Resolve.BoolExp
@@ -221,6 +222,7 @@ convertUpdateGeneric
      , Has SQLGenCtx r 
      , MonadIO tx 
      , MonadTx tx 
+     , Tracing.MonadTrace tx 
      )
   => Env.Environment
   -> UpdOpCtx -- the update context
@@ -252,6 +254,7 @@ convertUpdate
      , Has SQLGenCtx r
      , MonadIO tx
      , MonadTx tx
+     , Tracing.MonadTrace tx
      )
   => Env.Environment
   -> UpdOpCtx -- the update context
@@ -271,6 +274,7 @@ convertUpdateByPk
      , Has SQLGenCtx r
      , MonadIO tx
      , MonadTx tx
+     , Tracing.MonadTrace tx
      )
   => Env.Environment
   -> UpdOpCtx -- the update context
@@ -291,6 +295,7 @@ convertDeleteGeneric
      , Has SQLGenCtx r
      , MonadIO tx
      , MonadTx tx
+     , Tracing.MonadTrace tx
      )
   => Env.Environment
   -> DelOpCtx -- the delete context
@@ -324,6 +329,7 @@ convertDelete
      , Has SQLGenCtx r
      , MonadIO tx
      , MonadTx tx
+     , Tracing.MonadTrace tx
      )
   => Env.Environment
   -> DelOpCtx -- the delete context
@@ -343,6 +349,7 @@ convertDeleteByPk
      , Has SQLGenCtx r
      , MonadIO tx
      , MonadTx tx
+     , Tracing.MonadTrace tx
      )
   => Env.Environment
   -> DelOpCtx -- the delete context

--- a/server/src-lib/Hasura/GraphQL/Transport/HTTP.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/HTTP.hs
@@ -1,7 +1,8 @@
 -- | Execution of GraphQL queries over HTTP transport
 {-# LANGUAGE RecordWildCards #-}
 module Hasura.GraphQL.Transport.HTTP
-  ( runGQ
+  ( MonadExecuteQuery(..)
+  , runGQ
   , runGQBatched
   -- * imported from HTTP.Protocol; required by pro
   , GQLReq(..)
@@ -11,6 +12,8 @@ module Hasura.GraphQL.Transport.HTTP
   , OperationName(..)
   , GQLQueryText(..)
   ) where
+
+import           Control.Monad.Morph                    (hoist)
 
 import           Hasura.EncJSON
 import           Hasura.GraphQL.Logging                 (MonadQueryLog (..))
@@ -22,14 +25,39 @@ import           Hasura.Server.Init.Config
 import           Hasura.Server.Utils                    (RequestId)
 import           Hasura.Server.Version                  (HasVersion)
 import           Hasura.Session
+import           Hasura.Tracing                         (MonadTrace, TraceT, trace)
 
 import qualified Data.Environment                       as Env
 import qualified Database.PG.Query                      as Q
 import qualified Hasura.GraphQL.Execute                 as E
+import qualified Hasura.GraphQL.Execute.Query           as EQ
+import qualified Hasura.GraphQL.Resolve                 as R
 import qualified Hasura.Server.Telemetry.Counters       as Telem
+import qualified Hasura.Tracing                         as Tracing
 import qualified Language.GraphQL.Draft.Syntax          as G
 import qualified Network.HTTP.Types                     as HTTP
 import qualified Network.Wai.Extended                   as Wai
+
+
+class Monad m => MonadExecuteQuery m where
+  executeQuery
+    :: GQLReqParsed
+    -> [R.QueryRootFldUnresolved]
+    -> Maybe EQ.GeneratedSqlMap
+    -> PGExecCtx
+    -> Q.TxAccess
+    -> TraceT (LazyTx QErr) EncJSON
+    -> TraceT (ExceptT QErr m) (HTTP.ResponseHeaders, EncJSON)
+
+instance MonadExecuteQuery m => MonadExecuteQuery (ReaderT r m) where
+  executeQuery a b c d e f = hoist (hoist lift) $ executeQuery a b c d e f
+
+instance MonadExecuteQuery m => MonadExecuteQuery (ExceptT r m) where
+  executeQuery a b c d e f = hoist (hoist lift) $ executeQuery a b c d e f
+
+instance MonadExecuteQuery m => MonadExecuteQuery (TraceT m) where
+  executeQuery a b c d e f = hoist (hoist lift) $ executeQuery a b c d e f
+
 
 -- | Run (execute) a single GraphQL query
 runGQ
@@ -39,6 +67,8 @@ runGQ
      , MonadReader E.ExecutionCtx m
      , E.MonadGQLExecutionCheck m
      , MonadQueryLog m
+     , MonadTrace m
+     , MonadExecuteQuery m
      )
   => Env.Environment
   -> RequestId
@@ -85,6 +115,8 @@ runGQBatched
      , MonadReader E.ExecutionCtx m
      , E.MonadGQLExecutionCheck m
      , MonadQueryLog m
+     , MonadTrace m
+     , MonadExecuteQuery m
      )
   => Env.Environment
   -> RequestId
@@ -120,25 +152,27 @@ runHasuraGQ
      , MonadError QErr m
      , MonadReader E.ExecutionCtx m
      , MonadQueryLog m
+     , MonadTrace m
+     , MonadExecuteQuery m
      )
   => RequestId
   -> (GQLReqUnparsed, GQLReqParsed)
   -> UserInfo
-  -> E.ExecOp (LazyTx QErr)
+  -> E.ExecOp (Tracing.TraceT (LazyTx QErr))
   -> m (DiffTime, Telem.QueryType, HTTP.ResponseHeaders, EncJSON)
   -- ^ Also return 'Mutation' when the operation was a mutation, and the time
   -- spent in the PG query; for telemetry.
-runHasuraGQ reqId (query, _queryParsed) userInfo resolvedOp = do
+runHasuraGQ reqId (query, queryParsed) userInfo resolvedOp = do
   (E.ExecutionCtx logger _ pgExecCtx _ _ _ _ _) <- ask
   (telemTimeIO, respE) <- withElapsedTime $ runExceptT $ case resolvedOp of
-    E.ExOpQuery tx genSql _asts -> do
+    E.ExOpQuery tx genSql asts -> trace "pg" $ do
       -- log the generated SQL and the graphql query
       logQueryLog logger query genSql reqId
-      ([],) <$> runQueryTx pgExecCtx tx
+      Tracing.interpTraceT id $ executeQuery queryParsed asts genSql pgExecCtx Q.ReadOnly tx
 
-    E.ExOpMutation respHeaders tx -> do
+    E.ExOpMutation respHeaders tx -> trace "pg" $ do
       logQueryLog logger query Nothing reqId
-      (respHeaders,) <$> runLazyTx pgExecCtx Q.ReadWrite (withUserInfo userInfo tx)
+      (respHeaders,) <$> Tracing.interpTraceT (runLazyTx pgExecCtx Q.ReadWrite . withUserInfo userInfo) tx
 
     E.ExOpSubs _ ->
       throw400 UnexpectedPayload

--- a/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
@@ -42,6 +42,7 @@ import           Data.String
 import           GHC.AssertNF
 
 import           Hasura.EncJSON
+import           Hasura.GraphQL.Transport.HTTP               (MonadExecuteQuery(..))
 import           Hasura.GraphQL.Logging                      (MonadQueryLog (..))
 import           Hasura.GraphQL.Transport.HTTP.Protocol
 import           Hasura.GraphQL.Transport.WebSocket.Protocol
@@ -63,6 +64,7 @@ import qualified Hasura.GraphQL.Execute.Query                as EQ
 import qualified Hasura.GraphQL.Transport.WebSocket.Server   as WS
 import qualified Hasura.Logging                              as L
 import qualified Hasura.Server.Telemetry.Counters            as Telem
+import qualified Hasura.Tracing                              as Tracing
 
 -- | 'LQ.LiveQueryId' comes from 'Hasura.GraphQL.Execute.LiveQuery.State.addLiveQuery'. We use
 -- this to track a connection's operations so we can remove them from 'LiveQueryState', and
@@ -305,7 +307,7 @@ onConn (L.Logger logger) corsPolicy wsId requestHead ipAddress = do
             <> "HASURA_GRAPHQL_WS_READ_COOKIE to force read cookie when CORS is disabled."
 
 onStart
-  :: forall m. (HasVersion, MonadIO m, E.MonadGQLExecutionCheck m, MonadQueryLog m)
+  :: forall m. (HasVersion, MonadIO m, E.MonadGQLExecutionCheck m, MonadQueryLog m, Tracing.MonadTrace m, MonadExecuteQuery m)
   => Env.Environment -> WSServerEnv -> WSConn -> StartMsg -> m ()
 onStart env serverEnv wsConn (StartMsg opId q) = catchAndIgnore $ do
   timerTot <- startTimer
@@ -339,7 +341,7 @@ onStart env serverEnv wsConn (StartMsg opId q) = catchAndIgnore $ do
 
   case execPlan of
     E.GExPHasura resolvedOp ->
-      runHasuraGQ timerTot telemCacheHit requestId q userInfo resolvedOp
+      runHasuraGQ timerTot telemCacheHit requestId q reqParsed userInfo resolvedOp
     E.GExPRemote rsi opDef  ->
       runRemoteGQ timerTot telemCacheHit execCtx requestId userInfo reqHdrs opDef rsi
   where
@@ -349,16 +351,18 @@ onStart env serverEnv wsConn (StartMsg opId q) = catchAndIgnore $ do
       -> Telem.CacheHit
       -> RequestId
       -> GQLReqUnparsed
+      -> GQLReqParsed
       -> UserInfo
-      -> E.ExecOp (LazyTx QErr)
+      -> E.ExecOp (Tracing.TraceT (LazyTx QErr))
       -> ExceptT () m ()
-    runHasuraGQ timerTot telemCacheHit reqId query userInfo = \case
-      E.ExOpQuery opTx genSql _asts ->
-        execQueryOrMut Telem.Query genSql $ runQueryTx pgExecCtx opTx 
+    runHasuraGQ timerTot telemCacheHit reqId query queryParsed userInfo = \case
+      E.ExOpQuery opTx genSql asts -> Tracing.trace "pg" $
+        execQueryOrMut Telem.Query genSql . fmap snd $
+          Tracing.interpTraceT id $ executeQuery queryParsed asts genSql pgExecCtx Q.ReadOnly opTx
       -- Response headers discarded over websockets
-      E.ExOpMutation _ opTx -> do
+      E.ExOpMutation _ opTx -> Tracing.trace "pg" do
         execQueryOrMut Telem.Mutation Nothing $
-          runLazyTx pgExecCtx Q.ReadWrite $ withUserInfo userInfo opTx
+          Tracing.interpTraceT (runLazyTx pgExecCtx Q.ReadWrite . withUserInfo userInfo) opTx
       E.ExOpSubs lqOp -> do
         -- log the graphql query
         logQueryLog logger query Nothing reqId
@@ -503,15 +507,17 @@ onStart env serverEnv wsConn (StartMsg opId q) = catchAndIgnore $ do
 onMessage
   :: ( HasVersion
      , MonadIO m
-     , UserAuthentication m
+     , UserAuthentication (Tracing.TraceT m)
      , E.MonadGQLExecutionCheck m
      , MonadQueryLog m
+     , Tracing.HasReporter m
+     , MonadExecuteQuery m
      )
   => Env.Environment
   -> AuthMode
   -> WSServerEnv
   -> WSConn -> BL.ByteString -> m ()
-onMessage env authMode serverEnv wsConn msgRaw = do
+onMessage env authMode serverEnv wsConn msgRaw = Tracing.runTraceT "websocket" do
   case J.eitherDecode msgRaw of
     Left e    -> do
       let err = ConnErrMsg $ "parsing ClientMessage failed: " <> T.pack e
@@ -586,8 +592,8 @@ logWSEvent (L.Logger logger) wsConn wsEv = do
         ODStopped    -> False
 
 onConnInit
-  :: (HasVersion, MonadIO m, UserAuthentication m)
-  => L.Logger L.Hasura -> H.Manager -> WSConn -> AuthMode -> Maybe ConnParams -> m ()
+  :: (HasVersion, MonadIO m, UserAuthentication (Tracing.TraceT m))
+  => L.Logger L.Hasura -> H.Manager -> WSConn -> AuthMode -> Maybe ConnParams -> Tracing.TraceT m ()
 onConnInit logger manager wsConn authMode connParamsM = do
   -- TODO: what should be the behaviour of connection_init message when a
   -- connection is already iniatilized? Currently, we seem to be doing
@@ -685,10 +691,12 @@ createWSServerApp
      , MonadIO m
      , MC.MonadBaseControl IO m
      , LA.Forall (LA.Pure m)
-     , UserAuthentication m
+     , UserAuthentication (Tracing.TraceT m)
      , E.MonadGQLExecutionCheck m
      , WS.MonadWSLog m
      , MonadQueryLog m
+     , Tracing.HasReporter m
+     , MonadExecuteQuery m
      )
   => Env.Environment
   -> AuthMode

--- a/server/src-lib/Hasura/GraphQL/Validate/Types.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate/Types.hs
@@ -107,6 +107,7 @@ import qualified Language.Haskell.TH.Syntax    as TH
 import           Control.Lens                  (makePrisms)
 
 import qualified Hasura.RQL.Types.Column       as RQL
+import qualified Hasura.Tracing                as Tracing
 
 import           Hasura.GraphQL.NormalForm
 import           Hasura.GraphQL.Utils
@@ -800,6 +801,12 @@ instance (Monad m) => MonadReusability (ReusabilityT m) where
   recordVariableUse varName varType = ReusabilityT $
     modify' (<> Reusable (ReusableVariableTypes $ Map.singleton varName varType))
   markNotReusable = ReusabilityT $ put NotReusable
+
+instance Tracing.MonadTrace m => Tracing.MonadTrace (ReusabilityT m) where
+  trace name (ReusabilityT ma) = ReusabilityT (Tracing.trace name ma)
+  currentContext = lift Tracing.currentContext
+  currentReporter = lift Tracing.currentReporter
+  attachMetadata = lift . Tracing.attachMetadata
 
 runReusabilityT :: ReusabilityT m a -> m (a, QueryReusability)
 runReusabilityT = runReusabilityTWith mempty

--- a/server/src-lib/Hasura/RQL/DML/Delete.hs
+++ b/server/src-lib/Hasura/RQL/DML/Delete.hs
@@ -13,6 +13,7 @@ import           Instances.TH.Lift        ()
 
 import qualified Data.Sequence            as DS
 import qualified Data.Environment         as Env
+import qualified Hasura.Tracing           as Tracing
 
 import           Hasura.EncJSON
 import           Hasura.Prelude
@@ -119,6 +120,7 @@ execDeleteQuery
   ( HasVersion
   , MonadTx m
   , MonadIO m
+  , Tracing.MonadTrace m
   )
   => Env.Environment
   -> Bool
@@ -134,6 +136,7 @@ execDeleteQuery env strfyNum remoteJoinCtx (u, p) =
 runDelete
   :: ( HasVersion, QErrM m, UserInfoM m, CacheRM m
      , MonadTx m, HasSQLGenCtx m, MonadIO m
+     , Tracing.MonadTrace m
      )
   => Env.Environment
   -> DeleteQuery

--- a/server/src-lib/Hasura/RQL/DML/Insert.hs
+++ b/server/src-lib/Hasura/RQL/DML/Insert.hs
@@ -22,6 +22,7 @@ import           Hasura.SQL.Types
 import qualified Data.Environment         as Env
 import qualified Database.PG.Query        as Q
 import qualified Hasura.SQL.DML           as S
+import qualified Hasura.Tracing           as Tracing
 
 data ConflictTarget
   = CTColumn ![PGCol]
@@ -256,6 +257,7 @@ execInsertQuery
   :: ( HasVersion
      , MonadTx m
      , MonadIO m
+     , Tracing.MonadTrace m
      )
   => Env.Environment
   -> Bool
@@ -343,6 +345,7 @@ insertOrUpdateCheckExpr _ _ insCheck _ =
 runInsert
   :: ( HasVersion, QErrM m, UserInfoM m
      , CacheRM m, MonadTx m, HasSQLGenCtx m, MonadIO m
+     , Tracing.MonadTrace m
      )
   => Env.Environment -> InsertQuery -> m EncJSON
 runInsert env q = do

--- a/server/src-lib/Hasura/RQL/DML/Mutation.hs
+++ b/server/src-lib/Hasura/RQL/DML/Mutation.hs
@@ -19,6 +19,7 @@ import qualified Network.HTTP.Client       as HTTP
 import qualified Network.HTTP.Types        as N
 
 import qualified Hasura.SQL.DML            as S
+import qualified Hasura.Tracing            as Tracing
 
 import           Hasura.EncJSON
 import           Hasura.RQL.DML.Internal
@@ -62,6 +63,7 @@ runMutation
   ( HasVersion
   , MonadTx m
   , MonadIO m
+  , Tracing.MonadTrace m
   )
   => Env.Environment
   -> Mutation
@@ -75,6 +77,7 @@ mutateAndReturn
   ( HasVersion
   , MonadTx m
   , MonadIO m
+  , Tracing.MonadTrace m
   )
   => Env.Environment
   -> Mutation
@@ -104,6 +107,7 @@ mutateAndSel
   ( HasVersion
   , MonadTx m
   , MonadIO m
+  , Tracing.MonadTrace m
   )
   => Env.Environment
   -> Mutation
@@ -121,6 +125,7 @@ executeMutationOutputQuery
   ( HasVersion
   , MonadTx m
   , MonadIO m
+  , Tracing.MonadTrace m
   )
   => Env.Environment
   -> Q.Query -- ^ SQL query

--- a/server/src-lib/Hasura/RQL/DML/RemoteJoin.hs
+++ b/server/src-lib/Hasura/RQL/DML/RemoteJoin.hs
@@ -38,6 +38,7 @@ import qualified Data.HashSet                           as HS
 import qualified Data.List.NonEmpty                     as NE
 import qualified Data.Text                              as T
 import qualified Database.PG.Query                      as Q
+import qualified Hasura.Tracing                         as Tracing
 import qualified Language.GraphQL.Draft.Printer.Text    as G
 import qualified Language.GraphQL.Draft.Syntax          as G
 import qualified Network.HTTP.Client                    as HTTP
@@ -48,6 +49,7 @@ executeQueryWithRemoteJoins
   :: ( HasVersion
      , MonadTx m
      , MonadIO m
+     , Tracing.MonadTrace m
      )
   => Env.Environment
   -> HTTP.Manager
@@ -351,6 +353,7 @@ fetchRemoteJoinFields
   :: ( HasVersion
      , MonadError QErr m
      , MonadIO m
+     , Tracing.MonadTrace m
      )
   => Env.Environment
   -> HTTP.Manager

--- a/server/src-lib/Hasura/RQL/DML/Update.hs
+++ b/server/src-lib/Hasura/RQL/DML/Update.hs
@@ -30,6 +30,7 @@ import           Hasura.SQL.Types
 import qualified Database.PG.Query        as Q
 import qualified Hasura.SQL.DML           as S
 import qualified Data.Environment         as Env
+import qualified Hasura.Tracing           as Tracing
 
 data AnnUpdG v
   = AnnUpd
@@ -230,6 +231,7 @@ execUpdateQuery
   ( HasVersion
   , MonadTx m
   , MonadIO m
+  , Tracing.MonadTrace m
   )
   => Env.Environment
   -> Bool
@@ -245,6 +247,7 @@ execUpdateQuery env strfyNum remoteJoinCtx (u, p) =
 runUpdate
   :: ( HasVersion, QErrM m, UserInfoM m, CacheRM m
      , MonadTx m, HasSQLGenCtx m, MonadIO m
+     , Tracing.MonadTrace m
      )
   => Env.Environment -> UpdateQuery -> m EncJSON
 runUpdate env q = do

--- a/server/src-lib/Hasura/RQL/Types.hs
+++ b/server/src-lib/Hasura/RQL/Types.hs
@@ -41,6 +41,7 @@ module Hasura.RQL.Types
 import           Hasura.Prelude
 import           Hasura.Session
 import           Hasura.SQL.Types
+import           Hasura.Tracing                      (TraceT)
 
 import           Hasura.Db                           as R
 import           Hasura.RQL.Types.Action             as R
@@ -92,6 +93,8 @@ instance (UserInfoM m) => UserInfoM (ReaderT r m) where
   askUserInfo = lift askUserInfo
 instance (UserInfoM m) => UserInfoM (StateT s m) where
   askUserInfo = lift askUserInfo
+instance (UserInfoM m) => UserInfoM (TraceT m) where
+  askUserInfo = lift askUserInfo
 
 askTabInfo
   :: (QErrM m, CacheRM m)
@@ -137,6 +140,8 @@ instance (HasHttpManager m) => HasHttpManager (StateT s m) where
   askHttpManager = lift askHttpManager
 instance (Monoid w, HasHttpManager m) => HasHttpManager (WriterT w m) where
   askHttpManager = lift askHttpManager
+instance (HasHttpManager m) => HasHttpManager (TraceT m) where
+  askHttpManager = lift askHttpManager
 
 class (Monad m) => HasGCtxMap m where
   askGCtxMap :: m GC.GCtxMap
@@ -162,6 +167,8 @@ instance (Monoid w, HasSQLGenCtx m) => HasSQLGenCtx (WriterT w m) where
   askSQLGenCtx = lift askSQLGenCtx
 instance (HasSQLGenCtx m) => HasSQLGenCtx (TableCoreCacheRT m) where
   askSQLGenCtx = lift askSQLGenCtx
+instance (HasSQLGenCtx m) => HasSQLGenCtx (TraceT m) where
+  askSQLGenCtx = lift askSQLGenCtx
 
 class (Monad m) => HasSystemDefined m where
   askSystemDefined :: m SystemDefined
@@ -171,6 +178,8 @@ instance (HasSystemDefined m) => HasSystemDefined (ReaderT r m) where
 instance (HasSystemDefined m) => HasSystemDefined (StateT s m) where
   askSystemDefined = lift askSystemDefined
 instance (Monoid w, HasSystemDefined m) => HasSystemDefined (WriterT w m) where
+  askSystemDefined = lift askSystemDefined
+instance (HasSystemDefined m) => HasSystemDefined (TraceT m) where
   askSystemDefined = lift askSystemDefined
 
 newtype HasSystemDefinedT m a

--- a/server/src-lib/Hasura/RQL/Types/SchemaCache.hs
+++ b/server/src-lib/Hasura/RQL/Types/SchemaCache.hs
@@ -136,6 +136,7 @@ import           Hasura.RQL.Types.ScheduledTrigger
 import           Hasura.RQL.Types.SchemaCacheTypes
 import           Hasura.RQL.Types.Table
 import           Hasura.SQL.Types
+import           Hasura.Tracing                    (TraceT)
 
 import           Data.Aeson
 import           Data.Aeson.Casing
@@ -248,6 +249,8 @@ instance (TableCoreInfoRM m) => TableCoreInfoRM (StateT s m) where
   lookupTableCoreInfo = lift . lookupTableCoreInfo
 instance (Monoid w, TableCoreInfoRM m) => TableCoreInfoRM (WriterT w m) where
   lookupTableCoreInfo = lift . lookupTableCoreInfo
+instance (TableCoreInfoRM m) => TableCoreInfoRM (TraceT m) where
+  lookupTableCoreInfo = lift . lookupTableCoreInfo
 
 newtype TableCoreCacheRT m a
   = TableCoreCacheRT { runTableCoreCacheRT :: Dependency TableCoreCache -> m a }
@@ -269,6 +272,8 @@ instance (CacheRM m) => CacheRM (ReaderT r m) where
 instance (CacheRM m) => CacheRM (StateT s m) where
   askSchemaCache = lift askSchemaCache
 instance (Monoid w, CacheRM m) => CacheRM (WriterT w m) where
+  askSchemaCache = lift askSchemaCache
+instance (CacheRM m) => CacheRM (TraceT m) where
   askSchemaCache = lift askSchemaCache
 
 newtype CacheRT m a = CacheRT { runCacheRT :: SchemaCache -> m a }

--- a/server/src-lib/Hasura/RQL/Types/SchemaCache/Build.hs
+++ b/server/src-lib/Hasura/RQL/Types/SchemaCache/Build.hs
@@ -37,6 +37,7 @@ import           Hasura.RQL.Types.Error
 import           Hasura.RQL.Types.Metadata
 import           Hasura.RQL.Types.RemoteSchema (RemoteSchemaName)
 import           Hasura.RQL.Types.SchemaCache
+import           Hasura.Tracing                (TraceT)
 
 -- ----------------------------------------------------------------------------
 -- types used during schema cache construction
@@ -128,6 +129,8 @@ instance Monoid CacheInvalidations where
   mempty = CacheInvalidations False mempty
 
 instance (CacheRWM m) => CacheRWM (ReaderT r m) where
+  buildSchemaCacheWithOptions a b = lift $ buildSchemaCacheWithOptions a b
+instance (CacheRWM m) => CacheRWM (TraceT m) where
   buildSchemaCacheWithOptions a b = lift $ buildSchemaCacheWithOptions a b
 
 buildSchemaCache :: (CacheRWM m) => m ()

--- a/server/src-lib/Hasura/Server/App.hs
+++ b/server/src-lib/Hasura/Server/App.hs
@@ -5,7 +5,9 @@ module Hasura.Server.App where
 
 import           Control.Concurrent.MVar.Lifted
 import           Control.Exception                         (IOException, try)
+import           Control.Monad.Morph                       (hoist)
 import           Control.Monad.Trans.Control               (MonadBaseControl)
+import           Data.String                               (fromString)
 
 import           Control.Monad.Stateless
 import           Data.Aeson                                hiding (json)
@@ -18,6 +20,8 @@ import           System.FilePath                           (joinPath, takeFileNa
 import           Web.Spock.Core                            ((<//>))
 
 import qualified Control.Concurrent.Async.Lifted.Safe      as LA
+import qualified Control.Monad.Trans.Control               as MTC
+import qualified Data.ByteString.Char8                     as B8
 import qualified Data.ByteString.Lazy                      as BL
 import qualified Data.CaseInsensitive                      as CI
 import qualified Data.Environment                          as Env
@@ -65,6 +69,7 @@ import qualified Hasura.GraphQL.Transport.WebSocket        as WS
 import qualified Hasura.GraphQL.Transport.WebSocket.Server as WS
 import qualified Hasura.Logging                            as L
 import qualified Hasura.Server.API.PGDump                  as PGD
+import qualified Hasura.Tracing                            as Tracing
 import qualified Network.Wai.Handler.WebSockets.Custom     as WSC
 
 
@@ -214,6 +219,9 @@ setHeader (headerName, headerValue) =
 class Monad m => MetadataApiAuthorization m where
   authorizeMetadataApi :: HasVersion => RQLQuery -> UserInfo -> Handler m ()
 
+instance MetadataApiAuthorization m => MetadataApiAuthorization (Tracing.TraceT m) where
+  authorizeMetadataApi q ui = hoist (hoist lift) $ authorizeMetadataApi q ui
+
 -- | The config API (/v1alpha1/config) handler
 class Monad m => MonadConfigApiHandler m where
   runConfigApiHandler
@@ -223,14 +231,25 @@ class Monad m => MonadConfigApiHandler m where
     -- ^ console assets directory
     -> Spock.SpockCtxT () m ()
 
+-- instance (MonadIO m, UserAuthentication m, HttpLog m, Tracing.HasReporter m) => MonadConfigApiHandler (Tracing.TraceT m) where
+--   runConfigApiHandler = configApiGetHandler
+
+mapActionT
+  :: (Monad m, Monad n)
+  => (m (MTC.StT (Spock.ActionCtxT ()) a) -> n (MTC.StT (Spock.ActionCtxT ()) a))
+  -> Spock.ActionT m a
+  -> Spock.ActionT n a
+mapActionT f tma = MTC.restoreT . pure =<< (MTC.liftWith $ \run -> f (run tma))
+
+
 mkSpockAction
-  :: (HasVersion, MonadIO m, FromJSON a, ToJSON a, UserAuthentication m, HttpLog m)
+  :: (HasVersion, MonadIO m, FromJSON a, ToJSON a, UserAuthentication (Tracing.TraceT m), HttpLog m, Tracing.HasReporter m)
   => ServerCtx
   -> (Bool -> QErr -> Value)
   -- ^ `QErr` JSON encoder function
   -> (QErr -> QErr)
   -- ^ `QErr` modifier
-  -> APIHandler m a
+  -> APIHandler (Tracing.TraceT m) a
   -> Spock.ActionT m ()
 mkSpockAction serverCtx qErrEncoder qErrModifier apiHandler = do
     req <- Spock.request
@@ -240,36 +259,51 @@ mkSpockAction serverCtx qErrEncoder qErrModifier apiHandler = do
         authMode = scAuthMode serverCtx
         manager = scManager serverCtx
         ipAddress = Wai.getSourceFromFallback req
+        pathInfo = Wai.rawPathInfo req
+
+    tracingCtx <- liftIO $ Tracing.extractHttpContext headers
+
+    let runTraceT
+          :: forall m a
+           . (MonadIO m, Tracing.HasReporter m)
+          => Tracing.TraceT m a
+          -> m a
+        runTraceT = maybe
+          Tracing.runTraceT
+          Tracing.runTraceTInContext
+          tracingCtx
+          (fromString (B8.unpack pathInfo))
 
     requestId <- getRequestId headers
 
-    userInfoE <- fmap fst <$> lift (resolveUserInfo logger manager headers authMode)
-    userInfo  <- either (logErrorAndResp Nothing requestId req (Left reqBody) False headers . qErrModifier)
-                return userInfoE
+    mapActionT runTraceT $ do
+      userInfoE <- fmap fst <$> lift (resolveUserInfo logger manager headers authMode)
+      userInfo  <- either (logErrorAndResp Nothing requestId req (Left reqBody) False headers . qErrModifier)
+                  return userInfoE
 
-    let handlerState = HandlerCtx serverCtx userInfo headers requestId ipAddress
-        includeInternal = shouldIncludeInternal (_uiRole userInfo) $
-                          scResponseInternalErrorsConfig serverCtx
+      let handlerState = HandlerCtx serverCtx userInfo headers requestId ipAddress
+          includeInternal = shouldIncludeInternal (_uiRole userInfo) $
+                            scResponseInternalErrorsConfig serverCtx
 
-    (serviceTime, (result, q)) <- withElapsedTime $ case apiHandler of
-      AHGet handler -> do
-        res <- lift $ runReaderT (runExceptT handler) handlerState
-        return (res, Nothing)
-      AHPost handler -> do
-        parsedReqE <- runExceptT $ parseBody reqBody
-        parsedReq  <- either (logErrorAndResp (Just userInfo) requestId req (Left reqBody) includeInternal headers . qErrModifier)
-                      return parsedReqE
-        res <- lift $ runReaderT (runExceptT $ handler parsedReq) handlerState
-        return (res, Just parsedReq)
+      (serviceTime, (result, q)) <- withElapsedTime $ case apiHandler of
+        AHGet handler -> do
+          res <- lift $ runReaderT (runExceptT handler) handlerState
+          return (res, Nothing)
+        AHPost handler -> do
+          parsedReqE <- runExceptT $ parseBody reqBody
+          parsedReq  <- either (logErrorAndResp (Just userInfo) requestId req (Left reqBody) includeInternal headers . qErrModifier)
+                        return parsedReqE
+          res <- lift $ runReaderT (runExceptT $ handler parsedReq) handlerState
+          return (res, Just parsedReq)
 
-    -- apply the error modifier
-    let modResult = fmapL qErrModifier result
+      -- apply the error modifier
+      let modResult = fmapL qErrModifier result
 
-    -- log and return result
-    case modResult of
-      Left err  -> let jErr = maybe (Left reqBody) (Right . toJSON) q
-                  in logErrorAndResp (Just userInfo) requestId req jErr includeInternal headers err
-      Right res -> logSuccessAndResp (Just userInfo) requestId req (fmap toJSON q) res (Just (ioWaitTime, serviceTime)) headers
+      -- log and return result
+      case modResult of
+        Left err  -> let jErr = maybe (Left reqBody) (Right . toJSON) q
+                    in logErrorAndResp (Just userInfo) requestId req jErr includeInternal headers err
+        Right res -> logSuccessAndResp (Just userInfo) requestId req (fmap toJSON q) res (Just (ioWaitTime, serviceTime)) headers
 
     where
       logger = scLogger serverCtx
@@ -309,7 +343,7 @@ mkSpockAction serverCtx qErrEncoder qErrModifier apiHandler = do
 
 
 v1QueryHandler
-  :: (HasVersion, MonadIO m, MonadBaseControl IO m, MetadataApiAuthorization m)
+  :: (HasVersion, MonadIO m, MonadBaseControl IO m, MetadataApiAuthorization m, Tracing.MonadTrace m)
   => RQLQuery
   -> Handler m (HttpResponse EncJSON)
 v1QueryHandler query = do
@@ -333,7 +367,7 @@ v1QueryHandler query = do
       runQuery env pgExecCtx instanceId userInfo schemaCache httpMgr sqlGenCtx (SystemDefined False) query
 
 v1Alpha1GQHandler
-  :: (HasVersion, MonadIO m, E.MonadGQLExecutionCheck m, MonadQueryLog m)
+  :: (HasVersion, MonadIO m, E.MonadGQLExecutionCheck m, MonadQueryLog m, Tracing.MonadTrace m, GH.MonadExecuteQuery m)
   => E.GraphQLQueryType -> GH.GQLBatchedReqs GH.GQLQueryText -> Handler m (HttpResponse EncJSON)
 v1Alpha1GQHandler queryType query = do
   userInfo             <- asks hcUser
@@ -358,13 +392,13 @@ v1Alpha1GQHandler queryType query = do
     GH.runGQBatched env requestId responseErrorsConfig userInfo ipAddress reqHeaders queryType query
 
 v1GQHandler
-  :: (HasVersion, MonadIO m, E.MonadGQLExecutionCheck m, MonadQueryLog m)
+  :: (HasVersion, MonadIO m, E.MonadGQLExecutionCheck m, MonadQueryLog m, Tracing.MonadTrace m, GH.MonadExecuteQuery m)
   => GH.GQLBatchedReqs GH.GQLQueryText
   -> Handler m (HttpResponse EncJSON)
 v1GQHandler = v1Alpha1GQHandler E.QueryHasura
 
 v1GQRelayHandler
-  :: (HasVersion, MonadIO m, E.MonadGQLExecutionCheck m, MonadQueryLog m)
+  :: (HasVersion, MonadIO m, E.MonadGQLExecutionCheck m, MonadQueryLog m, Tracing.MonadTrace m, GH.MonadExecuteQuery m)
   => GH.GQLBatchedReqs GH.GQLQueryText
   -> Handler m (HttpResponse EncJSON)
 v1GQRelayHandler = v1Alpha1GQHandler E.QueryRelay
@@ -375,7 +409,7 @@ gqlExplainHandler
      , MonadIO m
      )
   => GE.GQLExplain
-  -> Handler m (HttpResponse EncJSON)
+  -> Handler (Tracing.TraceT m) (HttpResponse EncJSON)
 gqlExplainHandler query = do
   onlyAdmin
   scRef     <- asks (scCacheRef . hcServerCtx)
@@ -384,8 +418,10 @@ gqlExplainHandler query = do
   sqlGenCtx <- asks (scSQLGenCtx . hcServerCtx)
   env       <- asks (scEnvironment . hcServerCtx)
 
+  -- let runTx :: ReaderT HandlerCtx (Tracing.TraceT (Tracing.NoReporter (LazyTx QErr))) a
+  --           -> ExceptT QErr (ReaderT HandlerCtx (Tracing.TraceT m)) a
   let runTx rttx = ExceptT . ReaderT $ \ctx -> do
-        runExceptT (runLazyTx pgExecCtx Q.ReadOnly (runReaderT rttx ctx))
+        runExceptT (Tracing.interpTraceT (runLazyTx pgExecCtx Q.ReadOnly) (runReaderT rttx ctx))
 
   res <- GE.explainGQLQuery env pgExecCtx runTx sc sqlGenCtx
          (restrictActionExecuter "query actions cannot be explained") query
@@ -429,6 +465,9 @@ consoleAssetsHandler logger dir path = do
 class (Monad m) => ConsoleRenderer m where
   renderConsole :: HasVersion => T.Text -> AuthMode -> Bool -> Maybe Text -> m (Either String Text)
 
+instance ConsoleRenderer m => ConsoleRenderer (Tracing.TraceT m) where
+  renderConsole a b c d = lift $ renderConsole a b c d
+
 renderHtmlTemplate :: M.Template -> Value -> Either String Text
 renderHtmlTemplate template jVal =
   bool (Left errMsg) (Right res) $ null errs
@@ -457,7 +496,7 @@ queryParsers =
       return $ f q
 
 legacyQueryHandler
-  :: (HasVersion, MonadIO m, MonadBaseControl IO m, MetadataApiAuthorization m)
+  :: (HasVersion, MonadIO m, MonadBaseControl IO m, MetadataApiAuthorization m, Tracing.MonadTrace m)
   => TableName -> T.Text -> Object
   -> Handler m (HttpResponse EncJSON)
 legacyQueryHandler tn queryType req =
@@ -469,7 +508,7 @@ legacyQueryHandler tn queryType req =
 
 -- | Default implementation of the 'MonadConfigApiHandler'
 configApiGetHandler
-  :: (HasVersion, MonadIO m, UserAuthentication m, HttpLog m)
+  :: (HasVersion, MonadIO m, UserAuthentication (Tracing.TraceT m), HttpLog m, Tracing.HasReporter m)
   => ServerCtx -> Maybe Text -> Spock.SpockCtxT () m ()
 configApiGetHandler serverCtx@ServerCtx{..} consoleAssetsDir =
   Spock.get "v1alpha1/config" $ mkSpockAction serverCtx encodeQErr id $
@@ -497,12 +536,15 @@ mkWaiApp
      , LA.Forall (LA.Pure m)
      , ConsoleRenderer m
      , HttpLog m
-     , UserAuthentication m
+     -- , UserAuthentication m
+     , UserAuthentication (Tracing.TraceT m)
      , MetadataApiAuthorization m
      , E.MonadGQLExecutionCheck m
      , MonadConfigApiHandler m
      , MonadQueryLog m
      , WS.MonadWSLog m
+     , Tracing.HasReporter m
+     , GH.MonadExecuteQuery m
      )
   => Env.Environment
   -- ^ Set of environment variables for reference in UIs
@@ -605,11 +647,14 @@ httpApp
      , MonadBaseControl IO m
      , ConsoleRenderer m
      , HttpLog m
-     , UserAuthentication m
+     -- , UserAuthentication m
+     , UserAuthentication (Tracing.TraceT m)
      , MetadataApiAuthorization m
      , E.MonadGQLExecutionCheck m
      , MonadConfigApiHandler m
      , MonadQueryLog m
+     , Tracing.HasReporter m
+     , GH.MonadExecuteQuery m
      )
   => CorsConfig
   -> ServerCtx
@@ -701,10 +746,11 @@ httpApp corsCfg serverCtx enableConsole consoleAssetsDir enableTelemetry = do
     logger = scLogger serverCtx
 
     spockAction
-      :: (FromJSON a, ToJSON a, MonadIO m, UserAuthentication m, HttpLog m)
+      :: (FromJSON a, ToJSON a, MonadIO m, UserAuthentication (Tracing.TraceT m), HttpLog m, Tracing.HasReporter m)
       => (Bool -> QErr -> Value)
-      -> (QErr -> QErr) -> APIHandler m a -> Spock.ActionT m ()
+      -> (QErr -> QErr) -> APIHandler (Tracing.TraceT m) a -> Spock.ActionT m ()
     spockAction = mkSpockAction serverCtx
+
 
     -- all graphql errors should be of type 200
     allMod200 qe     = qe { qeStatus = HTTP.status200 }

--- a/server/src-lib/Hasura/Server/Logging.hs
+++ b/server/src-lib/Hasura/Server/Logging.hs
@@ -32,6 +32,7 @@ import           Hasura.RQL.Types
 import           Hasura.Server.Compression
 import           Hasura.Server.Utils
 import           Hasura.Session
+import           Hasura.Tracing            (TraceT)
 
 data StartupLog
   = StartupLog
@@ -152,6 +153,10 @@ class (Monad m) => HttpLog m where
     -> [HTTP.Header]
     -- ^ list of request headers
     -> m ()
+
+instance HttpLog m => HttpLog (TraceT m) where
+  logHttpError a b c d e f g = lift $ logHttpError a b c d e f g
+  logHttpSuccess a b c d e f g h i j = lift $ logHttpSuccess a b c d e f g h i j
 
 -- | Log information about the HTTP request
 data HttpInfoLog

--- a/server/src-lib/Hasura/Tracing.hs
+++ b/server/src-lib/Hasura/Tracing.hs
@@ -1,0 +1,237 @@
+{-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Hasura.Tracing
+  ( MonadTrace(..)
+  , TraceT
+  , runTraceT
+  , runTraceTWith
+  , runTraceTWithReporter
+  , runTraceTInContext
+  , interpTraceT
+  , TraceContext(..)
+  , Reporter(..)
+  , noReporter
+  , HasReporter(..)
+  , TracingMetadata
+  , SuspendedRequest(..)
+  , extractHttpContext
+  , traceHttpRequest
+  ) where
+
+import           Hasura.Prelude
+import           Control.Monad.Trans.Control
+import           Control.Monad.Morph
+import           Control.Monad.Unique
+import           Data.String                 (fromString)
+
+import qualified Data.ByteString             as BS
+import qualified Data.ByteString.Lazy        as BL
+import qualified Network.HTTP.Client         as HTTP
+import qualified Network.HTTP.Types.Header   as HTTP
+import qualified System.Random               as Rand
+import qualified Web.HttpApiData             as HTTP
+
+-- | Any additional human-readable key-value pairs relevant
+-- to the execution of a block of code.
+type TracingMetadata = [(Text, Text)]
+
+newtype Reporter = Reporter 
+  { runReporter 
+      :: forall io a
+       . MonadIO io
+      => TraceContext
+      -- ^ the current trace context
+      -> Text
+      -- ^ human-readable name for this block of code
+      -> io (a, TracingMetadata)
+      -- ^ the action whose execution we want to report, returning
+      -- any metadata emitted
+      -> io a
+  }
+
+noReporter :: Reporter
+noReporter = Reporter \_ _ -> fmap fst
+
+-- | A type class for monads which support some
+-- way to report execution traces.
+class Monad m => HasReporter m where
+  -- | Get the current tracer
+  askReporter :: m Reporter
+
+  default askReporter :: m Reporter
+  askReporter = pure noReporter
+
+instance HasReporter m => HasReporter (ReaderT r m) where
+  askReporter = lift askReporter
+
+instance HasReporter m => HasReporter (ExceptT e m) where
+  askReporter = lift askReporter
+
+-- | A trace context records the current active trace,
+-- the active span within that trace, and the span's parent,
+-- unless the current span is the root.
+data TraceContext = TraceContext
+  { tcCurrentTrace  :: Word64
+  , tcCurrentSpan   :: Word64
+  , tcCurrentParent :: Maybe Word64
+  }
+
+-- | The 'TraceT' monad transformer adds the ability to keep track of
+-- the current trace context.
+newtype TraceT m a = TraceT { unTraceT :: ReaderT (TraceContext, Reporter) (WriterT TracingMetadata m) a }
+  deriving (Functor, Applicative, Monad, MonadIO, MonadUnique)
+
+instance MonadTrans TraceT where
+  lift = TraceT . lift . lift
+
+instance MFunctor TraceT where 
+  hoist f (TraceT rwma) = TraceT (hoist (hoist f) rwma)
+
+deriving instance MonadBase b m => MonadBase b (TraceT m)
+deriving instance MonadBaseControl b m => MonadBaseControl b (TraceT m)
+
+instance MonadError e m => MonadError e (TraceT m) where
+  throwError = lift . throwError
+  catchError (TraceT m) f = TraceT (catchError m (unTraceT . f))
+
+instance MonadReader r m => MonadReader r (TraceT m) where
+  ask = TraceT $ lift ask
+  local f m = TraceT $ mapReaderT (local f) (unTraceT m)
+
+-- | Run an action in the 'TraceT' monad transformer.
+-- 'runTraceT' delimits a new trace with its root span, and the arguments
+-- specify a name and metadata for that span.
+runTraceT :: (HasReporter m, MonadIO m) => Text -> TraceT m a -> m a
+runTraceT name tma = do
+  rep <- askReporter
+  runTraceTWithReporter rep name tma
+
+runTraceTWith :: MonadIO m => TraceContext -> Reporter -> Text -> TraceT m a -> m a
+runTraceTWith ctx rep name tma =
+  runReporter rep ctx name 
+    $ runWriterT 
+    $ runReaderT (unTraceT tma) (ctx, rep)
+    
+-- | Run an action in the 'TraceT' monad transformer in an
+-- existing context.
+runTraceTInContext :: (MonadIO m, HasReporter m) => TraceContext -> Text -> TraceT m a -> m a
+runTraceTInContext ctx name tma = do
+  rep <- askReporter
+  runTraceTWith ctx rep name tma
+  
+-- | Run an action in the 'TraceT' monad transformer in an
+-- existing context.
+runTraceTWithReporter :: MonadIO m => Reporter -> Text -> TraceT m a -> m a
+runTraceTWithReporter rep name tma = do
+  ctx <- TraceContext
+           <$> liftIO Rand.randomIO
+           <*> liftIO Rand.randomIO
+           <*> pure Nothing
+  runTraceTWith ctx rep name tma
+
+-- | Monads which support tracing. 'TraceT' is the standard example.
+class Monad m => MonadTrace m where
+  -- | Trace the execution of a block of code, attaching a human-readable name.
+  trace :: Text -> m a -> m a
+
+  -- | Ask for the current tracing context, so that we can provide it to any
+  -- downstream services, e.g. in HTTP headers.
+  currentContext :: m TraceContext
+
+  -- | Ask for the current tracing reporter
+  currentReporter :: m Reporter
+
+  -- | Log some metadata to be attached to the current span
+  attachMetadata :: TracingMetadata -> m ()
+
+-- | Reinterpret a 'TraceT' action in another 'MonadTrace'.
+-- This can be useful when you need to reorganize a monad transformer stack.
+interpTraceT 
+  :: MonadTrace n
+  => (m (a, TracingMetadata) -> n (b, TracingMetadata))
+  -> TraceT m a
+  -> n b
+interpTraceT f (TraceT rwma) = do
+  ctx <- currentContext
+  rep <- currentReporter
+  (b, meta) <- f (runWriterT (runReaderT rwma (ctx, rep)))
+  attachMetadata meta
+  pure b
+
+-- | If the underlying monad can report trace data, then 'TraceT' will
+-- collect it and hand it off to that reporter.
+instance MonadIO m => MonadTrace (TraceT m) where
+  trace name ma = TraceT . ReaderT $ \(ctx, rep) -> do
+    spanId <- liftIO (Rand.randomIO :: IO Word64)
+    let subCtx = ctx { tcCurrentSpan = spanId
+                     , tcCurrentParent = Just (tcCurrentSpan ctx)
+                     }
+    lift . runReporter rep subCtx name . runWriterT $ runReaderT (unTraceT ma) (subCtx, rep)
+
+  currentContext = TraceT (asks fst)
+  
+  currentReporter = TraceT (asks snd)
+
+  attachMetadata = TraceT . tell
+
+instance MonadTrace m => MonadTrace (ReaderT r m) where
+  trace = mapReaderT . trace
+  currentContext = lift currentContext
+  currentReporter = lift currentReporter
+  attachMetadata = lift . attachMetadata
+
+instance MonadTrace m => MonadTrace (StateT e m) where
+  trace = mapStateT . trace
+  currentContext = lift currentContext
+  currentReporter = lift currentReporter
+  attachMetadata = lift . attachMetadata
+
+instance MonadTrace m => MonadTrace (ExceptT e m) where
+  trace = mapExceptT . trace
+  currentContext = lift currentContext
+  currentReporter = lift currentReporter
+  attachMetadata = lift . attachMetadata
+
+-- | A HTTP request, which can be modified before execution.
+data SuspendedRequest m a = SuspendedRequest HTTP.Request (HTTP.Request -> m a)
+
+-- | Extract the trace and parent span headers from a HTTP request
+-- and create a new 'TraceContext'. The new context will contain
+-- a fresh span ID, and the provided span ID will be assigned as
+-- the immediate parent span.
+extractHttpContext :: [HTTP.Header] -> IO (Maybe TraceContext)
+extractHttpContext hdrs = do
+  freshSpanId <- liftIO Rand.randomIO
+  pure $ TraceContext
+    <$> (HTTP.parseHeaderMaybe =<< lookup "X-Hasura-TraceId" hdrs)
+    <*> pure freshSpanId
+    <*> pure (HTTP.parseHeaderMaybe =<< lookup "X-Hasura-SpanId" hdrs)
+
+traceHttpRequest
+  :: MonadTrace m
+  => Text
+  -- ^ human-readable name for this block of code
+  -> m (SuspendedRequest m a)
+  -- ^ an action which yields the request about to be executed and suspends
+  -- before actually executing it
+  -> m a
+traceHttpRequest name f = trace name do
+  SuspendedRequest req next <- f
+  let reqBytes = case HTTP.requestBody req of
+        HTTP.RequestBodyBS bs -> Just (fromIntegral (BS.length bs))
+        HTTP.RequestBodyLBS bs -> Just (BL.length bs)
+        HTTP.RequestBodyBuilder len _ -> Just len
+        HTTP.RequestBodyStream len _ -> Just len
+        _ -> Nothing
+  for_ reqBytes \b ->
+    attachMetadata [("request_body_bytes", fromString (show b))]
+  TraceContext{..} <- currentContext
+  let tracingHeaders =
+        [ ("X-Hasura-TraceId", fromString (show tcCurrentTrace))
+        , ("X-Hasura-SpanId", fromString (show tcCurrentSpan))
+        ]
+      req' = req { HTTP.requestHeaders =
+                     tracingHeaders <> HTTP.requestHeaders req
+                 }
+  next req'

--- a/server/src-test/Hasura/Server/AuthSpec.hs
+++ b/server/src-test/Hasura/Server/AuthSpec.hs
@@ -1,19 +1,23 @@
+{-# LANGUAGE UndecidableInstances #-}
+
 module Hasura.Server.AuthSpec (spec) where
 
+import           Hasura.Logging
 import           Hasura.Prelude
 import           Hasura.Server.Version
-import           Hasura.Logging
 
-import qualified Crypto.JOSE.JWK         as Jose
-import qualified Data.Aeson              as J
-import           Data.Aeson              ((.=))
-import qualified Network.HTTP.Types      as N
+import           Control.Monad.Trans.Control
+import qualified Crypto.JOSE.JWK             as Jose
+import           Data.Aeson                  ((.=))
+import qualified Data.Aeson                  as J
+import qualified Network.HTTP.Types          as N
 
 import           Hasura.RQL.Types
-import           Hasura.Server.Auth      hiding (getUserInfoWithExpTime, processJwt)
+import           Hasura.Server.Auth          hiding (getUserInfoWithExpTime, processJwt)
+import           Hasura.Server.Auth.JWT      hiding (processJwt)
 import           Hasura.Server.Utils
 import           Hasura.Session
-import           Hasura.Server.Auth.JWT  hiding (processJwt)
+import qualified Hasura.Tracing              as Tracing
 import           Test.Hspec
 
 spec :: Spec
@@ -26,13 +30,13 @@ spec = do
 getUserInfoWithExpTimeTests :: Spec
 getUserInfoWithExpTimeTests = describe "getUserInfo" $ do
   ---- FUNCTION UNDER TEST:
-  let getUserInfoWithExpTime 
+  let getUserInfoWithExpTime
         :: J.Object
         -- ^ For JWT, inject the raw claims object as though returned from 'processAuthZHeader'
         -- acting on an 'Authorization' header from the request
         -> [N.Header] -> AuthMode -> IO (Either Code RoleName)
-      getUserInfoWithExpTime claims rawHeaders = 
-        runExceptT 
+      getUserInfoWithExpTime claims rawHeaders =
+        runExceptT
         . withExceptT qeCode -- just look at Code for purposes of tests
         . fmap _uiRole -- just look at RoleName for purposes of tests
         . fmap fst -- disregard Nothing expiration
@@ -43,15 +47,15 @@ getUserInfoWithExpTimeTests = describe "getUserInfo" $ do
             (, Nothing) <$> _UserInfo "hook"
             where
               -- we don't care about details here; we'll just check role name in tests:
-              _UserInfo nm = 
+              _UserInfo nm =
                 mkUserInfo (URBFromSessionVariablesFallback $ mkRoleNameE nm)
-                           UAdminSecretNotSent 
+                           UAdminSecretNotSent
                            (mkSessionVariables mempty)
-          processJwt = processJwt_ $ 
+          processJwt = processJwt_ $
             -- processAuthZHeader:
             \_jwtCtx _authzHeader -> return (claims , Nothing)
 
-  let setupAuthMode'E a b c d = 
+  let setupAuthMode'E a b c d =
         either (const $ error "fixme") id <$> setupAuthMode' a b c d
 
   let ourUnauthRole = mkRoleNameE "an0nymous"
@@ -105,7 +109,7 @@ getUserInfoWithExpTimeTests = describe "getUserInfo" $ do
           `shouldReturn` Left AccessDenied
 
     describe "unauth role set" $ do
-      mode <- runIO $ 
+      mode <- runIO $
         setupAuthMode'E (Just $ hashAdminSecret "secret") Nothing Nothing (Just ourUnauthRole)
       it "accepts when admin secret matches" $ do
         getUserInfoWithExpTime mempty [(adminSecretHeader, "secret")] mode
@@ -143,7 +147,7 @@ getUserInfoWithExpTimeTests = describe "getUserInfo" $ do
 
   -- Unauthorized role is not supported for webhook
   describe "webhook" $ do
-    mode <- runIO $ 
+    mode <- runIO $
       setupAuthMode'E (Just $ hashAdminSecret "secret") (Just fakeAuthHook) Nothing Nothing
 
     it "accepts when admin secret matches" $ do
@@ -187,11 +191,11 @@ getUserInfoWithExpTimeTests = describe "getUserInfo" $ do
   -- helper for generating mocked up verified JWT token claims, as though returned by 'processAuthZHeader':
   let unObject l = case J.object l of
         J.Object o -> o
-        _ -> error "impossible"
+        _          -> error "impossible"
 
   describe "JWT" $ do
     describe "unauth role NOT set" $ do
-      mode <- runIO $ 
+      mode <- runIO $
         setupAuthMode'E (Just $ hashAdminSecret "secret") Nothing (Just fakeJWTConfig) Nothing
 
       it "accepts when admin secret matches" $ do
@@ -223,8 +227,8 @@ getUserInfoWithExpTimeTests = describe "getUserInfo" $ do
           `shouldReturn` Left InvalidHeaders
 
     describe "unauth role set" $ do
-      mode <- runIO $ 
-        setupAuthMode'E (Just $ hashAdminSecret "secret") Nothing 
+      mode <- runIO $
+        setupAuthMode'E (Just $ hashAdminSecret "secret") Nothing
                         (Just fakeJWTConfig) (Just ourUnauthRole)
 
       it "accepts when admin secret matches" $ do
@@ -258,13 +262,13 @@ getUserInfoWithExpTimeTests = describe "getUserInfo" $ do
           `shouldReturn` Right ourUnauthRole
 
     describe "when Authorization header sent, and no admin secret" $ do
-      modeA <- runIO $ setupAuthMode'E (Just $ hashAdminSecret "secret") Nothing 
+      modeA <- runIO $ setupAuthMode'E (Just $ hashAdminSecret "secret") Nothing
                                        (Just fakeJWTConfig) (Just ourUnauthRole)
-      modeB <- runIO $ setupAuthMode'E (Just $ hashAdminSecret "secret") Nothing 
+      modeB <- runIO $ setupAuthMode'E (Just $ hashAdminSecret "secret") Nothing
                                        (Just fakeJWTConfig) Nothing
 
       -- Here the unauth role does not come into play at all, so map same tests over both modes:
-      forM_ [(modeA, "with unauth role set"), (modeB, "with unauth role NOT set")] $ 
+      forM_ [(modeA, "with unauth role set"), (modeB, "with unauth role NOT set")] $
         \(mode, modeMsg) -> describe modeMsg $ do
 
           it "authorizes successfully with JWT when requested role allowed" $ do
@@ -378,7 +382,7 @@ setupAuthModeTests = describe "setupAuthMode" $ do
       `shouldReturn` Left ()
 
 fakeJWTConfig :: JWTConfig
-fakeJWTConfig = 
+fakeJWTConfig =
   let jcKeyOrUrl = Left (Jose.fromOctets [])
       jcClaimNs = ClaimNs ""
       jcAudience = Nothing
@@ -392,17 +396,23 @@ fakeAuthHook = AuthHookG "http://fake" AHTGet
 mkRoleNameE :: Text -> RoleName
 mkRoleNameE = fromMaybe (error "fixme") . mkRoleName
 
-setupAuthMode' 
+newtype NoReporter a = NoReporter { runNoReporter :: IO a }
+  deriving newtype (Functor, Applicative, Monad, MonadIO, MonadBase IO, MonadBaseControl IO)
+
+instance Tracing.HasReporter NoReporter
+
+setupAuthMode'
   :: Maybe AdminSecretHash
   -> Maybe AuthHook
   -> Maybe JWTConfig
   -> Maybe RoleName
   -> IO (Either () AuthMode)
-setupAuthMode'  mAdminSecretHash mWebHook mJwtSecret mUnAuthRole = 
-  withVersion (VersionDev "fake") $ 
+setupAuthMode'  mAdminSecretHash mWebHook mJwtSecret mUnAuthRole =
+  withVersion (VersionDev "fake") $
   -- just throw away the error message for ease of testing:
-  fmap (either (const $ Left ()) Right) $
-  runExceptT $
-  setupAuthMode mAdminSecretHash mWebHook mJwtSecret mUnAuthRole
-    -- NOTE: this won't do any http or launch threads if we don't specify JWT URL:
-    (error "H.Manager") (Logger $ void . return)
+  fmap (either (const $ Left ()) Right)
+    $ runNoReporter
+    $ runExceptT 
+    $ setupAuthMode mAdminSecretHash mWebHook mJwtSecret mUnAuthRole
+      -- NOTE: this won't do any http or launch threads if we don't specify JWT URL:
+      (error "H.Manager") (Logger $ void . return)


### PR DESCRIPTION
### Description

A combination of two changes:

* Adding `MonadExecuteQuery` to support switching out the code we use to actually execute compiled SQL code
* Adding `MonadTrace` and `HasReporter` to support tracing with a flexible tracing backend implementation

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components

- [x] Server

### Related Issues

* TODO

### Solution and Design

Tracing interfaces and implementation are provided for adding the ability to perform fine-grained tracing throughout actions as they are performed by the application. Implementation can also be deferred so that library-use of GraphQL-Engine can implement different tracing mechanisms as required.

* The addition of two new classes in `Hasura.Tracing` - `HasReporter` and `MonadTrace` provide an interface for tracing actions
* An implementation via `TraceT` to allow for tracing to be performed

Caching foundations have been implemented to allow for data cahcing of queries and actions.

### Steps to test and verify

* Existing test-suites and integration testing should be performed to ensure that this has not introduced any regressions as current behaviour of the application should remain the same
* No impact on the user-interfaces in graphql-engine - Downstream codebases should be tested to verify that custom tracing implementations are executed as expected.

#### Catalog upgrade

Does this PR change Hasura Catalog version?

- [x] No
#### Metadata

Does this PR add a new Metadata feature?

- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No