### PR TITLE
configure header size limit for warp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 (Add entries here in the order of: server, console, cli, docs, others)
 
+- server: configure total header size limit via `HASURA_GRAPHQL_MAX_TOTAL_HEADER_LENGTH` or `--max-total-header-length` (default: 100KB)
 
 ## `v1.3.0`
 

--- a/server/src-lib/Hasura/App.hs
+++ b/server/src-lib/Hasura/App.hs
@@ -419,6 +419,7 @@ runHGEServer env ServeOptions{..} InitCtx{..} pgExecCtx initTime shutdownApp pos
                      . Warp.setHost soHost
                      . Warp.setGracefulShutdownTimeout (Just 30) -- 30s graceful shutdown
                      . Warp.setInstallShutdownHandler (shutdownHandler _icLoggers immortalThreads stopWsServer lockedEventsCtx _icPgPool)
+                     . Warp.setMaxTotalHeaderLength (1024 * 1024) -- 1MB header size limit (warp default: 50KB)
                      $ Warp.defaultSettings
   liftIO $ Warp.runSettings warpSettings app
 

--- a/server/src-lib/Hasura/App.hs
+++ b/server/src-lib/Hasura/App.hs
@@ -419,7 +419,7 @@ runHGEServer env ServeOptions{..} InitCtx{..} pgExecCtx initTime shutdownApp pos
                      . Warp.setHost soHost
                      . Warp.setGracefulShutdownTimeout (Just 30) -- 30s graceful shutdown
                      . Warp.setInstallShutdownHandler (shutdownHandler _icLoggers immortalThreads stopWsServer lockedEventsCtx _icPgPool)
-                     . Warp.setMaxTotalHeaderLength (1024 * 1024) -- 1MB header size limit (warp default: 50KB)
+                     . Warp.setMaxTotalHeaderLength (fromMaybe (100 * 1024) soMaxTotalHeaderLength) -- default total header length 100KB
                      $ Warp.defaultSettings
   liftIO $ Warp.runSettings warpSettings app
 

--- a/server/src-lib/Hasura/Server/Init/Config.hs
+++ b/server/src-lib/Hasura/Server/Init/Config.hs
@@ -38,32 +38,33 @@ type RawAuthHook = AuthHookG (Maybe T.Text) (Maybe AuthHookType)
 
 data RawServeOptions impl
   = RawServeOptions
-  { rsoPort                :: !(Maybe Int)
-  , rsoHost                :: !(Maybe HostPreference)
-  , rsoConnParams          :: !RawConnParams
-  , rsoTxIso               :: !(Maybe Q.TxIsolation)
-  , rsoAdminSecret         :: !(Maybe AdminSecretHash)
-  , rsoAuthHook            :: !RawAuthHook
-  , rsoJwtSecret           :: !(Maybe JWTConfig)
-  , rsoUnAuthRole          :: !(Maybe RoleName)
-  , rsoCorsConfig          :: !(Maybe CorsConfig)
-  , rsoEnableConsole       :: !Bool
-  , rsoConsoleAssetsDir    :: !(Maybe Text)
-  , rsoEnableTelemetry     :: !(Maybe Bool)
-  , rsoWsReadCookie        :: !Bool
-  , rsoStringifyNum        :: !Bool
-  , rsoEnabledAPIs         :: !(Maybe [API])
-  , rsoMxRefetchInt        :: !(Maybe LQ.RefetchInterval)
-  , rsoMxBatchSize         :: !(Maybe LQ.BatchSize)
-  , rsoEnableAllowlist     :: !Bool
-  , rsoEnabledLogTypes     :: !(Maybe [L.EngineLogType impl])
-  , rsoLogLevel            :: !(Maybe L.LogLevel)
-  , rsoPlanCacheSize       :: !(Maybe Cache.CacheSize)
-  , rsoDevMode             :: !Bool
-  , rsoAdminInternalErrors :: !(Maybe Bool)
-  , rsoEventsHttpPoolSize  :: !(Maybe Int)
-  , rsoEventsFetchInterval :: !(Maybe Milliseconds)
-  , rsoLogHeadersFromEnv   :: !Bool
+  { rsoPort                 :: !(Maybe Int)
+  , rsoHost                 :: !(Maybe HostPreference)
+  , rsoConnParams           :: !RawConnParams
+  , rsoTxIso                :: !(Maybe Q.TxIsolation)
+  , rsoAdminSecret          :: !(Maybe AdminSecretHash)
+  , rsoAuthHook             :: !RawAuthHook
+  , rsoJwtSecret            :: !(Maybe JWTConfig)
+  , rsoUnAuthRole           :: !(Maybe RoleName)
+  , rsoCorsConfig           :: !(Maybe CorsConfig)
+  , rsoEnableConsole        :: !Bool
+  , rsoConsoleAssetsDir     :: !(Maybe Text)
+  , rsoEnableTelemetry      :: !(Maybe Bool)
+  , rsoWsReadCookie         :: !Bool
+  , rsoStringifyNum         :: !Bool
+  , rsoEnabledAPIs          :: !(Maybe [API])
+  , rsoMxRefetchInt         :: !(Maybe LQ.RefetchInterval)
+  , rsoMxBatchSize          :: !(Maybe LQ.BatchSize)
+  , rsoEnableAllowlist      :: !Bool
+  , rsoEnabledLogTypes      :: !(Maybe [L.EngineLogType impl])
+  , rsoLogLevel             :: !(Maybe L.LogLevel)
+  , rsoPlanCacheSize        :: !(Maybe Cache.CacheSize)
+  , rsoDevMode              :: !Bool
+  , rsoAdminInternalErrors  :: !(Maybe Bool)
+  , rsoEventsHttpPoolSize   :: !(Maybe Int)
+  , rsoEventsFetchInterval  :: !(Maybe Milliseconds)
+  , rsoLogHeadersFromEnv    :: !Bool
+  , rsoMaxTotalHeaderLength :: !(Maybe Int)
   }
 
 -- | @'ResponseInternalErrorsConfig' represents the encoding of the internal
@@ -106,6 +107,7 @@ data ServeOptions impl
   , soEventsHttpPoolSize           :: !(Maybe Int)
   , soEventsFetchInterval          :: !(Maybe Milliseconds)
   , soLogHeadersFromEnv            :: !Bool
+  , soMaxTotalHeaderLength         :: !(Maybe Int)
   }
 
 data DowngradeOptions


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description

Warp's default total header limit size for HTTP 1.x is 50KB which turns out to be little low (reported in Intercom). See: https://hackage.haskell.org/package/warp-3.3.13/docs/src/Network.Wai.Handler.Warp.Settings.html#defaultSettings

This increases the header limit size to 100KB and makes it configurable.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

`curl -v -H @temp.log localhost:8080/v1/version`

where temp.log is a header file greater than 50KB. In prior versions, this will throw a bad request.

