### PR TITLE
cli: APIs for migrations on console

### DIFF
--- a/cli/commands/migrate_apply.go
+++ b/cli/commands/migrate_apply.go
@@ -118,7 +118,7 @@ type MigrateApplyOptions struct {
 }
 
 func (o *MigrateApplyOptions) Run() error {
-	migrationType, step, err := getMigrationTypeAndStep(o.UpMigration, o.DownMigration, o.VersionMigration, o.MigrationType, o.GotoVersion, o.SkipExecution)
+	migrationType, step, err := GetMigrationTypeAndStep(o.UpMigration, o.DownMigration, o.VersionMigration, o.MigrationType, o.GotoVersion, o.SkipExecution)
 	if err != nil {
 		return errors.Wrap(err, "error validating flags")
 	}
@@ -133,9 +133,9 @@ func (o *MigrateApplyOptions) Run() error {
 	return ExecuteMigration(migrationType, migrateDrv, step)
 }
 
-// Only one flag out of up, down and version can be set at a time. This function
-// checks whether that is the case and returns an error is not
-func getMigrationTypeAndStep(upMigration, downMigration, versionMigration, migrationType, gotoVersion string, skipExecution bool) (string, int64, error) {
+// GetMigrationTypeAndStep ensures that only one flag out of up, down and version
+// can be set at a time.
+func GetMigrationTypeAndStep(upMigration, downMigration, versionMigration, migrationType, gotoVersion string, skipExecution bool) (string, int64, error) {
 	var flagCount = 0
 	var stepString = "all"
 	var migrationName = "up"

--- a/cli/commands/migrate_apply.go
+++ b/cli/commands/migrate_apply.go
@@ -118,7 +118,7 @@ type MigrateApplyOptions struct {
 }
 
 func (o *MigrateApplyOptions) Run() error {
-	migrationType, step, err := GetMigrationTypeAndStep(o.UpMigration, o.DownMigration, o.VersionMigration, o.MigrationType, o.GotoVersion, o.SkipExecution)
+	migrationType, step, err := getMigrationTypeAndStep(o.UpMigration, o.DownMigration, o.VersionMigration, o.MigrationType, o.GotoVersion, o.SkipExecution)
 	if err != nil {
 		return errors.Wrap(err, "error validating flags")
 	}
@@ -133,9 +133,9 @@ func (o *MigrateApplyOptions) Run() error {
 	return ExecuteMigration(migrationType, migrateDrv, step)
 }
 
-// GetMigrationTypeAndStep ensures that only one flag out of up, down and version
+// getMigrationTypeAndStep ensures that only one flag out of up, down and version
 // can be set at a time.
-func GetMigrationTypeAndStep(upMigration, downMigration, versionMigration, migrationType, gotoVersion string, skipExecution bool) (string, int64, error) {
+func getMigrationTypeAndStep(upMigration, downMigration, versionMigration, migrationType, gotoVersion string, skipExecution bool) (string, int64, error) {
 	var flagCount = 0
 	var stepString = "all"
 	var migrationName = "up"

--- a/cli/migrate/api/apply.go
+++ b/cli/migrate/api/apply.go
@@ -124,9 +124,9 @@ func ApplyMigrationAPI(c *gin.Context) {
 			return
 		}
 
-		// there is some metadata part within the NewMigrate method, I'd have to perform those actions here
-
 		t.SkipExecution = skipExecution
+
+		// there is some metadata part within the NewMigrate method, I'd have to perform those actions here
 
 		err = executeMigration(migrateType, t, step)
 

--- a/cli/migrate/api/apply.go
+++ b/cli/migrate/api/apply.go
@@ -1,0 +1,25 @@
+package api
+
+import "github.com/gin-gonic/gin"
+
+type ApplyMigrationRequest struct {
+	UpMigration    string `json:"up"`
+	DownMigration  string `json:"down"`
+	SkipExecution  bool   `json:"skip_execution"`
+	MigrateVersion string `json:"version"`
+	MigrateType    string `json:"type"`
+	GotoVersion    string `json:"goto"`
+}
+
+func ApplyMigrationAPI(c *gin.Context) {
+	// migratePtr, ok := c.Get("migrate")
+	// if !ok {
+	// 	return
+	// }
+	// // Get File url
+	// sourcePtr, ok := c.Get("filedir")
+	// if !ok {
+	// 	return
+	// }
+
+}

--- a/cli/migrate/api/apply.go
+++ b/cli/migrate/api/apply.go
@@ -1,7 +1,89 @@
 package api
 
-import "github.com/gin-gonic/gin"
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
 
+	"github.com/gin-gonic/gin"
+	"github.com/hasura/graphql-engine/cli/migrate"
+	mig "github.com/hasura/graphql-engine/cli/migrate/cmd"
+)
+
+func getMigrationTypeAndStep(upMigration, downMigration, versionMigration, migrationType, gotoVersion string, skipExecution bool) (string, int64, error) {
+	var flagCount = 0
+	var stepString = "all"
+	var migrationName = "up"
+	if upMigration != "" {
+		stepString = upMigration
+		flagCount++
+	}
+	if downMigration != "" {
+		migrationName = "down"
+		stepString = downMigration
+		flagCount++
+	}
+	if versionMigration != "" {
+		migrationName = "version"
+		stepString = versionMigration
+		if migrationType == "down" {
+			stepString = "-" + stepString
+		}
+		flagCount++
+	}
+	if gotoVersion != "" {
+		migrationName = "gotoVersion"
+		stepString = gotoVersion
+		flagCount++
+	}
+
+	if flagCount > 1 {
+		return "", 0, errors.New("only one migration type can be applied at a time (--up, --down or --goto)")
+	}
+
+	if migrationName != "version" && skipExecution {
+		return "", 0, errors.New("--skip-execution flag can be set only with --version flag")
+	}
+
+	if stepString == "all" && migrationName != "version" {
+		return migrationName, -1, nil
+	}
+
+	step, err := strconv.ParseInt(stepString, 10, 64)
+	if err != nil {
+		return "", 0, errors.New("not a valid input for steps/version")
+	}
+	return migrationName, step, nil
+}
+
+func executeMigration(cmd string, t *migrate.Migrate, stepOrVersion int64) error {
+	var err error
+
+	switch cmd {
+	case "up":
+		err = mig.UpCmd(t, stepOrVersion)
+	case "down":
+		err = mig.DownCmd(t, stepOrVersion)
+	case "gotoVersion":
+		err = mig.GotoVersionCmd(t, stepOrVersion)
+	case "version":
+		var direction string
+		if stepOrVersion >= 0 {
+			direction = "up"
+		} else {
+			direction = "down"
+			stepOrVersion = -(stepOrVersion)
+		}
+		err = mig.GotoCmd(t, uint64(stepOrVersion), direction)
+	default:
+		err = fmt.Errorf("Invalid command")
+	}
+
+	return err
+}
+
+// ApplyMigrationRequest is the request type for the apply API endpoint
 type ApplyMigrationRequest struct {
 	UpMigration    string `json:"up"`
 	DownMigration  string `json:"down"`
@@ -11,15 +93,50 @@ type ApplyMigrationRequest struct {
 	GotoVersion    string `json:"goto"`
 }
 
+// ApplyMigrationAPI is a wrapper to apply migrations using the API
 func ApplyMigrationAPI(c *gin.Context) {
-	// migratePtr, ok := c.Get("migrate")
-	// if !ok {
-	// 	return
-	// }
-	// // Get File url
-	// sourcePtr, ok := c.Get("filedir")
-	// if !ok {
-	// 	return
-	// }
+	migratePtr, ok := c.Get("migrate")
+	if !ok {
+		return
+	}
 
+	t := migratePtr.(*migrate.Migrate)
+
+	if c.Request.Method == http.MethodGet {
+		var applyMigrationReq ApplyMigrationRequest
+
+		if c.Bind(&applyMigrationReq) != nil {
+			c.JSON(http.StatusBadRequest, &Response{Code: "bad_request", Message: "incorrect apply request"})
+			return
+		}
+
+		upMigration := applyMigrationReq.UpMigration
+		downMigration := applyMigrationReq.DownMigration
+		migrationVersion := applyMigrationReq.MigrateVersion
+		migrationType := applyMigrationReq.MigrateType
+		gotoVersion := applyMigrationReq.GotoVersion
+		skipExecution := applyMigrationReq.SkipExecution
+
+		migrateType, step, err := getMigrationTypeAndStep(upMigration, downMigration, migrationVersion, migrationType, gotoVersion, skipExecution)
+
+		if err != nil {
+			c.JSON(http.StatusBadRequest, &Response{Code: "bad_request", Message: err.Error()})
+			return
+		}
+
+		// there is some metadata part within the NewMigrate method, I'd have to perform those actions here
+
+		t.SkipExecution = skipExecution
+
+		err = executeMigration(migrateType, t, step)
+
+		if err != nil {
+			c.JSON(http.StatusBadRequest, &Response{Code: "bad_request", Message: "incorrect apply flags used"})
+			return
+		}
+
+		c.JSON(http.StatusOK, &Response{Message: "migrations have been applied"})
+		return
+	}
+	c.JSON(http.StatusMethodNotAllowed, &gin.H{"message": "Method not allowed"})
 }

--- a/cli/migrate/api/console.go
+++ b/cli/migrate/api/console.go
@@ -1,0 +1,175 @@
+package api
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/hasura/graphql-engine/cli/migrate"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	up   = "up"
+	down = "down"
+)
+
+type MigrationData struct {
+	FileContent      string `json:"content"`
+	FileType         string `json:"type"`
+	MigrationVersion int    `json:"version"`
+}
+
+type ConsoleAPIResponse struct {
+	Version           string                  `json:"version"`
+	UpMigrationData   MigrationData           `json:"up"`
+	DownMigrationData MigrationData           `json:"down"`
+	MigrationStatus   migrate.MigrationStatus `json:"status"`
+}
+
+func convertToUInt64(param string) uint64 {
+	num, err := strconv.ParseUint(param, 10, 64)
+	if err != nil {
+		return 1
+	}
+
+	return num
+}
+
+func getFileType(ext string) string {
+	if ext == ".yml" || ext == ".yaml" {
+		return "yaml"
+	}
+	if ext == ".sql" {
+		return "sql"
+	}
+
+	// TODO: this should also be an error probably
+	return ""
+}
+
+func isFilePresent(path string) bool {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false
+	}
+
+	return !info.IsDir()
+}
+
+func getMigrationFileContents(path string) (string, error) {
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
+func getValidFilePath(path string, migrationType string, extensions []string) (string, string) {
+	for _, ext := range extensions {
+		fullPath := path + migrationType + ext
+		exists := isFilePresent(fullPath)
+		if exists {
+			return fullPath, ext
+		}
+	}
+	// TODO: this should probably be an error
+	return "", ""
+}
+
+func getMigrationInfo(path string, migrationName string, version int) (MigrationData, MigrationData, error) {
+	// returns the type of file yml, yaml or sql
+	// the respective contents of the file
+	// this function will only look for up.* and down.* for now
+
+	fullPath := path + "/" + migrationName + "/"
+	validExtensions := []string{".yaml", ".sql", ".yml"}
+
+	upSource, upExt := getValidFilePath(fullPath, up, validExtensions)
+	downSource, downExt := getValidFilePath(fullPath, down, validExtensions)
+
+	upContent, err := getMigrationFileContents(upSource)
+	if err != nil {
+		return MigrationData{}, MigrationData{}, err
+	}
+
+	downContent, err := getMigrationFileContents(downSource)
+	if err != nil {
+		return MigrationData{}, MigrationData{}, err
+	}
+
+	return MigrationData{
+			FileContent:      upContent,
+			FileType:         getFileType(upExt),
+			MigrationVersion: version,
+		}, MigrationData{
+			FileContent:      downContent,
+			FileType:         getFileType(downExt),
+			MigrationVersion: version,
+		}, nil
+}
+
+func ConsoleAPI(c *gin.Context) {
+	migrationID := c.Param("migrationID")
+
+	migratePtr, ok := c.Get("migrate")
+	if !ok {
+		return
+	}
+	// Get File url
+	sourcePtr, ok := c.Get("filedir")
+	if !ok {
+		return
+	}
+
+	// Get Logger
+	loggerPtr, ok := c.Get("logger")
+	if !ok {
+		return
+	}
+
+	// Get version
+	version := c.GetInt("version")
+
+	// Convert to url.URL
+	t := migratePtr.(*migrate.Migrate)
+	sourceURL := sourcePtr.(*url.URL)
+	logger := loggerPtr.(*logrus.Logger)
+
+	if c.Request.Method == http.MethodGet {
+		err := t.ReScan()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, &Response{Code: "internal_error", Message: err.Error()})
+			return
+		}
+
+		status, err := t.GetStatus()
+
+		migrStatus, ok := status.Read(convertToUInt64(migrationID))
+		if !ok {
+			// TODO: have to change this
+			c.JSON(http.StatusInternalServerError, &Response{Code: "internal_error", Message: err.Error()})
+			return
+		}
+		// logger.Info("Here's some info", migrStatus.Name, "\n")
+		migrationName := migrationID + "_" + migrStatus.Name
+		upMigrationData, downMigrationData, err := getMigrationInfo(*&sourceURL.Path, migrationName, version)
+
+		if err != nil {
+			logger.Error("There has been an error: ", err.Error())
+		}
+
+		c.JSON(http.StatusOK, &ConsoleAPIResponse{
+			Version:           migrationID,
+			UpMigrationData:   upMigrationData,
+			DownMigrationData: downMigrationData,
+			MigrationStatus:   *migrStatus,
+		})
+		return
+	}
+
+	c.JSON(http.StatusMethodNotAllowed, &gin.H{"message": "Method not allowed"})
+}

--- a/cli/migrate/api/console.go
+++ b/cli/migrate/api/console.go
@@ -178,6 +178,7 @@ func ConsoleAPI(c *gin.Context) {
 
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, &Response{Code: "internal_error", Message: err.Error()})
+			return
 		}
 
 		c.JSON(http.StatusOK, &MigrationDataResponse{

--- a/cli/migrate/api/console.go
+++ b/cli/migrate/api/console.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/hasura/graphql-engine/cli/migrate"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -141,10 +140,10 @@ func ConsoleAPI(c *gin.Context) {
 	}
 
 	// Get Logger
-	loggerPtr, ok := c.Get("logger")
-	if !ok {
-		return
-	}
+	// loggerPtr, ok := c.Get("logger")
+	// if !ok {
+	// 	return
+	// }
 
 	// Get version
 	version := c.GetInt("version")
@@ -152,7 +151,6 @@ func ConsoleAPI(c *gin.Context) {
 	// Convert to url.URL
 	t := migratePtr.(*migrate.Migrate)
 	sourceURL := sourcePtr.(*url.URL)
-	logger := loggerPtr.(*logrus.Logger)
 
 	migrationVersion := c.Param("migrationVersion")
 
@@ -179,8 +177,7 @@ func ConsoleAPI(c *gin.Context) {
 		upMigrationData, downMigrationData, err := getMigrationInfo(*&sourceURL.Path, migrationDirName, version)
 
 		if err != nil {
-			// TODO: send the errorred response too?
-			logger.Error("There has been an error: ", err.Error())
+			c.JSON(http.StatusInternalServerError, &Response{Code: "internal_error", Message: err.Error()})
 		}
 
 		c.JSON(http.StatusOK, &MigrationDataResponse{

--- a/cli/pkg/console/apiserver.go
+++ b/cli/pkg/console/apiserver.go
@@ -61,6 +61,10 @@ func (r *APIServer) setRoutes(migrationDir string, logger *logrus.Logger) {
 		// Migrate api endpoints and middleware
 		migrateAPIs := apis.Group("/migrate")
 		{
+			applyAPIs := migrateAPIs.Group("/apply")
+			{
+				applyAPIs.Any("", api.ApplyMigrationAPI)
+			}
 			consoleAPIs := migrateAPIs.Group("/console")
 			{
 				consoleAPIs.Any("/:migrationVersion", api.ConsoleAPI)

--- a/cli/pkg/console/apiserver.go
+++ b/cli/pkg/console/apiserver.go
@@ -63,7 +63,7 @@ func (r *APIServer) setRoutes(migrationDir string, logger *logrus.Logger) {
 		{
 			consoleAPIs := migrateAPIs.Group("/console")
 			{
-				consoleAPIs.GET("/:migrationID", api.ConsoleAPI)
+				consoleAPIs.Any("/:migrationVersion", api.ConsoleAPI)
 			}
 			settingsAPIs := migrateAPIs.Group("/settings")
 			{

--- a/cli/pkg/console/apiserver.go
+++ b/cli/pkg/console/apiserver.go
@@ -61,6 +61,10 @@ func (r *APIServer) setRoutes(migrationDir string, logger *logrus.Logger) {
 		// Migrate api endpoints and middleware
 		migrateAPIs := apis.Group("/migrate")
 		{
+			consoleAPIs := migrateAPIs.Group("/console")
+			{
+				consoleAPIs.GET("/:migrationID", api.ConsoleAPI)
+			}
 			settingsAPIs := migrateAPIs.Group("/settings")
 			{
 				settingsAPIs.Any("", api.SettingsAPI)


### PR DESCRIPTION
### Description
This PR adds new APIs to the CLI that will help support migrations from the console. 

## TODOs
- [ ] The APIs are yet to be documented and tested properly.
- [ ] Migration metadata updates need to be added.

### Affected components
- [x] CLI

### Related Issues
resolves https://github.com/hasura/graphql-engine-internal/issues/474

### Solution and Design
 - Adding 2 new endpoints `/migrate/apply` and `/migrate/console/` to support the commands `apply` and management of the migration files respectively.

### Steps to test and verify
(TODO)
