### PR TITLE
server: log request/response sizes for event triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 (Add entries here in the order of: server, console, cli, docs, others)
 
 - console: update sidebar icons for different action and trigger types
+- server: add request/response sizes in event triggers (and scheduled trigger) logs
 
 ## `v1.3.0`
 

--- a/server/src-lib/Hasura/Eventing/HTTP.hs
+++ b/server/src-lib/Hasura/Eventing/HTTP.hs
@@ -17,6 +17,7 @@ module Hasura.Eventing.HTTP
   , logHTTPForET
   , logHTTPForST
   , ExtraLogContext(..)
+  , RequestDetails (..)
   , EventId
   , Invocation(..)
   , InvocationVersion
@@ -46,9 +47,9 @@ import qualified Data.TByteString              as TBS
 import qualified Data.Text                     as T
 import qualified Data.Text.Encoding            as TE
 import qualified Data.Text.Encoding.Error      as TE
+import qualified Data.Time.Clock               as Time
 import qualified Network.HTTP.Client           as HTTP
 import qualified Network.HTTP.Types            as HTTP
-import qualified Data.Time.Clock               as Time
 
 import           Control.Exception             (try)
 import           Data.Aeson
@@ -56,6 +57,7 @@ import           Data.Aeson.Casing
 import           Data.Aeson.TH
 import           Data.Either
 import           Data.Has
+import           Data.Int                      (Int64)
 import           Hasura.Logging
 import           Hasura.Prelude
 import           Hasura.RQL.DDL.Headers
@@ -146,6 +148,7 @@ data HTTPResp (a :: TriggerTypes)
    { hrsStatus  :: !Int
    , hrsHeaders :: ![HeaderConf]
    , hrsBody    :: !TBS.TByteString
+   , hrsSize    :: !Int64
    } deriving (Show, Eq)
 
 $(deriveToJSON (aesonDrop 3 snakeCase){omitNothingFields=True} ''HTTPResp)
@@ -189,28 +192,37 @@ mkHTTPResp resp =
   HTTPResp
   { hrsStatus = HTTP.statusCode $ HTTP.responseStatus resp
   , hrsHeaders = map decodeHeader $ HTTP.responseHeaders resp
-  , hrsBody = TBS.fromLBS $ HTTP.responseBody resp
+  , hrsBody = TBS.fromLBS respBody
+  , hrsSize = LBS.length respBody
   }
   where
+    respBody = HTTP.responseBody resp
     decodeBS = TE.decodeUtf8With TE.lenientDecode
     decodeHeader (hdrName, hdrVal)
       = HeaderConf (decodeBS $ CI.original hdrName) (HVValue (decodeBS hdrVal))
 
+newtype RequestDetails
+  = RequestDetails { _rdSize :: Int64 }
+$(deriveToJSON (aesonDrop 3 snakeCase) ''RequestDetails)
+
 data HTTPRespExtra (a :: TriggerTypes)
   = HTTPRespExtra
-  { _hreResponse :: Either (HTTPErr a) (HTTPResp a)
-  , _hreContext  :: ExtraLogContext
+  { _hreResponse :: !(Either (HTTPErr a) (HTTPResp a))
+  , _hreContext  :: !ExtraLogContext
+  , _hreRequest  :: !RequestDetails
   }
 
 instance ToJSON (HTTPRespExtra a) where
-  toJSON (HTTPRespExtra resp ctxt) = do
+  toJSON (HTTPRespExtra resp ctxt req) =
     case resp of
       Left errResp ->
         object [ "response" .= toJSON errResp
+               , "request" .= toJSON req
                , "context" .= toJSON ctxt
                ]
       Right rsp ->
         object [ "response" .= toJSON rsp
+               , "request" .= toJSON req
                , "context" .= toJSON ctxt
                ]
 
@@ -260,20 +272,26 @@ logHTTPForET
      , Has (Logger Hasura) r
      , MonadIO m
      )
-  => Either (HTTPErr 'EventType) (HTTPResp 'EventType) -> ExtraLogContext -> m ()
-logHTTPForET eitherResp extraLogCtx = do
+  => Either (HTTPErr 'EventType) (HTTPResp 'EventType)
+  -> ExtraLogContext
+  -> RequestDetails
+  -> m ()
+logHTTPForET eitherResp extraLogCtx reqDetails = do
   logger :: Logger Hasura <- asks getter
-  unLogger logger $ HTTPRespExtra eitherResp extraLogCtx
+  unLogger logger $ HTTPRespExtra eitherResp extraLogCtx reqDetails
 
 logHTTPForST
   :: ( MonadReader r m
      , Has (Logger Hasura) r
      , MonadIO m
      )
-  => Either (HTTPErr 'ScheduledType) (HTTPResp 'ScheduledType) -> ExtraLogContext -> m ()
-logHTTPForST eitherResp extraLogCtx = do
+  => Either (HTTPErr 'ScheduledType) (HTTPResp 'ScheduledType)
+  -> ExtraLogContext
+  -> RequestDetails
+  -> m ()
+logHTTPForST eitherResp extraLogCtx reqDetails = do
   logger :: Logger Hasura <- asks getter
-  unLogger logger $ HTTPRespExtra eitherResp extraLogCtx
+  unLogger logger $ HTTPRespExtra eitherResp extraLogCtx reqDetails
 
 runHTTP :: (MonadIO m) => HTTP.Manager -> HTTP.Request -> m (Either (HTTPErr a) (HTTPResp a))
 runHTTP manager req = do
@@ -289,10 +307,13 @@ tryWebhook ::
   )
   => [HTTP.Header]
   -> HTTP.ResponseTimeout
-  -> Value
+  -> LBS.ByteString
+  -- ^ the request body. It is passed as a 'BL.Bytestring' because we need to
+  -- log the request size. As the logging happens outside the function, we pass
+  -- it the final request body, instead of 'Value'
   -> String
   -> m (HTTPResp a)
-tryWebhook headers timeout payload webhook = traceHttpRequest (T.pack webhook) do
+tryWebhook headers timeout payload webhook = traceHttpRequest (T.pack webhook) $ do
   initReqE <- liftIO $ try $ HTTP.parseRequest webhook
   manager <- asks getter
   case initReqE of
@@ -302,10 +323,10 @@ tryWebhook headers timeout payload webhook = traceHttpRequest (T.pack webhook) d
             initReq
               { HTTP.method = "POST"
               , HTTP.requestHeaders = headers
-              , HTTP.requestBody = HTTP.RequestBodyLBS (encode payload)
+              , HTTP.requestBody = HTTP.RequestBodyLBS payload
               , HTTP.responseTimeout = timeout
               }
-      pure $ SuspendedRequest req \req' -> do
+      pure $ SuspendedRequest req $ \req' -> do
         eitherResp <- runHTTP manager req'
         onLeft eitherResp throwError
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

Event triggers (and scheduled triggers) now have request/response size in their logs. That is, `event-trigger`/`scheduled-trigger` logs have new fields: `detail.response.size` and `detail.request.size`. Sizes are in bytes, same as `http-log`.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
https://github.com/hasura/graphql-engine-pro/issues/417

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
Appropriate fields are in the `HTTPResp` and `HTTPRespExtra` ADTs in `Hasura.Eventing.HTTP` module. Now, `event-trigger`/`scheduled-trigger` logs have new fields: `detail.response.size` and `detail.request.size`. Sizes are in bytes, same as `http-log`.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
1. Add an event trigger/scheduled trigger from the console
2. The trigger is invoked, either by mutation or time
3. Observer `event-trigger`/`scheduled-trigger` logs have new fields: `detail.response.size` and `detail.request.size`.


### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No Breaking changes

`event-trigger` and `scheduled-trigger` logs have new fields - `detail.response.size` and `detail.request.size`

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
