### PR TITLE
console: increase size of redeliver event modal (close #5480)

### DIFF
--- a/console/src/components/Services/Events/Common/Components/RedeliverEvent.tsx
+++ b/console/src/components/Services/Events/Common/Components/RedeliverEvent.tsx
@@ -86,7 +86,7 @@ const RedeliverEvent: React.FC<Props> = ({ dispatch, eventId }) => {
                 null,
                 4
               )}
-              minLines={10}
+              minLines={8}
               maxLines={30}
               width="100%"
               showPrintMargin={false}

--- a/console/src/components/Services/Events/Common/Components/RedeliverEvent.tsx
+++ b/console/src/components/Services/Events/Common/Components/RedeliverEvent.tsx
@@ -68,7 +68,7 @@ const RedeliverEvent: React.FC<Props> = ({ dispatch, eventId }) => {
               name="event_payload"
               value={JSON.stringify(latestLog.request, null, 4)}
               minLines={10}
-              maxLines={10}
+              maxLines={30}
               width="100%"
               showPrintMargin={false}
               showGutter={false}
@@ -88,7 +88,7 @@ const RedeliverEvent: React.FC<Props> = ({ dispatch, eventId }) => {
                 name="event_payload"
                 value={JSON.stringify(latestLog.response, null, 4)}
                 minLines={10}
-                maxLines={10}
+                maxLines={30}
                 width="100%"
                 showPrintMargin={false}
                 showGutter={false}
@@ -104,7 +104,7 @@ const RedeliverEvent: React.FC<Props> = ({ dispatch, eventId }) => {
                 name="event_payload"
                 value={JSON.stringify(error, null, 4)}
                 minLines={8}
-                maxLines={10}
+                maxLines={30}
                 width="100%"
                 showPrintMargin={false}
                 showGutter={false}

--- a/console/src/components/Services/Events/Common/Components/RedeliverEvent.tsx
+++ b/console/src/components/Services/Events/Common/Components/RedeliverEvent.tsx
@@ -14,24 +14,20 @@ type Props = {
 };
 
 const RedeliverEvent: React.FC<Props> = ({ dispatch, eventId }) => {
-  // const [loading, setLoading] = React.useState(false);
-  const [error, setError] = React.useState<any>(null);
+  const [error, setError] = React.useState<null | Error>(null);
   const [logs, setLogs] = React.useState<InvocationLog[]>([]);
 
   React.useEffect(() => {
     const intervalId = setInterval(() => {
-      // setLoading(true);
       dispatch(
         getEventLogs(
           eventId,
           'data',
           l => {
             setLogs(l);
-            //    setLoading(false);
           },
           e => {
             setError(e);
-            //    setLoading(false);
           }
         )
       );
@@ -81,39 +77,25 @@ const RedeliverEvent: React.FC<Props> = ({ dispatch, eventId }) => {
                 Latest Invocation Response
               </div>
             </div>
-            {error === null ? (
-              <AceEditor
-                mode="json"
-                theme="github"
-                name="event_payload"
-                value={JSON.stringify(latestLog.response, null, 4)}
-                minLines={10}
-                maxLines={30}
-                width="100%"
-                showPrintMargin={false}
-                showGutter={false}
-                style={{
-                  backgroundColor: '#fdf9ed',
-                  marginTop: '10px',
-                }}
-              />
-            ) : (
-              <AceEditor
-                mode="json"
-                theme="github"
-                name="event_payload"
-                value={JSON.stringify(error, null, 4)}
-                minLines={8}
-                maxLines={30}
-                width="100%"
-                showPrintMargin={false}
-                showGutter={false}
-                style={{
-                  backgroundColor: '#fdf9ed',
-                  marginTop: '10px',
-                }}
-              />
-            )}
+            <AceEditor
+              mode="json"
+              theme="github"
+              name="event_payload"
+              value={JSON.stringify(
+                error === null ? latestLog.response : error,
+                null,
+                4
+              )}
+              minLines={10}
+              maxLines={30}
+              width="100%"
+              showPrintMargin={false}
+              showGutter={false}
+              style={{
+                backgroundColor: '#fdf9ed',
+                marginTop: '10px',
+              }}
+            />
           </div>
         </div>
         <div

--- a/console/src/components/Services/Events/Events.scss
+++ b/console/src/components/Services/Events/Events.scss
@@ -50,7 +50,6 @@
   width: 15px;
 }
 .invocationsSection {
-
   li {
     display: block;
     padding: 5px 10px;
@@ -144,6 +143,7 @@
 
 .redeliverModal {
   width: 75%;
+  margin-bottom: 0;
 }
 
 .redeliverEventSection {
@@ -197,10 +197,6 @@
   width: 100%;
   float: left;
   clear: both;
-}
-
-.redeliverModal {
-  width: 75%;
 }
 
 .redeliverEventSection {


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Change AceEditor max-lines for better readability of the textareas with payloads.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
https://github.com/hasura/graphql-engine/issues/5480

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
- Changed `maxLines` from 10 to 30

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
- Open redeliver event modal
- Check readability of the textareas with payloads