### PR TITLE
restrict env variables start with HASURA_GRAPHQL_ for headers configuration in actions, event triggers & remote schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Breaking change
 
-Environment variables starting with `HASURA_GRAPHQL_` are not allowed to be set in header configuration 
-of event triggers, actions & remote schemas.
+Headers from environment variables starting with `HASURA_GRAPHQL_` are not allowed  
+in event triggers, actions & remote schemas.
 
 If you do have such headers configured, then you must update the header configuration before upgrading.
 
@@ -13,7 +13,7 @@ If you do have such headers configured, then you must update the header configur
 
 (Add entries here in the order of: server, console, cli, docs, others)
 
-- server: disallow env variables starting with `HASURA_GRAPHQL_` for headers in actions, event triggers & remote schemas (#5519)
+- server: disallow headers from env variables starting with `HASURA_GRAPHQL_` in actions, event triggers & remote schemas (#5519)
 **WARNING**: This might break certain deployments. See `Breaking change` section above.
 - server: bugfix to allow HASURA_GRAPHQL_QUERY_PLAN_CACHE_SIZE of 0 (#5363)
 - server: support only a bounded plan cache, with a default size of 4000 (closes #5363)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,17 @@
 
 ### Breaking change
 
-Environment variables starting with `HASURA_GRAPHQL_` are restricted to configure `value_from_env` key
-in headers definition of event triggers, actions & remote schemas. The GraphQL Engine isn't upgradable
-to this version if the metadata contains any action/event trigger/remote schema whose headers are defined
-with restricted environment variable.
+Environment variables starting with `HASURA_GRAPHQL_` are not allowed to be set in header configuration 
+of event triggers, actions & remote schemas.
 
-To upgrade, recreate or update the action/event trigger/remote without restricted environment variable.
+If you do have such headers configured, then you must update the header configuration before upgrading.
 
 ### Bug fixes and improvements
 
 (Add entries here in the order of: server, console, cli, docs, others)
 
-- server: restrict env variables start with HASURA_GRAPHQL_ for headers definition in actions, event triggers & remote schemas (#5519)
+- server: disallow env variables starting with `HASURA_GRAPHQL_` for headers in actions, event triggers & remote schemas (#5519)
+**WARNING**: This might break certain deployments. See `Breaking change` section above.
 - server: bugfix to allow HASURA_GRAPHQL_QUERY_PLAN_CACHE_SIZE of 0 (#5363)
 - server: support only a bounded plan cache, with a default size of 4000 (closes #5363)
 - server: add logs for action handlers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 (Add entries here in the order of: server, console, cli, docs, others)
 
+- server: restrict env variables start with HASURA_GRAPHQL_ for headers definition in actions & event triggers
 - server: bugfix to allow HASURA_GRAPHQL_QUERY_PLAN_CACHE_SIZE of 0 (#5363)
 - server: support only a bounded plan cache, with a default size of 4000 (closes #5363)
 - server: add logs for action handlers
@@ -38,7 +39,7 @@
 - server: have haskell runtime release blocks of memory back to the OS eagerly (related to #3388)
 - server: unlock locked scheduled events on graceful shutdown (#4928)
 - server: disable prepared statements for mutations as we end up with single-use objects which result in excessive memory consumption for mutation heavy workloads (#5255)
-- server: include scheduled event metadata (`created_at`,`scheduled_time`,`id`, etc) along with the configured payload in the request body to the webhook. 
+- server: include scheduled event metadata (`created_at`,`scheduled_time`,`id`, etc) along with the configured payload in the request body to the webhook.
 **WARNING:** This is breaking for beta versions as the payload is now inside a key called `payload`.
 - console: allow configuring statement timeout on console RawSQL page (close #4998) (#5045)
 - console: support tracking partitioned tables (close #5071) (#5258)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,20 @@
 
 ## Next release
 
+### Breaking change
+
+Environment variables starting with `HASURA_GRAPHQL_` are restricted to configure `value_from_env` key
+in headers definition of event triggers, actions & remote schemas. The GraphQL Engine isn't upgradable
+to this version if the metadata contains any action/event trigger/remote schema whose headers are defined
+with restricted environment variable.
+
+To upgrade, recreate or update the action/event trigger/remote without restricted environment variable.
+
 ### Bug fixes and improvements
 
 (Add entries here in the order of: server, console, cli, docs, others)
 
-- server: restrict env variables start with HASURA_GRAPHQL_ for headers definition in actions & event triggers
+- server: restrict env variables start with HASURA_GRAPHQL_ for headers definition in actions, event triggers & remote schemas (#5519)
 - server: bugfix to allow HASURA_GRAPHQL_QUERY_PLAN_CACHE_SIZE of 0 (#5363)
 - server: support only a bounded plan cache, with a default size of 4000 (closes #5363)
 - server: add logs for action handlers

--- a/server/src-lib/Hasura/RQL/DDL/Headers.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Headers.hs
@@ -37,7 +37,7 @@ instance FromJSON HeaderConf where
       (Just val, Nothing) -> return $ HeaderConf name (HVValue val)
       (Nothing, Just val) -> do
         when (T.isPrefixOf "HASURA_GRAPHQL_" val) $
-          fail "env variables start with \"HASURA_GRAPHQL_\" are not allowed for value_from_env"
+          fail $ "env variables starting with \"HASURA_GRAPHQL_\" are not allowed in value_from_env: " <> T.unpack val
         return $ HeaderConf name (HVEnv val)
       (Just _, Just _)    -> fail "expecting only one of value or value_from_env keys"
   parseJSON _ = fail "expecting object for headers"

--- a/server/src-lib/Hasura/RQL/DDL/Headers.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Headers.hs
@@ -8,8 +8,8 @@ import           Hasura.RQL.Types.Error
 import           Language.Haskell.TH.Syntax (Lift)
 
 import qualified Data.CaseInsensitive       as CI
-import qualified Data.Text                  as T
 import qualified Data.Environment           as Env
+import qualified Data.Text                  as T
 import qualified Network.HTTP.Types         as HTTP
 
 
@@ -35,7 +35,10 @@ instance FromJSON HeaderConf where
     case (value, valueFromEnv ) of
       (Nothing, Nothing)  -> fail "expecting value or value_from_env keys"
       (Just val, Nothing) -> return $ HeaderConf name (HVValue val)
-      (Nothing, Just val) -> return $ HeaderConf name (HVEnv val)
+      (Nothing, Just val) -> do
+        when (T.isPrefixOf "HASURA_GRAPHQL_" val) $
+          fail "env variables start with \"HASURA_GRAPHQL_\" are not allowed for value_from_env"
+        return $ HeaderConf name (HVEnv val)
       (Just _, Just _)    -> fail "expecting only one of value or value_from_env keys"
   parseJSON _ = fail "expecting object for headers"
 

--- a/server/tests-py/queries/actions/metadata/create_with_headers.yaml
+++ b/server/tests-py/queries/actions/metadata/create_with_headers.yaml
@@ -1,0 +1,21 @@
+description: Define an action with headers configuration
+url: /v1/query
+status: 400
+query:
+  type: create_action
+  args:
+    name: create_user_1
+    definition:
+      kind: synchronous
+      arguments:
+      - name: name
+        type: String!
+      output_type: User!
+      handler: http://127.0.0.1:5593/create-user
+      headers:
+      - name: x-client-id
+        value_from_env: HASURA_GRAPHQL_CLIENT_NAME
+response:
+  path: $.definition.headers[0]
+  error: env variables start with "HASURA_GRAPHQL_" are not allowed for value_from_env
+  code: parse-failed

--- a/server/tests-py/queries/actions/metadata/create_with_headers.yaml
+++ b/server/tests-py/queries/actions/metadata/create_with_headers.yaml
@@ -17,5 +17,5 @@ query:
         value_from_env: HASURA_GRAPHQL_CLIENT_NAME
 response:
   path: $.definition.headers[0]
-  error: env variables starting with "HASURA_GRAPHQL_" are not allowed in value_from_env: HASURA_GRAPHQL_CLIENT_NAME
+  error: 'env variables starting with "HASURA_GRAPHQL_" are not allowed in value_from_env: HASURA_GRAPHQL_CLIENT_NAME'
   code: parse-failed

--- a/server/tests-py/queries/actions/metadata/create_with_headers.yaml
+++ b/server/tests-py/queries/actions/metadata/create_with_headers.yaml
@@ -17,5 +17,5 @@ query:
         value_from_env: HASURA_GRAPHQL_CLIENT_NAME
 response:
   path: $.definition.headers[0]
-  error: env variables start with "HASURA_GRAPHQL_" are not allowed for value_from_env
+  error: env variables starting with "HASURA_GRAPHQL_" are not allowed in value_from_env: HASURA_GRAPHQL_CLIENT_NAME
   code: parse-failed

--- a/server/tests-py/test_actions.py
+++ b/server/tests-py/test_actions.py
@@ -455,6 +455,9 @@ class TestActionsMetadata:
     def test_recreate_permission(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + '/recreate_permission.yaml')
 
+    def test_create_with_headers(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + '/create_with_headers.yaml')
+
 # Test case for bug reported at https://github.com/hasura/graphql-engine/issues/5166
 @pytest.mark.usefixtures('per_class_tests_db_state')
 class TestActionIntrospection:


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
In `headers` definition for actions, remote schemas & event triggers, don't allow `value_from_env` values start with `HASURA_GRAPHQL_`. 

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [x] Tests

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
N/A

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->


### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Creating action/event trigger having headers configuration with `HASURA_GRAPHQL_*` env variables.

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes

#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated

#### Breaking changes

- [ ] No Breaking changes
- [x] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [x] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

If metadata contains any action/event trigger/remote schema defined with `HASURA_GRAPHQL_*` env variables in headers configuration, then such graphql-engine isn't upgrade-able. To upgrade, recreate those actions/event triggers/remote schemas without restricted env variables.

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
