### PR TITLE
console: add toggle button to trigger operations selector on event trigger page (close #4972) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 (Add entries here in the order of: server, console, cli, docs, others)
 
 - console: display line number that error originated from in GraphQL editor (close #4849) (#4942)
+- console: add toggle button to trigger operations selector on event trigger page (close #4972) 
 
 ## `v1.3.0-beta.4`
 

--- a/console/src/client.js
+++ b/console/src/client.js
@@ -125,3 +125,4 @@ ReactDOM.render(
 if (process.env.NODE_ENV !== 'production') {
   window.React = React; // enable debugger
 }
+console.log("first code edit");

--- a/console/src/client.js
+++ b/console/src/client.js
@@ -125,4 +125,3 @@ ReactDOM.render(
 if (process.env.NODE_ENV !== 'production') {
   window.React = React; // enable debugger
 }
-console.log("first code edit");

--- a/console/src/components/Services/Data/Schema/Schema.js
+++ b/console/src/components/Services/Data/Schema/Schema.js
@@ -130,7 +130,7 @@ const DeleteSchemaButton = ({ dispatch, migrationMode }) => {
   return (
     migrationMode && (
       <Button
-        color="white"
+        color="red"
         size="xs"
         onClick={handleDelete}
         title="Delete current schema"

--- a/console/src/components/Services/Events/EventTriggers/Modify/OperationEditor.tsx
+++ b/console/src/components/Services/Events/EventTriggers/Modify/OperationEditor.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../utils';
 
 import Operations from '../Common/Operations';
+import Button from '../../../../Common/Button/Button';
 
 type OperationEditorProps = {
   currentTrigger: EventTrigger;
@@ -50,6 +51,16 @@ const OperationEditor = (props: OperationEditorProps) => {
     setOperationColumns(existingOpColumns);
   };
 
+  const editorToggle = (opCols: ETOperationColumn[]) => {
+    const newCols = opCols.map(oc => {
+      return {
+        ...oc,
+        enabled: !oc.enabled,
+      };
+    });
+    setOperationColumns(newCols);
+  };
+
   const renderEditor = (
     ops: Record<EventTriggerOperation, boolean>,
     opCols: ETOperationColumn[],
@@ -70,6 +81,15 @@ const OperationEditor = (props: OperationEditorProps) => {
       <div className={styles.modifyOpsCollapsedContent}>
         <div className={`col-md-12 ${styles.padd_remove}`}>
           Listen columns for update:&nbsp;
+          {ops.update && !readOnly ? (
+            <Button
+              color="white"
+              size="xs"
+              onClick={() => editorToggle(operationColumns)}
+            >
+              Toggle
+            </Button>
+          ) : null}
         </div>
         <div className={`col-md-12 ${styles.padd_remove}`}>
           {ops.update ? (
@@ -118,7 +138,6 @@ const OperationEditor = (props: OperationEditorProps) => {
   const collapsed = () => renderEditor(existingOps, existingOpColumns, true);
 
   const expanded = () => renderEditor(operations, operationColumns, false);
-
   return (
     <div className={`${styles.container} ${styles.borderBottom}`}>
       <div className={styles.modifySection}>


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [ ] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [ ] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [ ] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [ ] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
