### PR TITLE
add log kinds in cli-migrations image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ If you do have such headers configured, then you must update the header configur
 - console: handle nested fragments in allowed queries (close #5137) (#5252)
 - console: update sidebar icons for different action and trigger types (#5445)
 - console: make add column UX consistent with others (#5486)
+- build: introduce additional log kinds for cli-migrations image (#5529)
 
 ## `v1.3.0`
 

--- a/scripts/cli-migrations/v1/docker-entrypoint.sh
+++ b/scripts/cli-migrations/v1/docker-entrypoint.sh
@@ -4,8 +4,9 @@ set -e
 
 log() {
     TIMESTAMP=$(date -u "+%Y-%m-%dT%H:%M:%S.000+0000")
-    MESSAGE=$1
-    echo "{\"timestamp\":\"$TIMESTAMP\",\"level\":\"info\",\"type\":\"startup\",\"detail\":{\"kind\":\"migration-apply\",\"info\":\"$MESSAGE\"}}"
+    LOGKIND=$1
+    MESSAGE=$2
+    echo "{\"timestamp\":\"$TIMESTAMP\",\"level\":\"info\",\"type\":\"startup\",\"detail\":{\"kind\":\"$LOGKIND\",\"info\":\"$MESSAGE\"}}"
 }
 
 DEFAULT_MIGRATIONS_DIR="/hasura-migrations"
@@ -13,40 +14,40 @@ TEMP_MIGRATIONS_DIR="/tmp/hasura-migrations"
 
 # configure the target database for migrations
 if [ ${HASURA_GRAPHQL_MIGRATIONS_DATABASE_ENV_VAR} ]; then
-    log "database url for migrations is set by $HASURA_GRAPHQL_MIGRATIONS_DATABASE_ENV_VAR"
+    log "migrations-startup" "database url for migrations is set by $HASURA_GRAPHQL_MIGRATIONS_DATABASE_ENV_VAR"
     HASURA_GRAPHQL_MIGRATIONS_DATABASE_URL=$(printenv $HASURA_GRAPHQL_MIGRATIONS_DATABASE_ENV_VAR)
 elif [ -z ${HASURA_GRAPHQL_MIGRATIONS_DATABASE_URL+x} ]; then
     HASURA_GRAPHQL_MIGRATIONS_DATABASE_URL=$HASURA_GRAPHQL_DATABASE_URL
 fi
-log "database url for migrations is set by HASURA_GRAPHQL_DATABASE_URL"
+log "migrations-startup" "database url for migrations is set by HASURA_GRAPHQL_DATABASE_URL"
 
 # Use 9691 port for running temporary instance. 
 # In case 9691 is occupied (according to docker networking), then this will fail.
 # override with another port in that case
 # TODO: Find a proper random port
 if [ -z ${HASURA_GRAPHQL_MIGRATIONS_SERVER_PORT+x} ]; then
-    log "migrations server port env var is not set, defaulting to 9691"
+    log "migrations-startup" "migrations server port env var is not set, defaulting to 9691"
     HASURA_GRAPHQL_MIGRATIONS_SERVER_PORT=9691
 fi
 
 if [ -z ${HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT+x} ]; then
-    log "server timeout is not set, defaulting to 30 seconds"
+    log "migrations-startup" "server timeout is not set, defaulting to 30 seconds"
     HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT=30
 fi
 
 # wait for a port to be ready
 wait_for_port() {
     local PORT=$1
-    log "waiting $HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT for $PORT to be ready"
+    log "migrations-startup" "waiting $HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT for $PORT to be ready"
     for i in `seq 1 $HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT`;
     do
         nc -z localhost $PORT > /dev/null 2>&1 && log "port $PORT is ready" && return
         sleep 1
     done
-    log "failed waiting for $PORT" && exit 1
+    log "migrations-startup" "failed waiting for $PORT" && exit 1
 }
 
-log "starting graphql engine temporarily on port $HASURA_GRAPHQL_MIGRATIONS_SERVER_PORT"
+log "migrations-startup" "starting graphql engine temporarily on port $HASURA_GRAPHQL_MIGRATIONS_SERVER_PORT"
 
 # start graphql engine with metadata api enabled
 graphql-engine --database-url "$HASURA_GRAPHQL_MIGRATIONS_DATABASE_URL" \
@@ -61,13 +62,13 @@ wait_for_port $HASURA_GRAPHQL_MIGRATIONS_SERVER_PORT
 # check if migration directory is set, default otherwise
 log "checking for migrations directory"
 if [ -z ${HASURA_GRAPHQL_MIGRATIONS_DIR+x} ]; then
-    log "env var HASURA_GRAPHQL_MIGRATIONS_DIR is not set, defaulting to $DEFAULT_MIGRATIONS_DIR"
+    log "migrations-startup" "env var HASURA_GRAPHQL_MIGRATIONS_DIR is not set, defaulting to $DEFAULT_MIGRATIONS_DIR"
     HASURA_GRAPHQL_MIGRATIONS_DIR="$DEFAULT_MIGRATIONS_DIR"
 fi
 
 # apply migrations if the directory exist
 if [ -d "$HASURA_GRAPHQL_MIGRATIONS_DIR" ]; then
-    log "applying migrations from $HASURA_GRAPHQL_MIGRATIONS_DIR"
+    log "migrations-apply" "applying migrations from $HASURA_GRAPHQL_MIGRATIONS_DIR"
     mkdir -p "$TEMP_MIGRATIONS_DIR"
     cp -a "$HASURA_GRAPHQL_MIGRATIONS_DIR/." "$TEMP_MIGRATIONS_DIR/migrations/"
     cd "$TEMP_MIGRATIONS_DIR"
@@ -75,20 +76,20 @@ if [ -d "$HASURA_GRAPHQL_MIGRATIONS_DIR" ]; then
     hasura-cli migrate apply
     # check if metadata.[yaml|json] exist and apply
     if [ -f migrations/metadata.yaml ]; then
-        log "applying metadata from $HASURA_GRAPHQL_MIGRATIONS_DIR/metadata.yaml"
+        log "migrations-apply" "applying metadata from $HASURA_GRAPHQL_MIGRATIONS_DIR/metadata.yaml"
         hasura-cli metadata apply
     elif [ -f migrations/metadata.json ]; then
-        log "applying metadata from $HASURA_GRAPHQL_MIGRATIONS_DIR/metadata.json"
+        log "migrations-apply" "applying metadata from $HASURA_GRAPHQL_MIGRATIONS_DIR/metadata.json"
         hasura-cli metadata apply
     fi
 else
-    log "directory $HASURA_GRAPHQL_MIGRATIONS_DIR does not exist, skipping migrations"
+    log "migrations-apply" "directory $HASURA_GRAPHQL_MIGRATIONS_DIR does not exist, skipping migrations"
 fi
 
 # kill graphql engine that we started earlier
-log "killing temporary server"
+log "migrations-shutdown" "killing temporary server"
 kill $PID
 
 # pass control to CMD
-log "graphql-engine will now start in normal mode"
+log "migrations-shutdown" "graphql-engine will now start in normal mode"
 exec "$@"

--- a/scripts/cli-migrations/v1/docker-entrypoint.sh
+++ b/scripts/cli-migrations/v1/docker-entrypoint.sh
@@ -41,7 +41,7 @@ wait_for_port() {
     log "migrations-startup" "waiting $HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT for $PORT to be ready"
     for i in `seq 1 $HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT`;
     do
-        nc -z localhost $PORT > /dev/null 2>&1 && log "port $PORT is ready" && return
+        nc -z localhost $PORT > /dev/null 2>&1 && log "migrations-startup" "port $PORT is ready" && return
         sleep 1
     done
     log "migrations-startup" "failed waiting for $PORT, try increasing HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT (default: 30)" && exit 1

--- a/scripts/cli-migrations/v1/docker-entrypoint.sh
+++ b/scripts/cli-migrations/v1/docker-entrypoint.sh
@@ -44,7 +44,7 @@ wait_for_port() {
         nc -z localhost $PORT > /dev/null 2>&1 && log "port $PORT is ready" && return
         sleep 1
     done
-    log "migrations-startup" "failed waiting for $PORT" && exit 1
+    log "migrations-startup" "failed waiting for $PORT, try increasing HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT (default: 30)" && exit 1
 }
 
 log "migrations-startup" "starting graphql engine temporarily on port $HASURA_GRAPHQL_MIGRATIONS_SERVER_PORT"

--- a/scripts/cli-migrations/v2/docker-entrypoint.sh
+++ b/scripts/cli-migrations/v2/docker-entrypoint.sh
@@ -4,8 +4,9 @@ set -e
 
 log() {
     TIMESTAMP=$(date -u "+%Y-%m-%dT%H:%M:%S.000+0000")
-    MESSAGE=$1
-    echo "{\"timestamp\":\"$TIMESTAMP\",\"level\":\"info\",\"type\":\"startup\",\"detail\":{\"kind\":\"migration-apply\",\"info\":\"$MESSAGE\"}}"
+    LOGKIND=$1
+    MESSAGE=$2
+    echo "{\"timestamp\":\"$TIMESTAMP\",\"level\":\"info\",\"type\":\"startup\",\"detail\":{\"kind\":\"$LOGKIND\",\"info\":\"$MESSAGE\"}}"
 }
 
 DEFAULT_MIGRATIONS_DIR="/hasura-migrations"
@@ -14,40 +15,40 @@ TEMP_PROJECT_DIR="/tmp/hasura-project"
 
 # configure the target database for migrations
 if [ ${HASURA_GRAPHQL_MIGRATIONS_DATABASE_ENV_VAR} ]; then
-    log "database url for migrations is set by $HASURA_GRAPHQL_MIGRATIONS_DATABASE_ENV_VAR"
+    log "migrations-startup" "database url for migrations is set by $HASURA_GRAPHQL_MIGRATIONS_DATABASE_ENV_VAR"
     HASURA_GRAPHQL_MIGRATIONS_DATABASE_URL=$(printenv $HASURA_GRAPHQL_MIGRATIONS_DATABASE_ENV_VAR)
 elif [ -z ${HASURA_GRAPHQL_MIGRATIONS_DATABASE_URL+x} ]; then
     HASURA_GRAPHQL_MIGRATIONS_DATABASE_URL=$HASURA_GRAPHQL_DATABASE_URL
 fi
-log "database url for migrations is set by HASURA_GRAPHQL_DATABASE_URL"
+log "migrations-startup" "database url for migrations is set by HASURA_GRAPHQL_DATABASE_URL"
 
 # Use 9691 port for running temporary instance. 
 # In case 9691 is occupied (according to docker networking), then this will fail.
 # override with another port in that case
 # TODO: Find a proper random port
 if [ -z ${HASURA_GRAPHQL_MIGRATIONS_SERVER_PORT+x} ]; then
-    log "migrations server port env var is not set, defaulting to 9691"
+    log "migrations-startup" "migrations server port env var is not set, defaulting to 9691"
     HASURA_GRAPHQL_MIGRATIONS_SERVER_PORT=9691
 fi
 
 if [ -z ${HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT+x} ]; then
-    log "server timeout is not set, defaulting to 30 seconds"
+    log "migrations-startup" "server timeout is not set, defaulting to 30 seconds"
     HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT=30
 fi
 
 # wait for a port to be ready
 wait_for_port() {
     local PORT=$1
-    log "waiting $HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT for $PORT to be ready"
+    log "migrations-startup" "waiting $HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT for $PORT to be ready"
     for i in `seq 1 $HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT`;
     do
         nc -z localhost $PORT > /dev/null 2>&1 && log "port $PORT is ready" && return
         sleep 1
     done
-    log "failed waiting for $PORT" && exit 1
+    log "migrations-startup" "failed waiting for $PORT" && exit 1
 }
 
-log "starting graphql engine temporarily on port $HASURA_GRAPHQL_MIGRATIONS_SERVER_PORT"
+log "migrations-startup" "starting graphql engine temporarily on port $HASURA_GRAPHQL_MIGRATIONS_SERVER_PORT"
 
 # start graphql engine with metadata api enabled
 graphql-engine --database-url "$HASURA_GRAPHQL_MIGRATIONS_DATABASE_URL" \
@@ -62,20 +63,20 @@ wait_for_port $HASURA_GRAPHQL_MIGRATIONS_SERVER_PORT
 # check if migration directory is set, default otherwise
 log "checking for migrations directory"
 if [ -z ${HASURA_GRAPHQL_MIGRATIONS_DIR+x} ]; then
-    log "env var HASURA_GRAPHQL_MIGRATIONS_DIR is not set, defaulting to $DEFAULT_MIGRATIONS_DIR"
+    log "migrations-startup" "env var HASURA_GRAPHQL_MIGRATIONS_DIR is not set, defaulting to $DEFAULT_MIGRATIONS_DIR"
     HASURA_GRAPHQL_MIGRATIONS_DIR="$DEFAULT_MIGRATIONS_DIR"
 fi
 
 # check if metadata directory is set, default otherwise
 log "checking for metadata directory"
 if [ -z ${HASURA_GRAPHQL_METADATA_DIR+x} ]; then
-    log "env var HASURA_GRAPHQL_METADATA_DIR is not set, defaulting to $DEFAULT_METADATA_DIR"
+    log "migrations-startup" "env var HASURA_GRAPHQL_METADATA_DIR is not set, defaulting to $DEFAULT_METADATA_DIR"
     HASURA_GRAPHQL_METADATA_DIR="$DEFAULT_METADATA_DIR"
 fi
 
 # apply migrations if the directory exist
 if [ -d "$HASURA_GRAPHQL_MIGRATIONS_DIR" ]; then
-    log "applying migrations from $HASURA_GRAPHQL_MIGRATIONS_DIR"
+    log "migrations-apply" "applying migrations from $HASURA_GRAPHQL_MIGRATIONS_DIR"
     mkdir -p "$TEMP_PROJECT_DIR"
     cp -a "$HASURA_GRAPHQL_MIGRATIONS_DIR/." "$TEMP_PROJECT_DIR/migrations/"
     cd "$TEMP_PROJECT_DIR"
@@ -83,13 +84,13 @@ if [ -d "$HASURA_GRAPHQL_MIGRATIONS_DIR" ]; then
     echo "endpoint: http://localhost:$HASURA_GRAPHQL_MIGRATIONS_SERVER_PORT" >> config.yaml
     hasura-cli migrate apply
 else
-    log "directory $HASURA_GRAPHQL_MIGRATIONS_DIR does not exist, skipping migrations"
+    log "migrations-apply" "directory $HASURA_GRAPHQL_MIGRATIONS_DIR does not exist, skipping migrations"
 fi
 
 # apply metadata if the directory exist
 if [ -d "$HASURA_GRAPHQL_METADATA_DIR" ]; then
     rm -rf "TEMP_PROJECT_DIR"
-    log "applying metadata from $HASURA_GRAPHQL_METADATA_DIR"
+    log "migrations-apply" "applying metadata from $HASURA_GRAPHQL_METADATA_DIR"
     mkdir -p "$TEMP_PROJECT_DIR"
     cp -a "$HASURA_GRAPHQL_METADATA_DIR/." "$TEMP_PROJECT_DIR/metadata/"
     cd "$TEMP_PROJECT_DIR"
@@ -98,13 +99,13 @@ if [ -d "$HASURA_GRAPHQL_METADATA_DIR" ]; then
     echo "metadata_directory: metadata" >> config.yaml
     hasura-cli metadata apply
 else
-    log "directory $HASURA_GRAPHQL_METADATA_DIR does not exist, skipping metadata"
+    log "migrations-apply" "directory $HASURA_GRAPHQL_METADATA_DIR does not exist, skipping metadata"
 fi
 
 # kill graphql engine that we started earlier
-log "killing temporary server"
+log "migrations-shutdown" "killing temporary server"
 kill $PID
 
 # pass control to CMD
-log "graphql-engine will now start in normal mode"
+log "migrations-shutdown" "graphql-engine will now start in normal mode"
 exec "$@"

--- a/scripts/cli-migrations/v2/docker-entrypoint.sh
+++ b/scripts/cli-migrations/v2/docker-entrypoint.sh
@@ -45,7 +45,7 @@ wait_for_port() {
         nc -z localhost $PORT > /dev/null 2>&1 && log "port $PORT is ready" && return
         sleep 1
     done
-    log "migrations-startup" "failed waiting for $PORT" && exit 1
+    log "migrations-startup" "failed waiting for $PORT, try increasing HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT (default: 30)" && exit 1
 }
 
 log "migrations-startup" "starting graphql engine temporarily on port $HASURA_GRAPHQL_MIGRATIONS_SERVER_PORT"

--- a/scripts/cli-migrations/v2/docker-entrypoint.sh
+++ b/scripts/cli-migrations/v2/docker-entrypoint.sh
@@ -42,7 +42,7 @@ wait_for_port() {
     log "migrations-startup" "waiting $HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT for $PORT to be ready"
     for i in `seq 1 $HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT`;
     do
-        nc -z localhost $PORT > /dev/null 2>&1 && log "port $PORT is ready" && return
+        nc -z localhost $PORT > /dev/null 2>&1 && log "migrations-startup" "port $PORT is ready" && return
         sleep 1
     done
     log "migrations-startup" "failed waiting for $PORT, try increasing HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT (default: 30)" && exit 1
@@ -61,14 +61,12 @@ PID=$!
 wait_for_port $HASURA_GRAPHQL_MIGRATIONS_SERVER_PORT
 
 # check if migration directory is set, default otherwise
-log "checking for migrations directory"
 if [ -z ${HASURA_GRAPHQL_MIGRATIONS_DIR+x} ]; then
     log "migrations-startup" "env var HASURA_GRAPHQL_MIGRATIONS_DIR is not set, defaulting to $DEFAULT_MIGRATIONS_DIR"
     HASURA_GRAPHQL_MIGRATIONS_DIR="$DEFAULT_MIGRATIONS_DIR"
 fi
 
 # check if metadata directory is set, default otherwise
-log "checking for metadata directory"
 if [ -z ${HASURA_GRAPHQL_METADATA_DIR+x} ]; then
     log "migrations-startup" "env var HASURA_GRAPHQL_METADATA_DIR is not set, defaulting to $DEFAULT_METADATA_DIR"
     HASURA_GRAPHQL_METADATA_DIR="$DEFAULT_METADATA_DIR"


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description

Prior to this, there was only kind `migrations-apply` which is confusing, especially when a timeout happens prior to the actual migrate step. This PR introduces new log kinds: `migrations-startup` and `migrations-shutdown`.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [x] Build System
- [ ] Tests
- [ ] Other (list it)

### Steps to test and verify

Needs testing