### PR TITLE
server: set hasura.tracecontext in RQL mutations [#5542]

### DIFF
--- a/server/src-lib/Hasura/App.hs
+++ b/server/src-lib/Hasura/App.hs
@@ -235,7 +235,7 @@ migrateCatalogSchema env logger pool httpManager sqlGenCtx = do
   let pgExecCtx = mkPGExecCtx Q.Serializable pool
       adminRunCtx = RunCtx adminUserInfo httpManager sqlGenCtx
   currentTime <- liftIO Clock.getCurrentTime
-  initialiseResult <- runExceptT $ peelRun adminRunCtx pgExecCtx Q.ReadWrite $
+  initialiseResult <- runExceptT $ peelRun adminRunCtx pgExecCtx Q.ReadWrite Nothing $
     (,) <$> migrateCatalog env currentTime <*> liftTx fetchLastUpdate
 
   ((migrationResult, schemaCache), lastUpdateEvent) <-
@@ -586,7 +586,7 @@ runAsAdmin
 runAsAdmin pool sqlGenCtx httpManager m = do
   let runCtx = RunCtx adminUserInfo httpManager sqlGenCtx
       pgCtx = mkPGExecCtx Q.Serializable pool
-  runExceptT $ peelRun runCtx pgCtx Q.ReadWrite m
+  runExceptT $ peelRun runCtx pgCtx Q.ReadWrite Nothing m
 
 execQuery
   :: ( HasVersion

--- a/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
@@ -368,8 +368,9 @@ onStart env serverEnv wsConn (StartMsg opId q) = catchAndIgnore $ do
           Tracing.interpTraceT id $ executeQuery queryParsed asts genSql pgExecCtx Q.ReadOnly opTx
       -- Response headers discarded over websockets
       E.ExOpMutation _ opTx -> Tracing.trace "pg" do
+        ctx <- Tracing.currentContext
         execQueryOrMut Telem.Mutation Nothing $
-          Tracing.interpTraceT (runLazyTx pgExecCtx Q.ReadWrite . withUserInfo userInfo) opTx
+          Tracing.interpTraceT (runLazyTx pgExecCtx Q.ReadWrite . withTraceContext ctx . withUserInfo userInfo) opTx
       E.ExOpSubs lqOp -> do
         -- log the graphql query
         logQueryLog logger query Nothing reqId

--- a/server/src-lib/Hasura/RQL/Types/Run.hs
+++ b/server/src-lib/Hasura/RQL/Types/Run.hs
@@ -16,6 +16,7 @@ import           Control.Monad.Trans.Control (MonadBaseControl)
 import           Control.Monad.Unique
 
 import           Hasura.RQL.Types
+import qualified Hasura.Tracing              as Tracing
 
 data RunCtx
   = RunCtx
@@ -50,7 +51,8 @@ peelRun
   => RunCtx
   -> PGExecCtx
   -> Q.TxAccess
+  -> Maybe Tracing.TraceContext
   -> Run a
   -> ExceptT QErr m a
-peelRun runCtx@(RunCtx userInfo _ _) pgExecCtx txAccess (Run m) =
-  runLazyTx pgExecCtx txAccess $ withUserInfo userInfo $ runReaderT m runCtx
+peelRun runCtx@(RunCtx userInfo _ _) pgExecCtx txAccess ctx (Run m) =
+  runLazyTx pgExecCtx txAccess $ maybe id withTraceContext ctx $ withUserInfo userInfo $ runReaderT m runCtx

--- a/server/src-lib/Hasura/Server/API/Query.hs
+++ b/server/src-lib/Hasura/Server/API/Query.hs
@@ -198,10 +198,11 @@ runQuery
   -> SQLGenCtx -> SystemDefined -> RQLQuery -> m (EncJSON, RebuildableSchemaCache Run)
 runQuery env pgExecCtx instanceId userInfo sc hMgr sqlGenCtx systemDefined query = do
   accessMode <- getQueryAccessMode query
+  traceCtx <- Tracing.currentContext
   resE <- runQueryM env query & Tracing.interpTraceT \x -> do
     a <- x & runHasSystemDefinedT systemDefined
            & runCacheRWT sc
-           & peelRun runCtx pgExecCtx accessMode
+           & peelRun runCtx pgExecCtx accessMode (Just traceCtx)
            & runExceptT
            & liftIO
     pure (either 

--- a/server/src-lib/Hasura/Server/SchemaUpdate.hs
+++ b/server/src-lib/Hasura/Server/SchemaUpdate.hs
@@ -221,7 +221,7 @@ refreshSchemaCache sqlGenCtx pool logger httpManager cacheRef invalidations thre
     rebuildableCache <- fst <$> liftIO (readIORef $ _scrCache cacheRef)
     ((), cache, _) <- buildSchemaCacheWithOptions CatalogSync invalidations
       & runCacheRWT rebuildableCache
-      & peelRun runCtx pgCtx PG.ReadWrite
+      & peelRun runCtx pgCtx PG.ReadWrite Nothing
     pure ((), cache)
   case resE of
     Left e   -> logError logger threadType $ TEQueryError e

--- a/server/src-test/Main.hs
+++ b/server/src-test/Main.hs
@@ -83,7 +83,7 @@ buildPostgresSpecs pgConnOptions = do
 
             runAsAdmin :: Run a -> IO a
             runAsAdmin =
-                  peelRun runContext pgContext Q.ReadWrite
+                  peelRun runContext pgContext Q.ReadWrite Nothing
               >>> runExceptT
               >=> flip onLeft printErrJExit
 


### PR DESCRIPTION
This fix sets the `hasura.tracecontext` variable in websocket and RQL mutations.

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server

### Related Issues
Fixes #5542

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
Following the steps in the issue:

```
$ curl 'http://localhost:8080/v1/graphql' -d '{"query":"mutation MyMutation {\n  insert_test_one(object: {id: \"t\"}) {\n    id\n    \n  }\n}\n","variables":null,"operationName":"MyMutation"}'
{"data":{"insert_test_one":{"id":"t"}}}

$ curl 'http://localhost:8080/v1/query' -d '{"type":"insert","args":{"table":{"name":"test","schema":"public"},"objects":[{"id":"a"}],"returning":[]}}'
{"returning" : [{}], "affected_rows" : 1}
```

If CI passes, I can work on adding a test for this exact scenario.

### Limitations, known bugs & workarounds

It's still technically possible for the same connection to issue a query without `hasura.tracecontext`, which would cause us to again run afoul of the same postgres bug, but this should catch all the currently-possible ways in which that can happen.
 
### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No Breaking changes