### PR TITLE
Add bulldozer auto-merge and -update configuration

### DIFF
--- a/.bulldozer.yml
+++ b/.bulldozer.yml
@@ -1,0 +1,110 @@
+##
+## This defines how our `hasura-bulldozer-mergebot` behaves on this repository. 
+## See: https://github.com/palantir/bulldozer 
+##
+## Comments from the original example config are left here as documentation.
+## "HASURA NOTE:" precedes comments about our choices here.
+##
+
+#
+# "version" is the configuration version, currently "1".
+version: 1
+
+# "merge" defines how and when pull requests are merged. If the section is
+# missing, bulldozer will consider all pull requests and use default settings.
+merge:
+  # "trigger" defines the set of pull requests considered by bulldozer. If
+  # the section is missing, bulldozer considers all pull requests not excluded
+  # by the ignore conditions.
+  trigger:
+    # Pull requests with any of these labels (case-insensitive) are added to
+    # the trigger.
+    #
+    # HASURA NOTE: for now switch on only via opt-in with this label:
+    # CAREFUL!: if untrusted contributors can add labels, this would
+    #           effectively give them write permissions so long as CI passed!
+    labels: ["auto-update-auto-merge"]
+
+    ################## HASURA CAREFUL!: I think these are all dangerous (see above)
+    # Pull requests where the body or any comment contains any of these
+    # substrings are added to the trigger.
+    # comment_substrings: ["==MERGE_WHEN_READY=="]
+
+    # Pull requests where any comment matches one of these exact strings are
+    # added to the trigger.
+    # comments: ["Please merge this pull request!"]
+
+    # Pull requests where the body contains any of these substrings are added
+    # to the trigger.
+    # pr_body_substrings: ["==MERGE_WHEN_READY=="]
+    ##################
+
+    # Pull requests targeting any of these branches are added to the trigger.
+    # branches: ["develop"]
+
+  # "ignore" defines the set of pull request ignored by bulldozer. If the
+  # section is missing, bulldozer considers all pull requests. It takes the
+  # same keys as the "trigger" section.
+  ignore:
+    # HASURA NOTE: some existing semantic tags; not sure how widely in use they are:
+    labels: ["s/do-not-merge", "s/wip"]
+    # comment_substrings: ["==DO_NOT_MERGE=="]
+
+  # "method" defines the merge method. The available options are "merge",
+  # "rebase", "squash", and "ff-only".
+  method: merge
+
+  # Allows the merge method that is used when auto-merging a PR to be different based on the
+  # target branch. The keys of the hash are the target branch name, and the values are the merge method that
+  # will be used for PRs targeting that branch. The valid values are the same as for the "method" key.
+  # Note: If the target branch does not match any of the specified keys, the "method" key is used instead.
+  branch_method:
+    # develop: squash
+    master: merge
+
+  # "options" defines additional options for the individual merge methods.
+  options:
+    # "squash" options are only used when the merge method is "squash"
+    # squash:
+    #   # "title" defines how the title of the commit message is created when
+    #   # generating a squash commit. The options are "pull_request_title",
+    #   # "first_commit_title", and "github_default_title". The default is
+    #   # "pull_request_title".
+    #   title: "pull_request_title"
+
+    #   # "body" defines how the body of the commit message is created when
+    #   # generating a squash commit. The options are "pull_request_body",
+    #   # "summarize_commits", and "empty_body". The default is "empty_body".
+    #   body: "empty_body"
+
+    #   # If "body" is "pull_request_body", then the commit message will be the
+    #   # part of the pull request body surrounded by "message_delimiter"
+    #   # strings. This is disabled (empty string) by default.
+    #   message_delimiter: ==COMMIT_MSG==
+
+  # "required_statuses" is a list of additional status contexts that must pass
+  # before bulldozer can merge a pull request. This is useful if you want to
+  # require extra testing for automated merges, but not for manual merges.
+  # required_statuses:
+  #   - "ci/circleci: ete-tests"
+
+  # If true, bulldozer will delete branches after their pull requests merge.
+  #
+  # HASURA NOTE: this is easily undone in the github UI:
+  delete_after_merge: true
+
+# "update" defines how and when to update pull request branches. Unlike with
+# merges, if this section is missing, bulldozer will not update any pull requests.
+update:
+  # "trigger" defines the set of pull requests that should be updated by
+  # bulldozer. It accepts the same keys as the trigger in the "merge" block.
+  #
+  # HASURA NOTE: we definitely don't want to always update. auto-update
+  # (without merge) might be convenient and no harm adding it here.
+  trigger:
+    labels: ["auto-update-auto-merge", "auto-update"]
+
+  # "ignore" defines the set of pull requests that should not be updated by
+  # bulldozer. It accepts the same keys as the ignore in the "merge" block.
+  # ignore:
+  #   labels: ["Do Not Update"]


### PR DESCRIPTION
We still need to add the github app (as of time of opening this PR)

Afterwards devs should be able to allow bulldozer to automatically
"update" the branch, merging in parent when it changes, as well as
automatically merge when all checks pass.

This is opt-in by adding the `auto-update-auto-merge` label to the PR.

## To Review

*  look over bulldozer docs and verify config looks okay for us
* verify that only users who can merge PRs (after checks pass) can modify the labels on a PR