### PR TITLE
add userinfo to RO queries for use in views/RLS  fix #1848

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking change
 
-Headers from environment variables starting with `HASURA_GRAPHQL_` are not allowed  
+Headers from environment variables starting with `HASURA_GRAPHQL_` are not allowed
 in event triggers, actions & remote schemas.
 
 If you do have such headers configured, then you must update the header configuration before upgrading.
@@ -13,6 +13,7 @@ If you do have such headers configured, then you must update the header configur
 
 (Add entries here in the order of: server, console, cli, docs, others)
 
+- server: add userinfo to RO queries for use in views/RLS (partially fixes #1848)
 - server: fix failing introspection query when an enum column is part of a primary key (fixes #5200)
 - server: disallow headers from env variables starting with `HASURA_GRAPHQL_` in actions, event triggers & remote schemas (#5519)
 **WARNING**: This might break certain deployments. See `Breaking change` section above.

--- a/server/src-lib/Hasura/Db.hs
+++ b/server/src-lib/Hasura/Db.hs
@@ -199,11 +199,11 @@ withTraceContext
 withTraceContext ctx = \case
   LTErr e  -> LTErr e
   LTNoTx a -> LTNoTx a
-  LTTx tx  -> 
+  LTTx tx  ->
     let sql = Q.fromText $
-          "SET LOCAL \"hasura.tracecontext\" = " <> 
+          "SET LOCAL \"hasura.tracecontext\" = " <>
             toSQLTxt (S.SELit . J.encodeToStrictText . Tracing.injectEventContext $ ctx)
-        setTraceContext = 
+        setTraceContext =
           Q.unitQE defaultTxErrorHandler sql () False
      in LTTx $ setTraceContext >> tx
 

--- a/server/src-lib/Hasura/GraphQL/Transport/HTTP.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/HTTP.hs
@@ -171,7 +171,7 @@ runHasuraGQ reqId (query, queryParsed) userInfo resolvedOp = do
     E.ExOpQuery tx genSql asts -> trace "pg" $ do
       -- log the generated SQL and the graphql query
       logQueryLog logger query genSql reqId
-      Tracing.interpTraceT id $ executeQuery queryParsed asts genSql pgExecCtx Q.ReadOnly tx
+      Tracing.interpTraceT id $ executeQuery queryParsed asts genSql pgExecCtx Q.ReadOnly . withUserInfo userInfo tx
 
     E.ExOpMutation respHeaders tx -> trace "pg" $ do
       logQueryLog logger query Nothing reqId

--- a/server/src-lib/Hasura/GraphQL/Transport/HTTP.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/HTTP.hs
@@ -171,7 +171,8 @@ runHasuraGQ reqId (query, queryParsed) userInfo resolvedOp = do
     E.ExOpQuery tx genSql asts -> trace "pg" $ do
       -- log the generated SQL and the graphql query
       logQueryLog logger query genSql reqId
-      Tracing.interpTraceT id $ (executeQuery queryParsed asts genSql pgExecCtx Q.ReadOnly . withUserInfo userInfo) tx
+      ctx <- Tracing.currentContext
+      Tracing.interpTraceT id $ (executeQuery queryParsed asts genSql pgExecCtx Q.ReadOnly . withTraceContext ctx . withUserInfo userInfo) tx
 
     E.ExOpMutation respHeaders tx -> trace "pg" $ do
       logQueryLog logger query Nothing reqId

--- a/server/src-lib/Hasura/GraphQL/Transport/HTTP.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/HTTP.hs
@@ -171,7 +171,7 @@ runHasuraGQ reqId (query, queryParsed) userInfo resolvedOp = do
     E.ExOpQuery tx genSql asts -> trace "pg" $ do
       -- log the generated SQL and the graphql query
       logQueryLog logger query genSql reqId
-      Tracing.interpTraceT id $ executeQuery queryParsed asts genSql pgExecCtx Q.ReadOnly . withUserInfo userInfo tx
+      Tracing.interpTraceT id $ (executeQuery queryParsed asts genSql pgExecCtx Q.ReadOnly . withUserInfo userInfo) tx
 
     E.ExOpMutation respHeaders tx -> trace "pg" $ do
       logQueryLog logger query Nothing reqId

--- a/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
@@ -364,8 +364,9 @@ onStart env serverEnv wsConn (StartMsg opId q) = catchAndIgnore $ do
       -> ExceptT () m ()
     runHasuraGQ timerTot telemCacheHit reqId query queryParsed userInfo = \case
       E.ExOpQuery opTx genSql asts -> Tracing.trace "pg" $
+        ctx <- Tracing.currentContext
         execQueryOrMut Telem.Query genSql . fmap snd $
-          Tracing.interpTraceT id $ (executeQuery queryParsed asts genSql pgExecCtx Q.ReadOnly . withUserInfo userInfo) opTx
+          Tracing.interpTraceT id $ (executeQuery queryParsed asts genSql pgExecCtx Q.ReadOnly . withTraceContext ctx . withUserInfo userInfo) opTx
       -- Response headers discarded over websockets
       E.ExOpMutation _ opTx -> Tracing.trace "pg" do
         ctx <- Tracing.currentContext

--- a/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
@@ -365,7 +365,7 @@ onStart env serverEnv wsConn (StartMsg opId q) = catchAndIgnore $ do
     runHasuraGQ timerTot telemCacheHit reqId query queryParsed userInfo = \case
       E.ExOpQuery opTx genSql asts -> Tracing.trace "pg" $
         execQueryOrMut Telem.Query genSql . fmap snd $
-          Tracing.interpTraceT id $ executeQuery queryParsed asts genSql pgExecCtx Q.ReadOnly . withUserInfo userInfo opTx
+          Tracing.interpTraceT id $ (executeQuery queryParsed asts genSql pgExecCtx Q.ReadOnly . withUserInfo userInfo) opTx
       -- Response headers discarded over websockets
       E.ExOpMutation _ opTx -> Tracing.trace "pg" do
         ctx <- Tracing.currentContext

--- a/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
@@ -365,7 +365,7 @@ onStart env serverEnv wsConn (StartMsg opId q) = catchAndIgnore $ do
     runHasuraGQ timerTot telemCacheHit reqId query queryParsed userInfo = \case
       E.ExOpQuery opTx genSql asts -> Tracing.trace "pg" $
         execQueryOrMut Telem.Query genSql . fmap snd $
-          Tracing.interpTraceT id $ executeQuery queryParsed asts genSql pgExecCtx Q.ReadOnly opTx
+          Tracing.interpTraceT id $ executeQuery queryParsed asts genSql pgExecCtx Q.ReadOnly . withUserInfo userInfo opTx
       -- Response headers discarded over websockets
       E.ExOpMutation _ opTx -> Tracing.trace "pg" do
         ctx <- Tracing.currentContext

--- a/server/src-lib/Hasura/Server/Auth/JWT.hs
+++ b/server/src-lib/Hasura/Server/Auth/JWT.hs
@@ -234,7 +234,7 @@ updateJwkRef (Logger logger) manager url jwkRef = do
 -- When no 'x-hasura-user-role' is specified in the request, the mandatory
 -- 'x-hasura-default-role' [2] from the JWT claims will be used.
 
--- [1]: https://hasura.io/docs/1.0/graphql/manual/auth/authentication/unauthenticated-access.html 
+-- [1]: https://hasura.io/docs/1.0/graphql/manual/auth/authentication/unauthenticated-access.html
 -- [2]: https://hasura.io/docs/1.0/graphql/manual/auth/authentication/jwt.html#the-spec
 processJwt
   :: ( MonadIO m
@@ -282,6 +282,7 @@ processJwt_ processAuthZHeader_ jwtCtx headers mUnAuthRole =
       metadata <- parseJwtClaim (J.Object finalClaims) "x-hasura-* claims"
       userInfo <- mkUserInfo (URBPreDetermined requestedRole) UAdminSecretNotSent $
                   mkSessionVariablesText $ Map.toList metadata
+      -- userInfo
       pure (userInfo, expTimeM)
 
     withoutAuthZHeader = do
@@ -376,8 +377,8 @@ processAuthZHeader jwtCtx@JWTCtx{jcxClaimNs, jcxClaimsFormat} authzHeader = do
 -- parse x-hasura-allowed-roles, x-hasura-default-role from JWT claims
 parseHasuraClaims :: forall m. (MonadError QErr m) => J.Object -> m HasuraClaims
 parseHasuraClaims claimsMap = do
-  HasuraClaims <$> 
-    parseClaim allowedRolesClaim "should be a list of roles" <*> 
+  HasuraClaims <$>
+    parseClaim allowedRolesClaim "should be a list of roles" <*>
     parseClaim defaultRoleClaim  "should be a single role name"
 
   where


### PR DESCRIPTION
Adds userInfo (`hasura.user`) to Queries (already there for mutations) so that the Hasura Auth info can be used from SQL in RLS queries/Views.

partially fix #1848

### Description

Adds userInfo (`hasura.user`) to Queries (already there for mutations) so that the Hasura Auth info can be used from SQL in RLS queries/Views.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
#1848

### Steps to test and verify
- Set a RLS policy that accesses `current_setting('hasura.user', 't')::jsonb`
- There should be no JSON parsing exceptions thrown

### Limitations, known bugs & workarounds
This PR only allows access to the hasura session variables, it does not allow mapping from `x-hasura-role` to postgres db roles.


#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [ x ] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [ x ] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [ x ] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [ x ] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
