### PR TITLE
docs: add workshop video links

### DIFF
--- a/docs/graphql/manual/auth/authorization/index.rst
+++ b/docs/graphql/manual/auth/authorization/index.rst
@@ -57,3 +57,9 @@ Follow the example at :ref:`access control basics <auth_basics>`.
   permission-rules
   common-roles-auth-examples
   role-multiple-rules
+
+
+Additional resources
+--------------------
+
+**Enterprise-grade GraphQL authorization workshop:** Learn how to connect your auth systems to Hasura and how to implement any kind of authorization: rules, roles, tags, hierarchies, attribute based systems. `Watch workshop -> <https://us02web.zoom.us/webinar/register/WN_LKQGoU24RXGJEEDfvnE_sA>`__

--- a/docs/graphql/manual/getting-started/index.rst
+++ b/docs/graphql/manual/getting-started/index.rst
@@ -52,4 +52,3 @@ Get started using an existing database
    Using an existing database <using-existing-database>
    first-graphql-query
    first-event-trigger
-

--- a/docs/graphql/manual/schema/remote-relationships/index.rst
+++ b/docs/graphql/manual/schema/remote-relationships/index.rst
@@ -35,6 +35,11 @@ Hasura's remote joins architecture provides the following benefits.
 
 - **Data federation**: With remote joins, the join, authorization, and consistency checks of added sources all happen at the Hasura layer via metadata. This allows underlying data sources and APIs to evolve independently. Your applications have a unified API to query the full data landscape in your org.
 
+Additional resources
+--------------------
+
+**Data federation webinar:** Join data across your databases, microservices & SaaS services (GraphQL & REST) with Hasura. `Watch webinar -> <https://us02web.zoom.us/rec/play/7JR4JLyqqm43TNKctwSDA_Z9W464e6OsgSRN_fsPzkrmUSUHO1L0b7cWr1EpRAtxfyHyWMRdgGIh-g?continueMode=true>`__
+
 .. toctree::
   :maxdepth: 1
   :hidden:


### PR DESCRIPTION
### Description

On growth team's request.

This PR adds video links for:
- Authorization workshop
- Data federation webinar

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components

- [x] Docs

### Affected pages

- https://deploy-preview-5577--hasura-docs.netlify.app/graphql/manual/schema/remote-relationships/index.html#additional-resources
- https://deploy-preview-5577--hasura-docs.netlify.app/graphql/manual/auth/authorization/index.html#additional-resources

### To discuss

We are also supposed to add a link for [this workshop](https://hasura.io/events/hasura-con-2020/architecting-domain-driven-graphql-apps/). In this workshop, we build a Hasura app with basic authorization and Hasura features (actions, remote schemas, remote joins). Not sure where to put it. Can't add timestamps on a Zoom recording, so can't plug it in the feature pages. Was thinking of adding it to "Getting started" but it seems too advanced. Guides would be another option. @rikinsk what are your thoughts?