### PR TITLE
WIP: PG span improvements (close #465)

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Transport/HTTP.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/HTTP.hs
@@ -168,15 +168,18 @@ runHasuraGQ
 runHasuraGQ reqId (query, queryParsed) userInfo resolvedOp = do
   (E.ExecutionCtx logger _ pgExecCtx _ _ _ _ _) <- ask
   (telemTimeIO, respE) <- withElapsedTime $ runExceptT $ case resolvedOp of
-    E.ExOpQuery tx genSql asts -> trace "Fetch data" $ do
+    E.ExOpQuery tx genSql asts -> do
       -- log the generated SQL and the graphql query
       logQueryLog logger query genSql reqId
-      Tracing.interpTraceT id $ executeQuery queryParsed asts genSql pgExecCtx Q.ReadOnly tx
+      trace "Postgres" $
+        Tracing.interpTraceT id $ executeQuery queryParsed asts genSql pgExecCtx Q.ReadOnly tx
 
     E.ExOpMutation respHeaders tx -> trace "Fetch data" $ do
       logQueryLog logger query Nothing reqId
       ctx <- Tracing.currentContext
-      (respHeaders,) <$> Tracing.interpTraceT (runLazyTx pgExecCtx Q.ReadWrite . withTraceContext ctx . withUserInfo userInfo) tx
+      (respHeaders,) <$>
+        trace "Postgres" do
+          Tracing.interpTraceT (runLazyTx pgExecCtx Q.ReadWrite . withTraceContext ctx . withUserInfo userInfo) tx
 
     E.ExOpSubs _ ->
       throw400 UnexpectedPayload

--- a/server/src-lib/Hasura/GraphQL/Transport/HTTP.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/HTTP.hs
@@ -168,12 +168,12 @@ runHasuraGQ
 runHasuraGQ reqId (query, queryParsed) userInfo resolvedOp = do
   (E.ExecutionCtx logger _ pgExecCtx _ _ _ _ _) <- ask
   (telemTimeIO, respE) <- withElapsedTime $ runExceptT $ case resolvedOp of
-    E.ExOpQuery tx genSql asts -> trace "pg" $ do
+    E.ExOpQuery tx genSql asts -> trace "Fetch data" $ do
       -- log the generated SQL and the graphql query
       logQueryLog logger query genSql reqId
       Tracing.interpTraceT id $ executeQuery queryParsed asts genSql pgExecCtx Q.ReadOnly tx
 
-    E.ExOpMutation respHeaders tx -> trace "pg" $ do
+    E.ExOpMutation respHeaders tx -> trace "Fetch data" $ do
       logQueryLog logger query Nothing reqId
       ctx <- Tracing.currentContext
       (respHeaders,) <$> Tracing.interpTraceT (runLazyTx pgExecCtx Q.ReadWrite . withTraceContext ctx . withUserInfo userInfo) tx

--- a/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
@@ -363,11 +363,11 @@ onStart env serverEnv wsConn (StartMsg opId q) = catchAndIgnore $ do
       -> E.ExecOp (Tracing.TraceT (LazyTx QErr))
       -> ExceptT () m ()
     runHasuraGQ timerTot telemCacheHit reqId query queryParsed userInfo = \case
-      E.ExOpQuery opTx genSql asts -> Tracing.trace "pg" $
+      E.ExOpQuery opTx genSql asts -> Tracing.trace "Fetch data" $
         execQueryOrMut Telem.Query genSql . fmap snd $
           Tracing.interpTraceT id $ executeQuery queryParsed asts genSql pgExecCtx Q.ReadOnly opTx
       -- Response headers discarded over websockets
-      E.ExOpMutation _ opTx -> Tracing.trace "pg" do
+      E.ExOpMutation _ opTx -> Tracing.trace "Fetch data" do
         ctx <- Tracing.currentContext
         execQueryOrMut Telem.Mutation Nothing $
           Tracing.interpTraceT (runLazyTx pgExecCtx Q.ReadWrite . withTraceContext ctx . withUserInfo userInfo) opTx


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

Co-Authored with @evertedsphere 


### Description

Refining the tracing identifiers and adding granuality to postgres queries.

Renaming "pg" trace to "Fetch data".

Adding "Postgres" trace to direct Postgres query calls.


### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.


### Affected components

<!-- Remove non-affected components from the list -->

- [x] Server

### Related Issues

Issue that caused this PR: https://github.com/hasura/graphql-engine-pro/issues/465

### Solution and Design

Renaming trace IDs and adding trace calls for Postgres queries.

### Steps to test and verify

Run Multitenant and make queries. Check that logs include trace output.

TODO: Make sure that this can be tested from Pro directly.


### Server checklist

* Ensure that anything consuming trace spans 

#### Catalog upgrade

Does this PR change Hasura Catalog version?

- [x] No

#### Metadata

Does this PR add a new Metadata feature?

- [x] No

#### GraphQL

- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No Breaking changes

