### PR TITLE
Fix stringified JSON for the prepared_argument in query_log

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Execute/Query.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/Query.hs
@@ -281,7 +281,7 @@ data PreparedSql
 instance J.ToJSON PreparedSql where
   toJSON (PreparedSql q prepArgs _) =
     J.object [ "query" J..= Q.getQueryText q
-             , "prepared_arguments" J..= map (txtEncodedPGVal . snd) prepArgs
+             , "prepared_arguments" J..= map (pgScalarValueToJson . snd) prepArgs
              ]
 
 -- | Intermediate reperesentation of a computed SQL statement and prepared


### PR DESCRIPTION
Fix strigified JSON for the `prepared_argument` in `query_log`

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description

The `prepared_argument` in the `query_log` gets outputted as a string instead of a JSON value.

The current output for `query_log` looks like
```json
  "type": "query-log",
      "test_query": {
        "prepared_arguments":["{\"x-hasura-role\":\"admin\"}","1"]
       }
```

This PR fixes it to look like:
```json

  "type": "query-log",
      "test_query": {
        "prepared_arguments": [
          {
            "x-hasura-role": "admin"
          },
          3
        ]
```

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server

### Related Issues
https://github.com/hasura/graphql-engine/issues/5582

### Solution and Design
 Fix the `toJson` instance of `PreparedSql` to use `pgScalarValueToJson` instead of `txtEncodedPGVal

### Steps to test and verify

Run the `graphql-engine` using the following command:
``` bash
cabal run  -v0 -- exe:graphql-engine \             
  --database-url=<postgres_url> \
  serve --enable-console --console-assets-dir=../console/static/dist --enabled-log-types="startup,http-log,query-log,websocket-log,webhook-log"\
 --log-level debug| jq --unbuffered 'select(.type=="query-log")'
```

In the GraphiQL:

Query Type:
```
query($id: Int!) {
  test(where: {id: {_eq: $id}}) {
    id
    name
  }
}
```

Variables:
```
{
  "id": 1
}

```

