### PR TITLE
console: remove postinstall script from package.json

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -19,7 +19,6 @@
     "build": "webpack --progress -p --colors --display-error-details --config webpack/prod.config.js",
     "server-build": "make server-build",
     "build-unused": "webpack --verbose --colors --display-error-details --config webpack/prod.config.js --json | webpack-unused -s src",
-    "postinstall": "webpack --display-error-details --config webpack/prod.config.js",
     "cypress": "cypress open",
     "test": "cypress run --spec 'cypress/integration/**/**/test.ts' --key $CYPRESS_KEY --parallel --record",
     "lint": "eslint -c .eslintrc src --ext .js,.ts,.tsx",


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
There is this postinstall script that just shows if there are any errors in the bundle. In most cases there are no errors, so it just wastes 30ish seconds. In case of errors, the following script (`npm run dev` or `npm run build`) will throw an error anyway, so this script is unnecessary.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)
