### PR TITLE
console: misc fixes (#5600, #5598, #5515)

### DIFF
--- a/console/src/components/Services/Data/RawSQL/Actions.js
+++ b/console/src/components/Services/Data/RawSQL/Actions.js
@@ -42,6 +42,7 @@ const executeSQL = (isMigration, migrationName, statementTimeout) => (
 
   const { isTableTrackChecked, isCascadeChecked, sql } = getState().rawSQL;
   const { migrationMode, readOnlyMode } = getState().main;
+  const isStatementTimeout = statementTimeout && !isMigration;
 
   const migrateUrl = returnMigrateUrl(migrationMode);
 
@@ -49,7 +50,7 @@ const executeSQL = (isMigration, migrationName, statementTimeout) => (
 
   const schemaChangesUp = [];
 
-  if (statementTimeout && !isMigration) {
+  if (isStatementTimeout) {
     schemaChangesUp.push(
       getRunSqlQuery(
         getStatementTimeoutSql(statementTimeout),
@@ -111,7 +112,10 @@ const executeSQL = (isMigration, migrationName, statementTimeout) => (
         }
         dispatch(showSuccessNotification('SQL executed!'));
         dispatch(fetchDataInit()).then(() => {
-          dispatch({ type: REQUEST_SUCCESS, data });
+          dispatch({
+            type: REQUEST_SUCCESS,
+            data: data && (isStatementTimeout ? data[1] : data[0]),
+          });
         });
         dispatch(fetchTrackedFunctions());
       },
@@ -168,11 +172,7 @@ const rawSQLReducer = (state = defaultState, action) => {
         lastSuccess: null,
       };
     case REQUEST_SUCCESS:
-      if (
-        action.data &&
-        action.data[0] &&
-        action.data[0].result_type === 'CommandOk'
-      ) {
+      if (action.data && action.data.result_type === 'CommandOk') {
         return {
           ...state,
           ongoingRequest: false,
@@ -188,8 +188,8 @@ const rawSQLReducer = (state = defaultState, action) => {
         lastError: null,
         lastSuccess: true,
         resultType: 'tuples',
-        result: action.data[0].result.slice(1),
-        resultHeaders: action.data[0].result[0],
+        result: action.data.result.slice(1),
+        resultHeaders: action.data.result[0],
       };
     case REQUEST_ERROR:
       return {

--- a/console/src/components/Services/Data/TablePermissions/Permissions.js
+++ b/console/src/components/Services/Data/TablePermissions/Permissions.js
@@ -1766,7 +1766,7 @@ class Permissions extends Component {
               'Backend only',
               tooltip,
               backendStatus,
-              'https://docs.hasura.io/1.0/graphql/manual/auth/authorization/permission-rules.html#backend-only-inserts'
+              'https://hasura.io/docs/1.0/graphql/manual/auth/authorization/permission-rules.html#backend-only'
             )}
             useDefaultTitleStyle
             testId={'toggle-backend-only'}

--- a/console/src/components/Services/Events/Common/Components/RedeliverEvent.tsx
+++ b/console/src/components/Services/Events/Common/Components/RedeliverEvent.tsx
@@ -111,6 +111,7 @@ const RedeliverEvent: React.FC<Props> = ({ dispatch, eventId }) => {
             resizable
             manual
             showPagination={false}
+            freezeWhenExpanded
             SubComponent={(logRow: any) => {
               const finalIndex = logRow.index;
               const finalRow = logs[finalIndex];


### PR DESCRIPTION
### Description

1. Fix handling separated sql and statement timeout: https://github.com/hasura/graphql-engine/pull/5600
2. Fix broken link in permissions section: https://github.com/hasura/graphql-engine/pull/5598
3. Fix folding of invocation information in redeliver event modal (close #5515): https://github.com/hasura/graphql-engine/pull/5559

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components

- [x] Console
