### PR TITLE
WIP: Generic instances required for downstream FromJSON instances

### DIFF
--- a/server/src-lib/Hasura/Logging.hs
+++ b/server/src-lib/Hasura/Logging.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DerivingStrategies #-}
 
 module Hasura.Logging
   ( LoggerSettings(..)
@@ -48,6 +49,7 @@ import qualified System.Log.FastLogger      as FL
 newtype FormattedTime
   = FormattedTime { _unFormattedTime :: Text }
   deriving (Show, Eq, J.ToJSON)
+  deriving Generic
 
 -- | Typeclass representing any type which can be parsed into a list of enabled log types, and has a @Set@
 -- of default enabled log types, and can find out if a log type is enabled

--- a/server/src-lib/Hasura/Server/Auth.hs
+++ b/server/src-lib/Hasura/Server/Auth.hs
@@ -72,6 +72,7 @@ class (Monad m) => UserAuthentication m where
 --
 newtype AdminSecretHash = AdminSecretHash (Crypto.Digest Crypto.SHA512)
   deriving (Ord, Eq)
+  deriving Generic
 
 -- We don't want to be able to leak the secret hash. This is a dummy instance
 -- to support 'Show AuthMode' which we want for testing.

--- a/server/src-lib/Hasura/Server/Auth/WebHook.hs
+++ b/server/src-lib/Hasura/Server/Auth/WebHook.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveAnyClass #-}
+
 module Hasura.Server.Auth.WebHook
   ( AuthHookType(..)
   , AuthHookG (..)
@@ -36,17 +38,19 @@ data AuthHookType
   = AHTGet
   | AHTPost
   deriving (Eq)
+  deriving Generic
 
 instance Show AuthHookType where
   show AHTGet  = "GET"
   show AHTPost = "POST"
 
-
 data AuthHookG a b
   = AuthHookG
   { ahUrl  :: !a
   , ahType :: !b
-  } deriving (Show, Eq)
+  }
+  deriving (Show, Eq)
+  deriving Generic
 
 type AuthHook = AuthHookG T.Text AuthHookType
 

--- a/server/src-lib/Hasura/Server/Init/Config.hs
+++ b/server/src-lib/Hasura/Server/Init/Config.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE UndecidableInstances #-}
+
 -- | Types and classes related to configuration when the server is initialised
 module Hasura.Server.Init.Config where
 
@@ -33,6 +35,7 @@ data RawConnParams
   -- choose a different/new one.
   , rcpAllowPrepare :: !(Maybe Bool)
   } deriving (Show, Eq)
+  deriving Generic
 
 type RawAuthHook = AuthHookG (Maybe T.Text) (Maybe AuthHookType)
 
@@ -65,6 +68,7 @@ data RawServeOptions impl
   , rsoEventsFetchInterval :: !(Maybe Milliseconds)
   , rsoLogHeadersFromEnv   :: !Bool
   }
+  deriving Generic
 
 -- | @'ResponseInternalErrorsConfig' represents the encoding of the internal
 -- errors in the response to the client.


### PR DESCRIPTION

### Description

Addition of Generic instances for datatypes that are used downstream that require Generic constraints to implement FromJSON, etc.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components

- [x] Server

### Related Issues

TODO

<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design

Addition of Generic instances to 

* FormattedTime
* AdminSecretHash -- TODO: Review if this should be explicitly prohibited
* AuthHookG
* RawConnParams
* RawServeOptions

### Steps to test and verify

N/A

### Limitations, known bugs & workarounds

None.

### Server checklist

* Build the server and check that it compiles without errors

#### Catalog upgrade

Does this PR change Hasura Catalog version?
- [x] No

#### Metadata

Does this PR add a new Metadata feature?
- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No Breaking changes

