### PR TITLE
track graphql paths, tables, etc. responsible for trace messages in the metadata

### DIFF
--- a/server/src-exec/Main.hs
+++ b/server/src-exec/Main.hs
@@ -26,6 +26,7 @@ import qualified System.Posix.Signals       as Signals
 import qualified System.Metrics             as EKG
 
 
+
 main :: IO ()
 main = do
   tryExit $ do

--- a/server/src-lib/Hasura/GraphQL/Execute.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute.hs
@@ -338,6 +338,6 @@ execRemoteGQ env reqId userInfo reqHdrs q rsi opDef = do
       manager = _ecxHttpManager execCtx
       opType  = G._todType opDef
   logQueryLog logger q Nothing reqId
-  (time, respHdrs, resp) <- execRemoteGQ' env manager userInfo reqHdrs q rsi opType
+  (time, respHdrs, resp) <- execRemoteGQ' env manager userInfo reqHdrs q rsi opType []
   let !httpResp = HttpResponse (encJFromLBS resp) respHdrs
   return (time, httpResp)

--- a/server/src-lib/Hasura/RQL/Types/Common.hs
+++ b/server/src-lib/Hasura/RQL/Types/Common.hs
@@ -41,6 +41,8 @@ module Hasura.RQL.Types.Common
        , InputWebhook(..)
        , ResolvedWebhook(..)
        , resolveWebhook
+
+       , FieldPath(..)
        ) where
 
 import           Hasura.EncJSON
@@ -310,3 +312,7 @@ resolveWebhook env (InputWebhook urlTemplate) = do
   let eitherRenderedTemplate = renderURLTemplate env urlTemplate
   either (throw400 Unexpected . T.pack)
     (pure . ResolvedWebhook) eitherRenderedTemplate
+
+-- | Path to a remote join field in e.g. query response JSON from Postgres.
+newtype FieldPath = FieldPath {unFieldPath :: [FieldName]}
+  deriving (Show, Eq, Semigroup, Monoid, Hashable)


### PR DESCRIPTION
currently this adds a `field_paths` metadata field to remote joins, which shows which gql paths triggered a request to a remote api

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components

- [ ] Server

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [ ] No

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [ ] No

#### GraphQL
- [ ] No new GraphQL schema is generated

#### Breaking changes

- [ ] No Breaking changes