### PR TITLE
Introduce `safeSelectionSet` to prevent conflicts in root fields

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Parser.hs
+++ b/server/src-lib/Hasura/GraphQL/Parser.hs
@@ -21,6 +21,7 @@ module Hasura.GraphQL.Parser
   , list
   , object
   , selectionSet
+  , safeSelectionSet
   , selectionSetObject
 
   , InputFieldsParser

--- a/server/src-lib/Hasura/GraphQL/Parser/Internal/Parser.hs
+++ b/server/src-lib/Hasura/GraphQL/Parser/Internal/Parser.hs
@@ -13,7 +13,7 @@ import qualified Data.HashMap.Strict.Extended  as M
 import qualified Data.HashMap.Strict.InsOrd    as OMap
 import qualified Data.HashSet                  as S
 import qualified Data.Text                     as T
-import qualified Data.List.Extended                     as LE
+import qualified Data.List.Extended            as LE
 
 import           Control.Lens.Extended         hiding (enum, index)
 import           Data.Int                      (Int32, Int64)

--- a/server/src-lib/Hasura/GraphQL/Schema.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema.hs
@@ -152,9 +152,9 @@ buildGQLContext =
               ) |) [] (Map.toList allRemoteSchemas)
 
     let unauthenticatedContext :: m GQLContext
-        unauthenticatedContext = do
-          ucQueries   <- P.runSchemaT $ finalizeParser <$> unauthenticatedQueryWithIntrospection queryRemotes mutationRemotes
-          ucMutations <- P.runSchemaT $ fmap finalizeParser <$> unauthenticatedMutation mutationRemotes
+        unauthenticatedContext = P.runSchemaT do
+          ucQueries   <- finalizeParser <$> unauthenticatedQueryWithIntrospection queryRemotes mutationRemotes
+          ucMutations <- fmap finalizeParser <$> unauthenticatedMutation mutationRemotes
           pure $ GQLContext ucQueries ucMutations
 
         -- | The 'query' type of the remotes. TODO: also expose mutation

--- a/server/tests-py/queries/schema/duplication/create_action_and_track_table_fail.yaml
+++ b/server/tests-py/queries/schema/duplication/create_action_and_track_table_fail.yaml
@@ -1,0 +1,49 @@
+- description: Create custom object type for action return type
+  url: /v1/query
+  status: 200
+  query:
+    type: set_custom_types
+    args:
+      objects:
+      - name: UserId
+        fields:
+          - name: id
+            type: Int!
+
+- description: Create an action
+  url: /v1/query
+  status: 200
+  query:
+    type: create_action
+    args:
+      name: insert_user
+      definition:
+        kind: synchronous
+        arguments:
+        - name: email
+          type: Int!
+        - name: name
+          type: String!
+        output_type: UserId!
+        handler: http://127.0.0.1:5593/create-user
+
+- description: Track the table
+  url: /v1/query
+  status: 500
+  response:
+    path: "$.args"
+    code: unexpected
+    error: "found duplicate fields in selection set: insert_user"
+  query:
+    type: track_table
+    args:
+      table: user
+
+- description: Drop the custom types and action
+  url: /v1/query
+  status: 200
+  query:
+    type: drop_action
+    args:
+      name: insert_user
+      clear_data: true

--- a/server/tests-py/queries/schema/duplication/setup.yaml
+++ b/server/tests-py/queries/schema/duplication/setup.yaml
@@ -1,0 +1,13 @@
+type: run_sql
+args:
+  sql: |
+    CREATE TABLE "user" (
+      id serial primary key,
+      email text,
+      name text
+    );
+    CREATE TABLE users (
+       id serial primary key,
+       email text,
+       name text
+    );

--- a/server/tests-py/queries/schema/duplication/teardown.yaml
+++ b/server/tests-py/queries/schema/duplication/teardown.yaml
@@ -1,0 +1,10 @@
+type: bulk
+args:
+- type: set_custom_types
+  args: {}
+- type: run_sql
+  args:
+    cascade: true
+    sql: |
+      DROP TABLE "user";
+      DROP TABLE users;

--- a/server/tests-py/queries/schema/duplication/track_table_and_create_action_fail.yaml
+++ b/server/tests-py/queries/schema/duplication/track_table_and_create_action_fail.yaml
@@ -1,0 +1,44 @@
+- description: Track the "user" table
+  url: /v1/query
+  status: 200
+  response:
+    message: success
+  query:
+    type: track_table
+    args:
+      table: user
+
+- description: Create custom object type for action return type
+  url: /v1/query
+  status: 200
+  response:
+    message: success
+  query:
+    type: set_custom_types
+    args:
+      objects:
+        - name: UserId
+          fields:
+            - name: id
+              type: Int!
+
+- description: Create an action with a same name with a mutation that's created by tracking "user" table
+  url: /v1/query
+  status: 500
+  response:
+    path: "$.args"
+    code: unexpected
+    error: "found duplicate fields in selection set: insert_user"
+  query:
+    type: create_action
+    args:
+      name: insert_user
+      definition:
+        kind: synchronous
+        arguments:
+        - name: email
+          type: Int!
+        - name: name
+          type: String!
+        output_type: UserId!
+        handler: http://127.0.0.1:5593/create-user

--- a/server/tests-py/queries/schema/duplication/track_table_with_conflicting_custom_root_node_names_fail.yaml
+++ b/server/tests-py/queries/schema/duplication/track_table_with_conflicting_custom_root_node_names_fail.yaml
@@ -1,0 +1,25 @@
+- description: Track the "user" table
+  url: /v1/query
+  status: 200
+  response:
+    message: success
+  query:
+    type: track_table
+    args:
+      table: user
+
+- description: Track the users table with conflicting custom root level node names
+  url: /v1/query
+  status: 500
+  response:
+    path: $.args
+    code: unexpected
+    error: "found duplicate fields in selection set: user"
+  query:
+    type: track_table
+    version: 2
+    args:
+      table: users
+      configuration:
+        custom_root_fields:
+          select_by_pk: user

--- a/server/tests-py/test_schema_duplication.py
+++ b/server/tests-py/test_schema_duplication.py
@@ -1,0 +1,20 @@
+#!/usrbin/env python3
+
+import pytest
+from validate import check_query_f
+
+@pytest.mark.usefixtures('per_method_tests_db_state')
+class TestSchemaDuplication:
+
+    @classmethod
+    def dir(cls):
+        return "queries/schema/duplication/"
+
+    def test_create_action_followed_by_track_table(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + "create_action_and_track_table_fail.yaml")
+
+    def test_track_table_followed_by_create_action(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + "track_table_and_create_action_fail.yaml")
+
+    def test_track_table_with_conflicting_custom_root_node_names(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + 'track_table_with_conflicting_custom_root_node_names_fail.yaml')


### PR DESCRIPTION
### Description
We recently found an oversight of selection sets: we don't check for duplicates. In the unlikely (but, as evidenced, not impossible) case where we don't prevent a conflict from arising, said conflict should be detected when we build the schema. And in turns out that in some degenerate cases, we would **construct a schema without detecting the conflict** (specifically: when the conflicting root fields would yield types with the exact same fields, that therefore can't be differentiated).

(See discussion with @codingkarthik on Slack for more info, the test case, and the context.)

### Affected components

- [ ] Server

### Solution and Design
This is a very simple fix, that only fixes the problem for root fields. There are two other ways we could prevent this from happening:
  - make all combinators monadic and throw on invalid schema (bad, no)
  - make all combinators require a hashmap of field parsers, to delegate the responsibility of checking for duplicates to the callers (better, but perhaps overkill)
