### PR TITLE
cli: support file paths for metadata diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - docs: add docs page on networking with docker (close #4346) (#4811)
 - cli: add missing global flags for seeds command (#5565)
+- cli: update `hasura metadata diff` to accept filepaths (close #5433) (#)
 
 ## `v1.3.1-beta.1`
 

--- a/cli/commands/metadata_diff.go
+++ b/cli/commands/metadata_diff.go
@@ -48,7 +48,10 @@ By default, shows changes between exported metadata file and server metadata.`,
   hasura metadata diff local_metadata.yaml
 
   # Show changes between metadata from metadata.yaml and metadata_old.yaml:
-  hasura metadata diff metadata.yaml metadata_old.yaml
+	hasura metadata diff metadata.yaml metadata_old.yaml
+	
+	# Show changes among multiple metadata folders (v2 config only)
+	hasura metadata diff metadata1 metadata2
 
   # Apply admin secret for Hasura GraphQL Engine:
   hasura metadata diff --admin-secret "<admin-secret>"
@@ -66,7 +69,7 @@ By default, shows changes between exported metadata file and server metadata.`,
 }
 
 func (o *MetadataDiffOptions) runv2(args []string) error {
-	messageFormat := "Showing diff between %s and %s..."
+	messageFormat := "Showing diff between %s directory and %s..."
 	message := ""
 
 	switch len(args) {
@@ -92,7 +95,11 @@ func (o *MetadataDiffOptions) runv2(args []string) error {
 			return err
 		}
 		o.Metadata[1] = args[1]
-		message = fmt.Sprintf(messageFormat, o.Metadata[0], o.Metadata[1])
+		if args[0] == args[1] {
+			return errors.New("directories passed are the same")
+		}
+		messageEnd := fmt.Sprintf("the %s directory", o.Metadata[1])
+		message = fmt.Sprintf(messageFormat, o.Metadata[0], messageEnd)
 	}
 	o.EC.Logger.Info(message)
 	var oldYaml, newYaml []byte
@@ -249,7 +256,7 @@ func checkDir(path string) error {
 		return err
 	}
 	if !file.IsDir() {
-		return fmt.Errorf("metadata diff only works with folder but got file %s", path)
+		return fmt.Errorf("metadata diff only works with folders but got file %s", path)
 	}
 	return nil
 }

--- a/cli/commands/metadata_diff.go
+++ b/cli/commands/metadata_diff.go
@@ -47,7 +47,7 @@ By default, shows changes between exported metadata file and server metadata.`,
   # Show changes between server metadata and that in local_metadata.yaml:
   hasura metadata diff local_metadata.yaml
 
-  # Show changes between metadata from metadata.yaml and metadata_old.yaml:
+	# Show changes between metadata from metadata.yaml and metadata_old.yaml:
 	hasura metadata diff metadata.yaml metadata_old.yaml
 	
 	# Show changes among multiple metadata folders (v2 config only)
@@ -217,6 +217,7 @@ func (o *MetadataDiffOptions) Run() error {
 	return o.runv1(o.Args)
 }
 
+// Move to using myers diffing algo
 func printDiff(before, after string, to io.Writer, logger *logrus.Logger) {
 	diffs := difflib.Diff(strings.Split(before, "\n"), strings.Split(after, "\n"))
 
@@ -259,7 +260,7 @@ func checkDir(path string) error {
 		return err
 	}
 	if !file.IsDir() {
-		return fmt.Errorf("metadata diff only works with folders but got file %s", path)
+		return fmt.Errorf("metadata diff only works with directories but got file %s", path)
 	}
 	return nil
 }

--- a/cli/commands/metadata_diff.go
+++ b/cli/commands/metadata_diff.go
@@ -225,6 +225,8 @@ func printDiff(before, after string, to io.Writer, logger *logrus.Logger) {
 	}
 
 	if isThereADiff {
+		logger.Info("displaying diff...")
+		fmt.Fprintf(to, "\n")
 		for _, diff := range diffs {
 			text := diff.Payload
 
@@ -238,7 +240,7 @@ func printDiff(before, after string, to io.Writer, logger *logrus.Logger) {
 		return
 	}
 
-	logger.Infoln("no diff")
+	logger.Info("no diff")
 }
 
 func checkDir(path string) error {

--- a/cli/commands/metadata_diff.go
+++ b/cli/commands/metadata_diff.go
@@ -253,6 +253,9 @@ func printDiff(before, after string, to io.Writer, logger *logrus.Logger) {
 func checkDir(path string) error {
 	file, err := os.Stat(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("this directory does not exist")
+		}
 		return err
 	}
 	if !file.IsDir() {

--- a/cli/migrate/database/hasuradb/types.go
+++ b/cli/migrate/database/hasuradb/types.go
@@ -313,10 +313,10 @@ func (mderror *InconsistentMetadataError) String() string {
 }
 
 type SQLInternalError struct {
-	Arguments                 []string      `json:"arguments" mapstructure:"arguments,omitempty"`
+	Arguments                 []string       `json:"arguments" mapstructure:"arguments,omitempty"`
 	Error                     *PostgresError `json:"error" mapstructure:"error,omitempty"`
-	Prepared                  bool          `json:"prepared" mapstructure:"prepared,omitempty"`
-	Statement                 string        `json:"statement" mapstructure:"statement,omitempty"`
+	Prepared                  bool           `json:"prepared" mapstructure:"prepared,omitempty"`
+	Statement                 string         `json:"statement" mapstructure:"statement,omitempty"`
 	InconsistentMetadataError `mapstructure:",squash"`
 }
 type PostgresError struct {

--- a/cli/migrate/database/hasuradb/types_test.go
+++ b/cli/migrate/database/hasuradb/types_test.go
@@ -88,7 +88,7 @@ func TestInconsistentMetadataError_String(t *testing.T) {
 			"can generate error correctly when all fields are given",
 			fields{
 				Reason: "test reason",
-				Type: "test",
+				Type:   "test",
 				Definition: func() interface{} {
 					var m interface{}
 					err := json.Unmarshal([]byte(`{"test": "test"}`), &m)
@@ -112,8 +112,8 @@ definition:
 				Definition: func() interface{} {
 					return "test"
 				}(),
-				Reason:     "",
-				Type:       "",
+				Reason: "",
+				Type:   "",
 			},
 			`definition: 
 "test"`,
@@ -124,8 +124,8 @@ definition:
 				Definition: func() interface{} {
 					return 1
 				}(),
-				Reason:     "",
-				Type:       "",
+				Reason: "",
+				Type:   "",
 			},
 			`definition: 
 1`,
@@ -134,10 +134,10 @@ definition:
 			"will not panic when Definition is (struct Array)",
 			fields{
 				Definition: func() interface{} {
-					return []struct{Name string}{ { "test" } , { "test"} }
+					return []struct{ Name string }{{"test"}, {"test"}}
 				}(),
-				Reason:     "",
-				Type:       "",
+				Reason: "",
+				Type:   "",
 			},
 			`definition: 
 [

--- a/cli/migrate/migrate.go
+++ b/cli/migrate/migrate.go
@@ -1850,7 +1850,7 @@ func (m *Migrate) ExportDataDump(tableNames []string) ([]byte, error) {
 	// to support tables starting with capital letters
 	modifiedTableNames := make([]string, len(tableNames))
 	for idx, val := range tableNames {
-		modifiedTableNames[idx] = fmt.Sprintf(`"%s"`, val) 
+		modifiedTableNames[idx] = fmt.Sprintf(`"%s"`, val)
 	}
 	return m.databaseDrv.ExportDataDump(modifiedTableNames)
 }

--- a/cli/update/update.go
+++ b/cli/update/update.go
@@ -39,7 +39,7 @@ func getLatestVersion() (*semver.Version, *semver.Version, error) {
 		return nil, nil, errors.Wrap(err, "decoding update check response")
 	}
 	if response.Latest == nil && response.PreRelease == nil {
-		return nil,nil, fmt.Errorf("expected version info not found at %s", updateCheckURL)
+		return nil, nil, fmt.Errorf("expected version info not found at %s", updateCheckURL)
 	}
 
 	return response.Latest, response.PreRelease, nil


### PR DESCRIPTION
resolves #5433 

### Description

This PR adds support for file paths on the `metadata diff` command. Also resolves this comment from https://github.com/hasura/graphql-engine-internal/issues/479#issuecomment-664119245

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components

- [x] CLI
