### PR TITLE
Add run as user/group to docker images (close #4651 #3824)

### DIFF
--- a/install-manifests/kubernetes/deployment.yaml
+++ b/install-manifests/kubernetes/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       labels:
         app: hasura
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
       containers:
       - image: hasura/graphql-engine:v1.3.1
         imagePullPolicy: IfNotPresent

--- a/scripts/cli-migrations/v1/Dockerfile
+++ b/scripts/cli-migrations/v1/Dockerfile
@@ -7,7 +7,11 @@ ENV HASURA_GRAPHQL_SHOW_UPDATE_NOTIFICATION=false
 
 COPY docker-entrypoint.sh /bin/
 COPY cli-hasura-linux-amd64 /bin/hasura-cli
-RUN chmod +x /bin/hasura-cli
+RUN chmod +x /bin/hasura-cli\
+    && addgroup -g 1000 hasura \
+    && adduser -u 1000 -s /bin/sh -S -G hasura hasura
+
+USER 1000
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/scripts/cli-migrations/v1/docker-entrypoint.sh
+++ b/scripts/cli-migrations/v1/docker-entrypoint.sh
@@ -70,7 +70,7 @@ fi
 if [ -d "$HASURA_GRAPHQL_MIGRATIONS_DIR" ]; then
     log "migrations-apply" "applying migrations from $HASURA_GRAPHQL_MIGRATIONS_DIR"
     mkdir -p "$TEMP_MIGRATIONS_DIR"
-    cp -a "$HASURA_GRAPHQL_MIGRATIONS_DIR/." "$TEMP_MIGRATIONS_DIR/migrations/"
+    cp -dR "$HASURA_GRAPHQL_MIGRATIONS_DIR/." "$TEMP_MIGRATIONS_DIR/migrations/"
     cd "$TEMP_MIGRATIONS_DIR"
     echo "endpoint: http://localhost:$HASURA_GRAPHQL_MIGRATIONS_SERVER_PORT" > config.yaml
     hasura-cli migrate apply

--- a/scripts/cli-migrations/v2/Dockerfile
+++ b/scripts/cli-migrations/v2/Dockerfile
@@ -7,7 +7,9 @@ FROM hasura/graphql-engine:v1.3.1
 # install libstdc++6 from .deb file
 COPY --from=packager /tmp/libstdc++6* .
 RUN busybox dpkg-deb -x libstdc++6*.deb / \
-    && rm libstdc++6*.deb
+    && rm libstdc++6*.deb \
+    && addgroup -g 1000 hasura \
+    && adduser -u 1000 -s /bin/sh -S -G hasura hasura
 
 # set an env var to let the cli know that
 # update notification is disabled
@@ -17,7 +19,11 @@ COPY docker-entrypoint.sh /bin/
 COPY cli-hasura-linux-amd64 /bin/hasura-cli
 COPY manifest.yaml /tmp/manifest.yaml
 RUN chmod +x /bin/hasura-cli \
-    && hasura-cli plugins install cli-ext --manifest-file /tmp/manifest.yaml \
+    && chown 1000:1000 /tmp/manifest.yaml
+
+USER 1000
+
+RUN hasura-cli plugins install cli-ext --manifest-file /tmp/manifest.yaml \
     && rm /tmp/manifest.yaml
 
 # set an env var to let the cli know that

--- a/scripts/cli-migrations/v2/docker-entrypoint.sh
+++ b/scripts/cli-migrations/v2/docker-entrypoint.sh
@@ -76,7 +76,7 @@ fi
 if [ -d "$HASURA_GRAPHQL_MIGRATIONS_DIR" ]; then
     log "migrations-apply" "applying migrations from $HASURA_GRAPHQL_MIGRATIONS_DIR"
     mkdir -p "$TEMP_PROJECT_DIR"
-    cp -a "$HASURA_GRAPHQL_MIGRATIONS_DIR/." "$TEMP_PROJECT_DIR/migrations/"
+    cp -dR "$HASURA_GRAPHQL_MIGRATIONS_DIR/." "$TEMP_PROJECT_DIR/migrations/"
     cd "$TEMP_PROJECT_DIR"
     echo "version: 2" > config.yaml
     echo "endpoint: http://localhost:$HASURA_GRAPHQL_MIGRATIONS_SERVER_PORT" >> config.yaml
@@ -90,7 +90,7 @@ if [ -d "$HASURA_GRAPHQL_METADATA_DIR" ]; then
     rm -rf "TEMP_PROJECT_DIR"
     log "migrations-apply" "applying metadata from $HASURA_GRAPHQL_METADATA_DIR"
     mkdir -p "$TEMP_PROJECT_DIR"
-    cp -a "$HASURA_GRAPHQL_METADATA_DIR/." "$TEMP_PROJECT_DIR/metadata/"
+    cp -dR "$HASURA_GRAPHQL_METADATA_DIR/." "$TEMP_PROJECT_DIR/metadata/"
     cd "$TEMP_PROJECT_DIR"
     echo "version: 2" > config.yaml
     echo "endpoint: http://localhost:$HASURA_GRAPHQL_MIGRATIONS_SERVER_PORT" >> config.yaml

--- a/server/packaging/build/Dockerfile
+++ b/server/packaging/build/Dockerfile
@@ -1,4 +1,10 @@
 FROM scratch
 COPY rootfs/ /
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
+RUN addgroup -g 1000 hasura \
+    && adduser -u 1000 -s /bin/sh -S -G hasura hasura
+
+USER 1000
+
 CMD ["graphql-engine", "serve"]


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
The hasura/graphql-engine images currently run as `root`.  Best practices and our security policies are to run as non-root whenever possible.

We currently run an intermediate build to add a `hasura (1000)` user and group to the main image, and modify the cli-migrations-v2 image to move and fix ownership on the installed plugin and tweak a couple of the `cp` lines in the docker-entrypoint.sh script so we can copy as a non-privileged user.   We've been running it this was for several months now and from what we can tell there's no reason to run the server containers as root.

<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Changelog

Not sure if this is considered a user-facing content? Will be happy to update if necessary.

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components

- [ x ] Other (list it)

Docker Images:

-  hasura/graphql-engine:<release versions>
-  hasura/graphql-engine:<release versions>.cli-migrations-v2
-  hasura/graphql-engine:<release versions>.cli-migrations

Added the pod level `securityContext` in the kubernetes deployment example.

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

These changes should resolve these issues:

#4651
#3824

### Solution and Design

- Add non-user runas user/group to base graphql-engine image.
- Update cli-migration images to use new user and update entrypoint scripts to cp in a compatible way.
- Update example k8s deployment with securityContext runAs user/group.

### Steps to test and verify

I apologize, but I can not reverse engineer enough of the build process to actually build the graphql-engine image.

- I was able to compile and run the server locally.
- Trying to run CircleCI locally failed.  The local version doesn't support artifacts or caching so I can't pass results between jobs.
- Trying to run `cd server/ && make ci-build` fails because it assumes it in a container and has access to /build.
- Trying to run  `cd server/ && make ci-image` fails because the build.sh script in `hasura/graphql-engine-packager:20190731` image dies because ldd output isn't being parsed correctly (`/root/graphql-engine:` doesn't exist. The colon should be filtered.)

I'd be happy to do more thorough testing if someone is willing to help walk me through building the images outside the CI environment.

---

Testing:

- Build image.
- Run image.
- Check to see if graphql-engine server is running as user 1000 (hasura)
- Build/Test cli-migrations images

### Limitations, known bugs & workarounds

None that I know of

### Server checklist
<!-- A checklist for server code -->

No server code has changed.

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [ x ] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [ x ] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [ x ] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [ x ] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
