### PR TITLE
server: Add path info to tracing metadata for Postgres calls

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Execute/Query.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/Query.hs
@@ -368,7 +368,9 @@ mkLazyRespTx env manager reqHdrs userInfo resolved =
      RRSql (PreparedSql q args maybeRemoteJoins) -> do
         let prepArgs = map fst args
         case maybeRemoteJoins of
-          Nothing -> Tracing.trace "Postgres" . liftTx $ asSingleRowJsonResp q prepArgs
+          Nothing -> Tracing.trace "Postgres" do
+            Tracing.attachMetadata [("path", G.unName alias)]
+            liftTx $ asSingleRowJsonResp q prepArgs
           Just remoteJoins ->
             executeQueryWithRemoteJoins env manager reqHdrs userInfo q prepArgs remoteJoins
      RRActionQuery actionTx           -> actionTx


### PR DESCRIPTION
### Description

Add the GraphQL path to metadata for Postgres calls.

This only handles the simplest case right now, with no remote joins, hence the Draft status.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server

### Related Issues

https://github.com/hasura/graphql-engine-pro/issues/513
