### PR TITLE
Console: Enter the Role name in permission tab with white space

### DIFF
--- a/console/src/components/Services/Data/TablePermissions/Permissions.js
+++ b/console/src/components/Services/Data/TablePermissions/Permissions.js
@@ -482,7 +482,7 @@ class Permissions extends Component {
         });
 
         const dispatchRoleNameChange = e => {
-          const newRole = e.target.value.trim();
+          const newRole = e.target.value;
 
           dispatch(permSetRoleName(newRole));
         };


### PR DESCRIPTION
Closes @ #5553 

### Description
Removed `trim()` from RoleName. So, that we can write Role name with white space in permission tab.

### Affected components

- [X] Console
