### PR TITLE
console: init new websocket client when headers change (close #5744)

### DIFF
--- a/console/src/components/Services/ApiExplorer/Actions.js
+++ b/console/src/components/Services/ApiExplorer/Actions.js
@@ -272,6 +272,8 @@ const analyzeFetcher = (headers, mode) => {
 
 const changeRequestHeader = (index, key, newValue, isDisabled) => {
   return (dispatch, getState) => {
+    websocketSubscriptionClient = null;
+
     const currentState = getState().apiexplorer;
 
     const updatedHeader = {


### PR DESCRIPTION
close https://github.com/hasura/graphql-engine/issues/5744 

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components

- [x] Console
