### PR TITLE
server: limit length of event trigger names (close #5786)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ This release contains the [PDV refactor (#4111)](https://github.com/hasura/graph
 - server: change `created_at` column type from `timestamp` to `timestamptz` for scheduled triggers tables (fix #5722)
 - server: allow configuring timeouts for actions (fixes #4966)
 - server: accept only non-negative integers for batch size and refetch interval (close #5653) (#5759)
+- server: limit the length of trigger names (close #5786)
 - console: allow user to cascade Postgres dependencies when dropping Postgres objects (close #5109) (#5248)
 - console: mark inconsistent remote schemas in the UI (close #5093) (#5181)
 - cli: add missing global flags for seeds command (#5565)

--- a/console/src/components/Services/Events/EventTriggers/Add/Add.tsx
+++ b/console/src/components/Services/Events/EventTriggers/Add/Add.tsx
@@ -198,6 +198,7 @@ const Add: React.FC<Props> = props => {
               className={`${styles.tableNameInput} form-control`}
               value={name}
               onChange={handleTriggerNameChange}
+              maxLength={49}
             />
             <hr />
             <h4 className={styles.subheading_text}>

--- a/console/src/components/Services/Events/EventTriggers/Common/Tooltips.js
+++ b/console/src/components/Services/Events/EventTriggers/Common/Tooltips.js
@@ -9,7 +9,7 @@ export const manualTriggerInfo = (
 
 export const triggerNameDescription = (
   <Tooltip id="tooltip-trigger-name-description">
-    Trigger name can be alphanumeric and can contain underscores and hyphens
+    Trigger name can be alphanumeric and can contain underscores and hyphens and can be upto 49 characters.
   </Tooltip>
 );
 

--- a/server/src-lib/Hasura/Eventing/EventTrigger.hs
+++ b/server/src-lib/Hasura/Eventing/EventTrigger.hs
@@ -248,7 +248,7 @@ processEventQueue logger logenv httpMgr pool getSchemaCache eeCtx@EventEngineCtx
       cache <- liftIO getSchemaCache
       
       tracingCtx <- liftIO (Tracing.extractEventContext (eEvent e))
-      let spanName eti = "Event trigger: " <> unNonEmptyText (unTriggerName (etiName eti))
+      let spanName eti = "Event trigger: " <> getRestrictedText (unTriggerName (etiName eti))
           runTraceT = maybe
             Tracing.runTraceT
             Tracing.runTraceTInContext

--- a/server/src-lib/Hasura/Eventing/EventTrigger.hs
+++ b/server/src-lib/Hasura/Eventing/EventTrigger.hs
@@ -248,7 +248,7 @@ processEventQueue logger logenv httpMgr pool getSchemaCache eeCtx@EventEngineCtx
       cache <- liftIO getSchemaCache
       
       tracingCtx <- liftIO (Tracing.extractEventContext (eEvent e))
-      let spanName eti = "Event trigger: " <> getRestrictedText (unTriggerName (etiName eti))
+      let spanName eti = "Event trigger: " <> unNonEmptyText (unTriggerName (etiName eti))
           runTraceT = maybe
             Tracing.runTraceT
             Tracing.runTraceTInContext

--- a/server/src-lib/Hasura/Eventing/ScheduledTrigger.hs
+++ b/server/src-lib/Hasura/Eventing/ScheduledTrigger.hs
@@ -514,7 +514,7 @@ processScheduledEvent logEnv pgpool se@ScheduledEventFull {..} type' = Tracing.r
         (processSuccess pgpool se decodedHeaders type' webhookReqBodyJson)
         res
   where
-    traceNote = "Scheduled trigger" <> foldMap ((": " <>) . unNonEmptyText . unTriggerName) sefName
+    traceNote = "Scheduled trigger" <> foldMap ((": " <>) . triggerNameToTxt) sefName
 
 processError
   :: (MonadIO m, MonadError QErr m)

--- a/server/src-lib/Hasura/Eventing/ScheduledTrigger.hs
+++ b/server/src-lib/Hasura/Eventing/ScheduledTrigger.hs
@@ -514,7 +514,7 @@ processScheduledEvent logEnv pgpool se@ScheduledEventFull {..} type' = Tracing.r
         (processSuccess pgpool se decodedHeaders type' webhookReqBodyJson)
         res
   where
-    traceNote = "Scheduled trigger" <> foldMap ((": " <>) . unNonEmptyText . unTriggerName) sefName
+    traceNote = "Scheduled trigger" <> foldMap ((": " <>) . getRestrictedText . unTriggerName) sefName
 
 processError
   :: (MonadIO m, MonadError QErr m)

--- a/server/src-lib/Hasura/Eventing/ScheduledTrigger.hs
+++ b/server/src-lib/Hasura/Eventing/ScheduledTrigger.hs
@@ -514,7 +514,7 @@ processScheduledEvent logEnv pgpool se@ScheduledEventFull {..} type' = Tracing.r
         (processSuccess pgpool se decodedHeaders type' webhookReqBodyJson)
         res
   where
-    traceNote = "Scheduled trigger" <> foldMap ((": " <>) . getRestrictedText . unTriggerName) sefName
+    traceNote = "Scheduled trigger" <> foldMap ((": " <>) . unNonEmptyText . unTriggerName) sefName
 
 processError
   :: (MonadIO m, MonadError QErr m)

--- a/server/src-lib/Hasura/RQL/DDL/EventTrigger.hs
+++ b/server/src-lib/Hasura/RQL/DDL/EventTrigger.hs
@@ -42,7 +42,7 @@ data OpVar = OLD | NEW deriving (Show)
 pgIdenTrigger:: Ops -> TriggerName -> T.Text
 pgIdenTrigger op trn = pgFmtIden . qualifyTriggerName op $ triggerNameToTxt trn
   where
-    qualifyTriggerName op' trn' = "notify_hasura_" <> trn' <> "_" <> T.pack (show op')
+    qualifyTriggerName op' trn' = "hasura_" <> trn' <> "_" <> T.pack (show op')
 
 getDropFuncSql :: Ops -> TriggerName -> T.Text
 getDropFuncSql op trn = "DROP FUNCTION IF EXISTS"

--- a/server/src-lib/Hasura/RQL/Types/EventTrigger.hs
+++ b/server/src-lib/Hasura/RQL/Types/EventTrigger.hs
@@ -39,11 +39,11 @@ import qualified Data.Text                  as T
 import qualified Database.PG.Query          as Q
 import qualified Text.Regex.TDFA            as TDFA
 
--- PG allows for identifiers to be of length upto 63
--- So subtracting the length required for hasura_ and _(INSERT | UPDATE | DELETE) 
--- We are left with 49 chars alone for the actual name provided by the user and
--- save the correct functions for the event triggers without the function name being
--- truncated by PG
+-- This change helps us create functions for the event triggers
+-- without the function name being truncated by PG, since PG allows
+-- for only 63 chars for identifiers. 
+-- Reasoning for the 49 characters:
+-- 63 - (hasura_) - (_INSERT | _UPDATE | _DELETE)
 maxTriggerNameLength :: Int
 maxTriggerNameLength = 49
 

--- a/server/src-lib/Hasura/Server/API/PGDump.hs
+++ b/server/src-lib/Hasura/Server/API/PGDump.hs
@@ -87,7 +87,7 @@ execPGDump b ci = do
 
     notifyTriggerRegex =
       let regexStr :: String =
-            "^CREATE TRIGGER \"?notify_hasura_.+\"? AFTER [[:alnum:]]+ "
+            "^CREATE TRIGGER \"?hasura_.+\"? AFTER [[:alnum:]]+ "
               <> "ON .+ FOR EACH ROW EXECUTE (FUNCTION|PROCEDURE) "
-              <> "\"?hdb_views\"?\\.\"?notify_hasura_.+\"?\\(\\);$"
+              <> "\"?hdb_views\"?\\.\"?hasura_.+\"?\\(\\);$"
       in TDFA.makeRegex regexStr :: TDFA.Regex

--- a/server/src-lib/Hasura/Server/API/PGDump.hs
+++ b/server/src-lib/Hasura/Server/API/PGDump.hs
@@ -87,7 +87,7 @@ execPGDump b ci = do
 
     notifyTriggerRegex =
       let regexStr :: String =
-            "^CREATE TRIGGER \"?hasura_.+\"? AFTER [[:alnum:]]+ "
+            "^CREATE TRIGGER \"?(notify_hasura|hasura_).+\"? AFTER [[:alnum:]]+ "
               <> "ON .+ FOR EACH ROW EXECUTE (FUNCTION|PROCEDURE) "
-              <> "\"?hdb_views\"?\\.\"?hasura_.+\"?\\(\\);$"
+              <> "\"?hdb_views\"?\\.\"?(notify_hasura_|hasura_).+\"?\\(\\);$"
       in TDFA.makeRegex regexStr :: TDFA.Regex


### PR DESCRIPTION
fixes #5786

### Description

The problem was with long names for the event triggers was that PG truncated the name of the functions used for the event triggers and that would mess up the invocation of certain event triggers depending on the 
This PR introduces a limit on how long the name of an event trigger can be, which in this case is 49 chars.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [x] Console

### Solution and Design

We throw an error when an user tries to create a new event trigger that's longer than a limit (49 chars).

### Server checklist

#### Catalog upgrade
- [x] No

#### Metadata

Does this PR add a new Metadata feature?
- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated

#### Breaking changes
- [x] No Breaking changes
