### PR TITLE
Better concurrency mechanic for shutdown-latch

### DIFF
--- a/server/src-exec/Main.hs
+++ b/server/src-exec/Main.hs
@@ -63,7 +63,7 @@ runApp env (HGEOptionsG rci hgeCmd) =
       -- once again, we terminate the process immediately.
       _ <- liftIO $ Signals.installHandler
         Signals.sigTERM
-        (Signals.CatchOnce (shutdownGracefully initCtx))
+        (Signals.CatchOnce (void $ shutdownGracefully initCtx))
         Nothing
       runHGEServer env serveOptions initCtx Nothing initTime shutdownApp Nothing ekgStore
 

--- a/server/src-lib/Hasura/App.hs
+++ b/server/src-lib/Hasura/App.hs
@@ -274,11 +274,11 @@ waitForShutdown = C.readMVar . unShutdownLatch
 
 -- | Initiate a graceful shutdown of the server associated with the provided
 -- latch.
-shutdownGracefully :: InitCtx -> IO ()
+shutdownGracefully :: InitCtx -> IO Bool
 shutdownGracefully = shutdownGracefully' . _icShutdownLatch
 
-shutdownGracefully' :: ShutdownLatch -> IO ()
-shutdownGracefully' = void . flip C.tryPutMVar () . unShutdownLatch
+shutdownGracefully' :: ShutdownLatch -> IO Bool
+shutdownGracefully' = flip C.tryPutMVar () . unShutdownLatch
 
 -- | If an exception is encountered , flush the log buffer and
 -- rethrow If we do not flush the log buffer on exception, then log lines

--- a/server/src-lib/Hasura/App.hs
+++ b/server/src-lib/Hasura/App.hs
@@ -270,7 +270,7 @@ newShutdownLatch = fmap ShutdownLatch C.newEmptyMVar
 
 -- | Block the current thread, waiting on the latch.
 waitForShutdown :: ShutdownLatch -> IO ()
-waitForShutdown = C.takeMVar . unShutdownLatch
+waitForShutdown = C.readMVar . unShutdownLatch
 
 -- | Initiate a graceful shutdown of the server associated with the provided
 -- latch.
@@ -278,7 +278,7 @@ shutdownGracefully :: InitCtx -> IO ()
 shutdownGracefully = shutdownGracefully' . _icShutdownLatch
 
 shutdownGracefully' :: ShutdownLatch -> IO ()
-shutdownGracefully' = flip C.putMVar () . unShutdownLatch
+shutdownGracefully' = void . flip C.tryPutMVar () . unShutdownLatch
 
 -- | If an exception is encountered , flush the log buffer and
 -- rethrow If we do not flush the log buffer on exception, then log lines

--- a/server/src-lib/Hasura/App.hs
+++ b/server/src-lib/Hasura/App.hs
@@ -273,7 +273,8 @@ waitForShutdown :: ShutdownLatch -> IO ()
 waitForShutdown = C.readMVar . unShutdownLatch
 
 -- | Initiate a graceful shutdown of the server associated with the provided
--- latch.
+-- latch. Returns 'True' if the shutdown was initiated successfully - that is,
+-- the latch is not blocked by another existing shutdown attempt.
 shutdownGracefully :: InitCtx -> IO Bool
 shutdownGracefully = shutdownGracefully' . _icShutdownLatch
 


### PR DESCRIPTION

### Description

There is a shutdown-latch datatype in use and exported by the graphql-engine haskell library. This has an interface of `newShutdownLatch`, `waitForShutdown`, and `shutdownGracefully`.

There is an issue with the current implementation that doesn't allow for reuse of the latch:

* Calling shutdown twice will block the second call - This is unlikely to be expected.
* Waiting for shutdown more than once will block - This prevents using the same latch to trigger multiple shutdown procedures


### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components

- [x] Server


### Related Issues

No known related issues.


### Solution and Design

This patch addresses this by changing the implementation of

```haskell
waitForShutdown = C.takeMVar . unShutdownLatch
```

to

```haskell
waitForShutdown = C.readMVar . unShutdownLatch
```

and

```haskell
shutdownGracefully' = flip C.putMVar () . unShutdownLatch
```

to

```haskell
shutdownGracefully' = void . flip C.tryPutMVar () . unShutdownLatch
```

Thus allowing multiple non-blocking calls to `shutdownGracefully`, and multiple instances of `waitForShutdown` that all unblock immediately after `shutdownGracefully` has been called once.



### Steps to test and verify

In Haskell library-usage of graphql-server you may now pass the same latch to multiple running services and terminate them all simultaneously with a single shutdown call.

### Limitations, known bugs & workarounds

No known limitations.


### Server checklist

N/A

#### Catalog upgrade

Does this PR change Hasura Catalog version?
 
- [x] No

#### Metadata


Does this PR add a new Metadata feature?

- [x] No


#### GraphQL

- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No Breaking changes

