### PR TITLE
docs: link to bulk requests on perm. metadata api (close #5825)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,6 @@ This release contains the [PDV refactor (#4111)](https://github.com/hasura/graph
 - console: mark inconsistent remote schemas in the UI (close #5093) (#5181)
 - cli: add missing global flags for seeds command (#5565)
 - docs: add docs page on networking with docker (close #4346) (#4811)
-- docs: sadd link to bulk api request on permissions metadata api page (#5825)
 
 
 ## `v1.3.2`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ This release contains the [PDV refactor (#4111)](https://github.com/hasura/graph
 - console: mark inconsistent remote schemas in the UI (close #5093) (#5181)
 - cli: add missing global flags for seeds command (#5565)
 - docs: add docs page on networking with docker (close #4346) (#4811)
+- docs: sadd link to bulk api request on permissions metadata api page (#5825)
 
 
 ## `v1.3.2`

--- a/docs/graphql/core/api-reference/schema-metadata-api/permission.rst
+++ b/docs/graphql/core/api-reference/schema-metadata-api/permission.rst
@@ -673,6 +673,10 @@ An example:
 
 .. _set_permission_comment_syntax:
 
+.. note::
+
+   It is possible to do these requests in **bulk** by using [a bulk request](https://hasura.io/docs/1.0/graphql/core/api-reference/schema-metadata-api/index.html#request-types).
+
 Args syntax
 ^^^^^^^^^^^
 


### PR DESCRIPTION
Link to bulk request for schema metadata api since people that update the permissions might want to do these calls in bulk (close #5825)

❗❗❗❗❗❗❗**The way i linked the pages does not seem to be correct. Can someone help me with the :ref:<> syntax? I 'm trying to deep link to this url: https://hasura.io/docs/1.0/graphql/core/api-reference/schema-metadata-api/index.html#request-types **

![image](https://user-images.githubusercontent.com/1710840/94526825-64f1f480-0236-11eb-8218-c91b3fed0d0e.png)

![image](https://user-images.githubusercontent.com/1710840/94526832-66232180-0236-11eb-9f4b-9a7b4661116d.png)
 

### Description
When a user is looking at the documentation to update permissions using the api, they might also be wondering if they an do these calls in bulk. Currently there is no link between these 2 pages.

### Changelog

- [x] has been added

### Affected components

- [x] Docs

### Related Issues
#5825
