### PR TITLE
console: append "IF NOT EXISTS" for adding and "IF EXISTS" for removing of columns (fix #5284)

### DIFF
--- a/console/src/components/Services/Data/TableModify/ModifyActions.js
+++ b/console/src/components/Services/Data/TableModify/ModifyActions.js
@@ -1045,14 +1045,20 @@ const deleteColumnSql = (column, tableSchema) => {
 
     const schemaChangesUp = [
       getRunSqlQuery(
-        alterStatement + 'DROP COLUMN ' + '"' + name + '" CASCADE'
+        alterStatement + 'DROP COLUMN IF EXISTS ' + '"' + name + '" CASCADE'
       ),
     ];
     const schemaChangesDown = [];
 
     schemaChangesDown.push(
       getRunSqlQuery(
-        alterStatement + 'ADD COLUMN ' + '"' + name + '"' + ' ' + col_type
+        alterStatement +
+          'ADD COLUMN IF NOT EXISTS ' +
+          '"' +
+          name +
+          '"' +
+          ' ' +
+          col_type
       )
     );
 
@@ -1216,7 +1222,7 @@ const addColSql = (
       '"' +
       tableName +
       '"' +
-      ' ADD COLUMN ' +
+      ' ADD COLUMN IF NOT EXISTS ' +
       '"' +
       colName +
       '"' +
@@ -1279,7 +1285,7 @@ const addColSql = (
       '"' +
       tableName +
       '"' +
-      ' DROP COLUMN ' +
+      ' DROP COLUMN IF EXISTS ' +
       '"' +
       colName +
       '";';


### PR DESCRIPTION
### Description

Added 
- "IF NOT EXISTS" to ALTER TABLE ADD COLUMN in up and down migrations
- "IF EXISTS" to ALTER TABLE DROP COLUMN in up and down migrations

This helps to avoid potential problem of failing a migration that adds or removes columns twice.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Console

### Related Issues
#5284