### PR TITLE
Dataloader prototype: update the Schema to return a tree of root fields.

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Context.hs
+++ b/server/src-lib/Hasura/GraphQL/Context.hs
@@ -13,10 +13,12 @@ module Hasura.GraphQL.Context
   , QueryDB(..)
   , ActionQuery(..)
   , QueryRootTree
+  , QueryRootField
   , QueryRootJoin
   , MutationDB(..)
   , ActionMutation(..)
   , MutationRootTree
+  , MutationRootField
   , MutationRootJoin
   , SubscriptionRootField
   , SubscriptionRootFieldResolved
@@ -105,8 +107,9 @@ data ActionQuery v
 
 type RemoteField = (RQL.RemoteSchemaInfo, G.Field G.NoFragments Variable)
 
-type QueryRootTree v = RootTree (RootField (QueryDB v) RemoteField (ActionQuery v) J.Value)
-type QueryRootJoin v = RootJoin (RootField (QueryDB v) RemoteField (ActionQuery v) J.Value)
+type QueryRootField v = RootField (QueryDB v) RemoteField (ActionQuery v) J.Value
+type QueryRootTree  v = RootTree (QueryRootField v)
+type QueryRootJoin  v = RootJoin (QueryRootField v)
 
 data MutationDB v
   = MDBInsert (AnnInsert   v)
@@ -117,10 +120,9 @@ data ActionMutation v
   = AMSync !(RQL.AnnActionExecution v)
   | AMAsync !RQL.AnnActionMutationAsync
 
-type MutationRootTree v =
-  RootTree (RootField (MutationDB v) RemoteField (ActionMutation v) J.Value)
-type MutationRootJoin v =
-  RootJoin (RootField (MutationDB v) RemoteField (ActionMutation v) J.Value)
+type MutationRootField v = RootField (MutationDB v) RemoteField (ActionMutation v) J.Value
+type MutationRootTree  v = RootTree (MutationRootField v)
+type MutationRootJoin  v = RootJoin (MutationRootField v)
 
 type SubscriptionRootField v = RootField (QueryDB v) Void (RQL.AnnActionAsyncQuery v) Void
 type SubscriptionRootFieldResolved = RootField (QueryDB S.SQLExp) Void RQL.AnnSimpleSel Void

--- a/server/src-lib/Hasura/GraphQL/Execute.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute.hs
@@ -28,8 +28,8 @@ import qualified Data.Environment                       as Env
 import qualified Data.HashMap.Strict                    as Map
 
 import qualified Data.HashSet                           as HS
-import qualified Language.GraphQL.Draft.Syntax          as G
 import qualified Language.GraphQL.Draft.Printer         as G
+import qualified Language.GraphQL.Draft.Syntax          as G
 import qualified Network.HTTP.Client                    as HTTP
 import qualified Network.HTTP.Types                     as HTTP
 import qualified Network.Wai.Extended                   as Wai
@@ -295,7 +295,7 @@ getResolvedExecPlan env logger pgExecCtx {- planCache-} userInfo sqlGenCtx
               in
               unless (multipleAllowed || null rst) $
                 throw400 ValidationFailed "subscriptions must select one top level field"
-          validSubscriptionAST <- for unpreparedAST validateSubscriptionRootField
+          validSubscriptionAST <- for unpreparedAST \(C.RootTree rootField _) -> validateSubscriptionRootField rootField
           (lqOp, _plan) <- EL.buildLiveQueryPlan pgExecCtx userInfo validSubscriptionAST
           return $ SubscriptionExecutionPlan lqOp
 

--- a/server/src-lib/Hasura/GraphQL/Schema/Action.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema/Action.hs
@@ -16,6 +16,7 @@ import qualified Hasura.GraphQL.Parser.Internal.Parser as P
 import qualified Hasura.RQL.DML.Internal               as RQL
 import qualified Hasura.RQL.DML.Select.Types           as RQL
 
+import           Hasura.GraphQL.Context
 import           Hasura.GraphQL.Parser                 (FieldParser, InputFieldsParser, Kind (..),
                                                         Parser, UnpreparedValue (..))
 import           Hasura.GraphQL.Parser.Class
@@ -201,7 +202,7 @@ actionOutputFields outputObject = do
       roleName <- lift askRoleName
       tablePerms <- MaybeT $ pure $ RQL.getPermInfoMaybe roleName PASelect tableInfo
       tableParser <- lift $ selectTable tableName fieldName Nothing tablePerms
-      pure $ tableParser <&> \selectExp ->
+      pure $ tableParser <&> \(RootTree (RFDB (QDBSimple selectExp)) _) ->
         let tableRelName = RelName $ mkNonEmptyTextUnsafe $ G.unName fieldName
             columnMapping = Map.fromList $
               [ (unsafePGCol $ G.unName $ unObjectFieldName k, pgiColumn v)

--- a/server/src-lib/Hasura/GraphQL/Schema/Select.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema/Select.hs
@@ -965,8 +965,12 @@ relationshipField relationshipInfo = runMaybeT do
                        ]
   where
     -- temporary, until we work on proper generalized joins
-    extractSimpleSelect (RootTree (RFDB (QDBSimple selectExp)) _) = selectExp
-    extractAggSelect (RootTree (RFDB (QDBAggregation selectExp)) _) = selectExp
+    extractSimpleSelect = \case
+      RootTree (RFDB (QDBSimple selectExp)) _ -> selectExp
+      _                                       -> error "internal error: unexpected tree in relationship"
+    extractAggSelect = \case
+      RootTree (RFDB (QDBAggregation selectExp)) _ -> selectExp
+      _                                            -> error "internal error: unexpected tree in aggregate relationsh"
 
 -- | Computed field parser
 computedField

--- a/server/src-lib/Hasura/RQL/DDL/Schema/Table.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Table.hs
@@ -43,8 +43,8 @@ import           Network.URI.Extended               ()
 import qualified Hasura.Incremental                 as Inc
 
 import           Hasura.EncJSON
-import           Hasura.GraphQL.Schema.Common       (textToName)
 import           Hasura.GraphQL.Context
+import           Hasura.GraphQL.Schema.Common       (textToName)
 import           Hasura.RQL.DDL.Deps
 import           Hasura.RQL.DDL.Schema.Cache.Common
 import           Hasura.RQL.DDL.Schema.Catalog
@@ -134,7 +134,7 @@ checkConflictingNode sc tnGQL = do
     Left _ -> pure ()
     Right (results, _reusability) -> do
       case OMap.lookup $$(G.litName "__schema") results of
-        Just (RFRaw (Object schema)) -> do
+        Just (RootTree (RFRaw (Object schema)) _) -> do
           let names = do
                 Object queryType <- Map.lookup "queryType" schema
                 Array fields <- Map.lookup "fields" queryType


### PR DESCRIPTION
## Motivation

This PR is an exploratory first step towards a generalized data-loader engine. It changes the way we parse the schema, without actually introducing any behaviour change. This paves the way towards all sorts of projects for which we need to split a query into several sub-queries that need to be recombined, such as MySQL support, and eventually generalized joins.

The goal of this PR is therefore to provide a point of discussion for this implementation strategy and to help identify unknowns, not necessarily to be submitted as-is, especially since it doesn't settle on a proper representation for join information (see limitations below).

## Description

This PR changes one main thing: we now represent a query as a *tree* of `QueryRootField`: each query is represented as a `QueryRootField` and a list of joins: a sub-tree, and information about how the joins should be performed... This means that the schema needs to be aware of root fields, and it creates some complexities. However, this PR **does not change the behaviour of the parsers**: it always returns a one-node leaf tree. Meaning that the execution code **also behaves the same**, and discards any join (since it assumes there are none).

As a result, this is expected to be a completely transparent change, having no impact on the features of the code.

## Limitations

One important implementation detail that this PR does not address is the question of what information is required to represent joins, so that at execution time it will be possible to perform the joins properly. AFAICT, two pieces of information are required:
* which fields of the query should be read to extract the primary keys for the join
* under what name should the result be inserted

It is, however, debatable: perhaps the query could be generated so that the field containing the primary keys already has the proper name, to avoid conflicts in the request? Furthermore, just having a field name isn't enough, as maybe the fields to be extracted for a join are nested; maybe a full JSON path is instead required.