### PR TITLE
Dataloader prototype: JSON joins

### DIFF
--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -425,16 +425,17 @@ library
                      , Hasura.GraphQL.Execute.Action
                      , Hasura.GraphQL.Execute.Inline
                      , Hasura.GraphQL.Execute.Insert
-                     , Hasura.GraphQL.Execute.Plan
-                     , Hasura.GraphQL.Execute.Types
-                     , Hasura.GraphQL.Execute.Mutation
-                     , Hasura.GraphQL.Execute.Remote
-                     , Hasura.GraphQL.Execute.Resolve
-                     , Hasura.GraphQL.Execute.Prepare
+                     , Hasura.GraphQL.Execute.Join
                      , Hasura.GraphQL.Execute.LiveQuery.Options
                      , Hasura.GraphQL.Execute.LiveQuery.Plan
                      , Hasura.GraphQL.Execute.LiveQuery.Poll
                      , Hasura.GraphQL.Execute.LiveQuery.State
+                     , Hasura.GraphQL.Execute.Mutation
+                     , Hasura.GraphQL.Execute.Plan
+                     , Hasura.GraphQL.Execute.Prepare
+                     , Hasura.GraphQL.Execute.Remote
+                     , Hasura.GraphQL.Execute.Resolve
+                     , Hasura.GraphQL.Execute.Types
                      , Hasura.GraphQL.Execute.LiveQuery.TMap
                      , Hasura.GraphQL.RemoteServer
                      , Hasura.GraphQL.Context

--- a/server/src-lib/Hasura/GraphQL/Execute/Join.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/Join.hs
@@ -1,0 +1,141 @@
+module Hasura.GraphQL.Execute.Join where
+
+import           Hasura.Prelude
+
+import           Control.Arrow       (left)
+import           Data.Foldable
+
+import qualified Data.Aeson          as J
+import qualified Data.Aeson.Internal as J
+import qualified Data.HashMap.Strict as HMS
+import qualified Data.Text           as T
+
+import           Hasura.EncJSON
+
+
+-- | Given a path and a JSON object, extract all matching values.
+--
+-- This function assumes that arrays should not be filtered (as if the path had
+-- been written using [*]). This slightly reinterprets the meaning of Aeson's
+-- JSONPathElement (the index is ignored).
+--
+-- For a JSON path "data.articles[*].author" (which would be represented as
+-- `[Key "data", Key "articles", Index _, Key "author"]`), and given a JSON object:
+--   { "data":
+--     { "articles: [
+--         {"id": 0, "name": "foo", "author": "A.A"},
+--         {"id": 1, "name": "bar", "author": "B.B"}
+--       ]
+--     }
+--   }
+--
+-- this function would return `[J.String "A.A", J.String "B.B"]`.
+extractPrimaryKeys :: J.JSONPath -> EncJSON -> Either Text [J.Value]
+extractPrimaryKeys path response = do
+  jsonValue <- left T.pack $ J.eitherDecode $ encJToLBS response
+  foldlM walk [jsonValue] path
+  where
+    walk :: [J.Value] -> J.JSONPathElement -> Either Text [J.Value]
+    walk values step = fmap concat $ for values \value -> case (value, step) of
+      (J.Object object, J.Key key) -> case HMS.lookup key object of
+        Nothing -> Left $ "key " <> key <> " not found"
+        Just v  -> Right [v]
+      (J.Array  array,  J.Index _) -> Right $ toList array
+      _                            -> Left "failed to expand path" -- FIXME
+
+-- | Given a path and a JSON object, create a map of all matching objects. Keys
+-- | of the map will be the JSON value at the path, associated to the surrounding
+-- | object.
+--
+-- This function assumes that arrays should not be filtered (as if the path had
+-- been written using [*]). This slightly reinterprets the meaning of Aeson's
+-- JSONPathElement (the index is ignored).
+--
+-- For a JSON path "data.authors.name" (which would be represented as
+-- `[Key "data", Key "authors", Key "name"]`), and given a JSON object:
+--   { "data":
+--     { "authors: [
+--         {"id": 0, "name": "A.A", "age": 42},
+--         {"id": 1, "name": "B.B", "age": 64}
+--       ]
+--     }
+--   }
+--
+-- this function would return a map:
+--   "A.A" => {"id": 0, "name": "A.A", "age": 42}
+--   "B.B" => {"id": 1, "name": "B.B", "age": 64}
+extractObjects :: J.JSONPath -> EncJSON -> Either Text (HMS.HashMap J.Value J.Value)
+extractObjects path response = do
+  jsonValue <- left T.pack $ J.eitherDecode $ encJToLBS response
+  assocList <- foldlM walk [(jsonValue, J.Null)] path
+  Right $ HMS.fromList assocList
+  where
+    walk :: [(J.Value, J.Value)] -> J.JSONPathElement -> Either Text [(J.Value, J.Value)]
+    walk values step = fmap concat $ for values \(value, _) -> case (value, step) of
+      (J.Object object, J.Key key) -> case HMS.lookup key object of
+        Nothing -> Left $ "key " <> key <> " not found"
+        Just v  -> Right [(v, value)]
+      (J.Array  array,  J.Index _) -> Right $ (,J.Null) <$> toList array
+      _                            -> Left "failed to expand path" -- FIXME
+
+-- | Given a path, a JSON object, and a mapping of JSON values, traverse the
+-- | JSON object and replace elements at the given path by the one given in the
+-- | map.
+--
+-- This function assumes that arrays should not be filtered (as if the path had
+-- been written using [*]). This slightly reinterprets the meaning of Aeson's
+-- JSONPathElement (the index is ignored).
+--
+-- *!* WARNING *!*
+-- This function makes a MAJOR assumption, which is probably wrong: that there
+-- WILL be a corresponding JSON value for every lookup we do.
+--
+-- Given:
+--   the JSON path "data.articles[*].author"
+--   the following mapping:
+--     "A.A" => {"id": 0, "name": "A.A", "age": 42}
+--     "B.B" => {"id": 1, "name": "B.B", "age": 64}
+--   and the following JSON object
+--     { "data":
+--       { "articles: [
+--           {"id": 0, "name": "foo", "author": "A.A"},
+--           {"id": 1, "name": "bar", "author": "B.B"}
+--         ]
+--       }
+--     }
+-- This function would return:
+--   { "data":
+--     { "articles: [
+--         {"id": 0, "name": "foo", "author": {
+--             "id": 0, "name": "A.A", "age": 42
+--           }
+--         },
+--         {"id": 1, "name": "bar", "author": {
+--             "id": 1, "name": "B.B", "age": 64
+--           }
+--         }
+--       ]
+--     }
+--   }
+joinJSON :: J.JSONPath -> HMS.HashMap J.Value J.Value -> EncJSON -> Either Text EncJSON
+joinJSON path objectMap query =
+  fmap encJFromJValue $ replace path =<< left T.pack (J.eitherDecode $ encJToLBS query)
+  where
+    replace :: J.JSONPath -> J.Value -> Either Text J.Value
+    replace [J.Key key] value = case value of
+      J.Object object -> case HMS.lookup key object of
+        Nothing -> Left $ "key " <> key <> " not found"
+        Just pk -> case HMS.lookup pk objectMap of
+          -- this assumes that all joins WILL have a matching object in the response!
+          Nothing  -> Left $ "object with primary key " <> key <> " not found in sub query"
+          Just val -> Right val
+      _               -> Left "failed to expand path"
+    replace (step : rest) value = case (value, step) of
+      (J.Object object, J.Key key) -> do
+        newValue <- case HMS.lookup key object of
+          Nothing -> Left $ "key " <> key <> " not found"
+          Just v  -> replace rest v
+        Right $ J.Object $ HMS.insert key newValue object
+      (J.Array  array,  J.Index _) -> J.Array <$> traverse (replace rest) array
+      _                            -> Left "failed to expand path" -- FIXME
+    replace _ _ = Left "failed to expand path" -- FIXME


### PR DESCRIPTION
## Motivation

This PR is an exploratory step towards a generalized data-loader engine. It explores a possible implementation of arbitrary JSON joins.

The goal of this PR is therefore to provide a point of discussion for this implementation strategy and to help identify unknowns, not necessarily to be submitted as-is, especially since it doesn't actually do anything beyond introducing dead code.

## Description

This PR introduces a few functions that manipulate the JSON that we received from individual queries:
  - given a JSON result and a path, extract all the keys that will be required to craft the future sub-queries
  - given a JSON result and a path, build a hashmap of JSON objects, indexed by the key at the path
  - given a JSON result, a path, and a hashmap, replace primary keys by the expended object

Those functions end up sharing a lot of similarities with the ones in `RQL.DML.RemoteJoin`. How much can be deduplicated is yet to be figured out. While, ultimately, it would be possible to change remote joins to be performed using the generalized dataloader engine, there's no plan to do so in the short term (don't fix what ain't broke).

## Limitations

- the `joinJSON` function assumes that there will be a corresponding object in the HashMap, which might not be a valid requirement;
- this code hasn't been properly tested beyond some simple manual tests
- this code is MUCH simpler than the corresponding code in `RQL.DML.RemoteJoin`, which suggests that there are a lot of to-be-determined complexities it doesn't handle yet.