### PR TITLE
cli: take seeds file path relative to project directory (fix #5980)

### DIFF
--- a/cli/seed/apply.go
+++ b/cli/seed/apply.go
@@ -24,7 +24,7 @@ func ApplySeedsToDatabase(ec *cli.ExecutionContext, fs afero.Fs, m *migrate.Migr
 
 	if len(filenames) > 0 {
 		for _, filename := range filenames {
-			absFilename := filepath.Join(ec.SeedsDirectory, filename)
+			absFilename := filepath.Join(ec.ExecutionDirectory, filename)
 			b, err := afero.ReadFile(fs, absFilename)
 			if err != nil {
 				return errors.Wrap(err, "error opening file")


### PR DESCRIPTION
##Description

### Changelog
- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [X] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
#5980 

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [X] No
- [ ] Yes
- [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [ ] No Breaking changes
- [x] There are breaking changes:
    --seeds command now takes filename relative to project directory instead of `seeds/` directory.    