### PR TITLE
console: select first operator by default on the browse rows screen (close #5729)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Next release
 
-- console: select first operator by default on the browse rows screen (close #5729)
-
 ### Heterogeneous execution
 
 Previous releases have allowed queries to request data from either Postgres or remote schemas, but not both. This release removes that restriction, so multiple data sources may be mixed within a single query. For example, GraphQL Engine can execute a query like
@@ -69,6 +67,7 @@ This release contains the [PDV refactor (#4111)](https://github.com/hasura/graph
 - console: add option to flag an insertion as a migration from `Data` section (close #1766) (#4933)
 - console: down migrations improvements (close #3503, #4988) (#4790)
 - console: allow setting computed fields for views (close #6168) (#6174)
+- console: select first operator by default on the browse rows screen (close #5729) (#6032)
 - cli: add missing global flags for seed command (#5565)
 - cli: allow seeds as alias for seed command (#5693)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next release
 
+- console: select first operator by default on the browse rows screen (close #5729)
+
 ### Heterogeneous execution
 
 Previous releases have allowed queries to request data from either Postgres or remote schemas, but not both. This release removes that restriction, so multiple data sources may be mixed within a single query. For example, GraphQL Engine can execute a query like

--- a/console/cypress/integration/data/materialized-views/spec.ts
+++ b/console/cypress/integration/data/materialized-views/spec.ts
@@ -301,13 +301,6 @@ export const passVFilterQueryEq = () => {
     .parent()
     .first()
     .select('id');
-  // Select operator as `eq`
-  cy.get('select')
-    .find('option')
-    .contains('-- op --')
-    .parent()
-    .last()
-    .select('$eq');
   // Type value as `filter-text`
   cy.get("input[placeholder='-- value --']")
     .last()

--- a/console/cypress/integration/data/views/spec.ts
+++ b/console/cypress/integration/data/views/spec.ts
@@ -292,13 +292,6 @@ export const passVFilterQueryEq = () => {
     .parent()
     .first()
     .select('id');
-  // Select operator as `eq`
-  cy.get('select')
-    .find('option')
-    .contains('-- op --')
-    .parent()
-    .last()
-    .select('$eq');
   // Type value as `filter-text`
   cy.get("input[placeholder='-- value --']")
     .last()

--- a/console/src/components/Services/Data/DataState.js
+++ b/console/src/components/Services/Data/DataState.js
@@ -1,5 +1,5 @@
 const defaultCurFilter = {
-  where: { $and: [{ '': { '': '' } }] },
+  where: { $and: [{ '': { $eq: '' } }] },
   limit: 10,
   offset: 0,
   order_by: [{ column: '', type: 'asc', nulls: 'last' }],

--- a/console/src/components/Services/Data/TableBrowseRows/FilterActions.js
+++ b/console/src/components/Services/Data/TableBrowseRows/FilterActions.js
@@ -127,7 +127,7 @@ const filterReducer = (state = defaultCurFilter, action) => {
         const newCurFilterQ = {};
         newCurFilterQ.where =
           'where' in q && '$and' in q.where
-            ? { $and: [...q.where.$and, { '': { '': '' } }] }
+            ? { $and: [...q.where.$and, { '': { $eq: '' } }] }
             : { ...defaultCurFilter.where };
         newCurFilterQ.order_by =
           'order_by' in q
@@ -185,7 +185,7 @@ const filterReducer = (state = defaultCurFilter, action) => {
       return {
         ...state,
         where: {
-          $and: [...state.where.$and, { '': { '': '' } }],
+          $and: [...state.where.$and, { '': { $eq: '' } }],
         },
       };
     case REMOVE_FILTER:


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

When user opens a browse rows screen and when new filter is added, operator is set to "equals" by default.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Console

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

#5729

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

Default operator value is added to filterReducer.
