### PR TITLE
server: avoid running hlint on an empty list of files

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -29,4 +29,11 @@ jobs:
 
       - name: Run hlint
         shell: bash
-        run: git diff --name-only origin/${{github.base_ref}}..${{github.sha}} -- ${{env.working-directory}} | grep -E '\.hs$|\.lhs$' | xargs -i -d '\n' sh -c 'ls -d {} 2>/dev/null || true' | xargs -d '\n' ${{env.working-directory}}/hlint --json --hint=${{env.working-directory}}/.hlint.yaml | jq -r '.[] | "::" + (if (.severity=="Warning" or .severity=="Error") then "error" else "warning" end) + " file=\(.file),line=\(.startLine),col=\(.startColumn)::\(.severity):" + " \(.hint)%0AFound:%0A  \(.from | gsub("\n";"%0A  "))%0A" + try ("Perhaps:%0A  " + (.to | gsub("\n";"%0A  "))) catch ""'
+        run: |
+          CHANGED_HS_FILES=$(git diff --name-only origin/${{github.base_ref}}...${{github.sha}} -- ${{env.working-directory}} | grep -E '\.hs$|\.lhs$' | xargs -i -d '\n' sh -c 'ls -d {} 2>/dev/null || true')
+          echo "$CHANGED_HS_FILES"
+          JQ_SCRIPT='.[] | "::" + (if (.severity=="Warning" or .severity=="Error") then "error" else "warning" end) + " file=\(.file),line=\(.startLine),col=\(.startColumn)::\(.severity):" + " \(.hint)%0AFound:%0A  \(.from | gsub("\n";"%0A  "))%0A" + try ("Perhaps:%0A  " + (.to | gsub("\n";"%0A  "))) catch ""'
+          if [[ "$CHANGED_HS_FILES" ]]
+          then
+            echo "$CHANGED_HS_FILES" | xargs ${{env.working-directory}}/hlint --json --hint=${{env.working-directory}}/.hlint.yaml | jq -r "$JQ_SCRIPT"
+          fi

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run hlint
         shell: bash
         run: |
-          CHANGED_HS_FILES=$(git diff --name-only origin/${{github.base_ref}}...${{github.sha}} -- ${{env.working-directory}} | grep -E '\.hs$|\.lhs$' | xargs -i -d '\n' sh -c 'ls -d {} 2>/dev/null || true')
+          CHANGED_HS_FILES=$(git diff --name-only origin/${{github.base_ref}}...${{github.sha}} -- "${{env.working-directory}}/*.hs" | xargs -i -d '\n' sh -c 'ls -d {} 2>/dev/null || true')
           echo "$CHANGED_HS_FILES"
           JQ_SCRIPT='.[] | "::" + (if (.severity=="Warning" or .severity=="Error") then "error" else "warning" end) + " file=\(.file),line=\(.startLine),col=\(.startColumn)::\(.severity):" + " \(.hint)%0AFound:%0A  \(.from | gsub("\n";"%0A  "))%0A" + try ("Perhaps:%0A  " + (.to | gsub("\n";"%0A  "))) catch ""'
           if [[ "$CHANGED_HS_FILES" ]]


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

Fixes a bug in the hlint CI action, which would break when the commit contains changes in the `server/` directory, but no Haskell files were touched.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [x] Tests

