### PR TITLE
server: split RQL.Types.DML

### DIFF
--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -372,30 +372,29 @@ library
                      , Hasura.Server.Auth.JWT.Logging
                      , Hasura.RQL.Instances
                      , Hasura.RQL.Types
-                     , Hasura.RQL.Types.SchemaCache
-                     , Hasura.RQL.Types.Table
-                     , Hasura.RQL.Types.SchemaCache.Build
-                     , Hasura.RQL.Types.SchemaCacheTypes
-                     , Hasura.RQL.Types.Function
+                     , Hasura.RQL.Types.Action
                      , Hasura.RQL.Types.Catalog
                      , Hasura.RQL.Types.Column
                      , Hasura.RQL.Types.Common
                      , Hasura.RQL.Types.ComputedField
-                     , Hasura.RQL.Types.DML
+                     , Hasura.RQL.Types.CustomTypes
                      , Hasura.RQL.Types.Error
                      , Hasura.RQL.Types.EventTrigger
+                     , Hasura.RQL.Types.Function
                      , Hasura.RQL.Types.Metadata
                      , Hasura.RQL.Types.Permission
                      , Hasura.RQL.Types.QueryCollection
-                     , Hasura.RQL.Types.Action
                      , Hasura.RQL.Types.Relationship
-                     , Hasura.RQL.Types.RemoteSchema
                      , Hasura.RQL.Types.RemoteRelationship
+                     , Hasura.RQL.Types.RemoteSchema
                      , Hasura.RQL.Types.ScheduledTrigger
+                     , Hasura.RQL.Types.SchemaCache
+                     , Hasura.RQL.Types.SchemaCache.Build
+                     , Hasura.RQL.Types.SchemaCacheTypes
+                     , Hasura.RQL.Types.Table
                      , Hasura.RQL.DDL.Action
                      , Hasura.RQL.DDL.ComputedField
                      , Hasura.RQL.DDL.CustomTypes
-                     , Hasura.RQL.Types.CustomTypes
                      , Hasura.RQL.DDL.Deps
                      , Hasura.RQL.DDL.Headers
                      , Hasura.RQL.DDL.Metadata
@@ -428,9 +427,11 @@ library
                      , Hasura.RQL.DML.Insert
                      , Hasura.RQL.DML.Internal
                      , Hasura.RQL.DML.Update
+                     , Hasura.RQL.DML.Types
                      , Hasura.RQL.IR.BoolExp
                      , Hasura.RQL.IR.Delete
                      , Hasura.RQL.IR.Insert
+                     , Hasura.RQL.IR.OrderBy
                      , Hasura.RQL.IR.RemoteJoin
                      , Hasura.RQL.IR.Returning
                      , Hasura.RQL.IR.Select

--- a/server/src-lib/Hasura/Backends/Postgres/Translate/Insert.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Translate/Insert.hs
@@ -1,6 +1,5 @@
 module Hasura.Backends.Postgres.Translate.Insert
  ( mkInsertCTE
- , buildConflictClause
  , toSQLConflict
  , insertCheckConstraint
  , insertOrUpdateCheckExpr
@@ -8,9 +7,6 @@ module Hasura.Backends.Postgres.Translate.Insert
 
 import           Hasura.Prelude
 
-import qualified Data.HashSet                                 as HS
-
-import           Data.Text.Extended
 import           Instances.TH.Lift                            ()
 
 import qualified Hasura.Backends.Postgres.SQL.DML             as S
@@ -18,7 +14,6 @@ import qualified Hasura.Backends.Postgres.SQL.DML             as S
 import           Hasura.Backends.Postgres.SQL.Types
 import           Hasura.Backends.Postgres.Translate.BoolExp
 import           Hasura.Backends.Postgres.Translate.Returning
-import           Hasura.RQL.DML.Internal
 import           Hasura.RQL.IR.Insert
 import           Hasura.RQL.Types
 
@@ -51,70 +46,6 @@ toSQLConflict tableName = \case
       CTColumn pgCols -> S.SQLColumn pgCols
       CTConstraint cn -> S.SQLConstraint cn
 
-
-validateInpCols :: (MonadError QErr m) => [PGCol] -> [PGCol] -> m ()
-validateInpCols inpCols updColsPerm = forM_ inpCols $ \inpCol ->
-  unless (inpCol `elem` updColsPerm) $ throw400 ValidationFailed $
-    "column " <> inpCol <<> " is not updatable"
-
-buildConflictClause
-  :: (UserInfoM m, QErrM m)
-  => SessVarBldr 'Postgres m
-  -> TableInfo 'Postgres
-  -> [PGCol]
-  -> OnConflict
-  -> m (ConflictClauseP1 'Postgres S.SQLExp)
-buildConflictClause sessVarBldr tableInfo inpCols (OnConflict mTCol mTCons act) =
-  case (mTCol, mTCons, act) of
-    (Nothing, Nothing, CAIgnore)    -> return $ CP1DoNothing Nothing
-    (Just col, Nothing, CAIgnore)   -> do
-      validateCols col
-      return $ CP1DoNothing $ Just $ CTColumn $ getPGCols col
-    (Nothing, Just cons, CAIgnore)  -> do
-      validateConstraint cons
-      return $ CP1DoNothing $ Just $ CTConstraint cons
-    (Nothing, Nothing, CAUpdate)    -> throw400 UnexpectedPayload
-      "Expecting 'constraint' or 'constraint_on' when the 'action' is 'update'"
-    (Just col, Nothing, CAUpdate)   -> do
-      validateCols col
-      (updFltr, preSet) <- getUpdPerm
-      resolvedUpdFltr <- convAnnBoolExpPartialSQL sessVarBldr updFltr
-      resolvedPreSet <- mapM (convPartialSQLExp sessVarBldr) preSet
-      return $ CP1Update (CTColumn $ getPGCols col) inpCols resolvedPreSet resolvedUpdFltr
-    (Nothing, Just cons, CAUpdate)  -> do
-      validateConstraint cons
-      (updFltr, preSet) <- getUpdPerm
-      resolvedUpdFltr <- convAnnBoolExpPartialSQL sessVarBldr updFltr
-      resolvedPreSet <- mapM (convPartialSQLExp sessVarBldr) preSet
-      return $ CP1Update (CTConstraint cons) inpCols resolvedPreSet resolvedUpdFltr
-    (Just _, Just _, _)             -> throw400 UnexpectedPayload
-      "'constraint' and 'constraint_on' cannot be set at a time"
-  where
-    coreInfo = _tiCoreInfo tableInfo
-    fieldInfoMap = _tciFieldInfoMap coreInfo
-    -- toSQLBool = toSQLBoolExp (S.mkQual $ _tciName coreInfo)
-
-    validateCols c = do
-      let targetcols = getPGCols c
-      void $ withPathK "constraint_on" $ indexedForM targetcols $
-        \pgCol -> askPGType fieldInfoMap pgCol ""
-
-    validateConstraint c = do
-      let tableConsNames = maybe [] toList $
-                           fmap _cName <$> tciUniqueOrPrimaryKeyConstraints coreInfo
-      withPathK "constraint" $
-       unless (c `elem` tableConsNames) $
-       throw400 Unexpected $ "constraint " <> getConstraintTxt c
-                   <<> " for table " <> _tciName coreInfo
-                   <<> " does not exist"
-
-    getUpdPerm = do
-      upi <- askUpdPermInfo tableInfo
-      let updFiltr = upiFilter upi
-          preSet = upiSet upi
-          updCols = HS.toList $ upiCols upi
-      validateInpCols inpCols updCols
-      return (updFiltr, preSet)
 
 -- | Annotates the check constraint expression with @boolean@
 -- (<check-condition>)::boolean

--- a/server/src-lib/Hasura/Backends/Postgres/Translate/Select.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Translate/Select.hs
@@ -28,6 +28,7 @@ import           Hasura.Backends.Postgres.Translate.BoolExp
 import           Hasura.EncJSON
 import           Hasura.GraphQL.Schema.Common
 import           Hasura.RQL.DML.Internal
+import           Hasura.RQL.IR.OrderBy
 import           Hasura.RQL.IR.Select
 import           Hasura.RQL.Types
 import           Hasura.SQL.Types

--- a/server/src-lib/Hasura/GraphQL/Schema/OrderBy.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema/OrderBy.hs
@@ -7,18 +7,20 @@ import           Hasura.Prelude
 import qualified Data.List.NonEmpty                 as NE
 import qualified Language.GraphQL.Draft.Syntax      as G
 
-import           Hasura.Backends.Postgres.SQL.DML   as SQL
-import qualified Hasura.GraphQL.Parser              as P
-import qualified Hasura.RQL.IR.Select               as RQL
-import           Hasura.RQL.Types                   as RQL
-
 import           Data.Text.Extended
+
+import qualified Hasura.Backends.Postgres.SQL.DML   as PG
+import qualified Hasura.GraphQL.Parser              as P
+import qualified Hasura.RQL.IR.OrderBy              as IR
+import qualified Hasura.RQL.IR.Select               as IR
+
 import           Hasura.Backends.Postgres.SQL.Types
 import           Hasura.GraphQL.Parser              (InputFieldsParser, Kind (..), Parser,
                                                      UnpreparedValue)
 import           Hasura.GraphQL.Parser.Class
 import           Hasura.GraphQL.Schema.Common
 import           Hasura.GraphQL.Schema.Table
+import           Hasura.RQL.Types
 
 
 -- | Corresponds to an object type for an order by.
@@ -35,7 +37,7 @@ orderByExp
   :: forall m n r. (MonadSchema n m, MonadTableInfo r m, MonadRole r m)
   => QualifiedTable
   -> SelPermInfo 'Postgres
-  -> m (Parser 'Input n [RQL.AnnOrderByItemG 'Postgres UnpreparedValue])
+  -> m (Parser 'Input n [IR.AnnOrderByItemG 'Postgres UnpreparedValue])
 orderByExp table selectPermissions = memoizeOn 'orderByExp table $ do
   tableGQLName <- getTableGQLName table
   let name = tableGQLName <> $$(G.litName "_order_by")
@@ -47,13 +49,13 @@ orderByExp table selectPermissions = memoizeOn 'orderByExp table $ do
   where
     mkField
       :: FieldInfo 'Postgres
-      -> m (Maybe (InputFieldsParser n (Maybe [RQL.AnnOrderByItemG 'Postgres UnpreparedValue])))
+      -> m (Maybe (InputFieldsParser n (Maybe [IR.AnnOrderByItemG 'Postgres UnpreparedValue])))
     mkField fieldInfo = runMaybeT $
       case fieldInfo of
         FIColumn columnInfo -> do
           let fieldName = pgiName columnInfo
           pure $ P.fieldOptional fieldName Nothing orderByOperator
-            <&> fmap (pure . mkOrderByItemG (RQL.AOCColumn columnInfo)) . join
+            <&> fmap (pure . mkOrderByItemG (IR.AOCColumn columnInfo)) . join
         FIRelationship relationshipInfo -> do
           let remoteTable = riRTable relationshipInfo
           fieldName <- MaybeT $ pure $ G.mkName $ relNameToTxt $ riName relationshipInfo
@@ -64,13 +66,13 @@ orderByExp table selectPermissions = memoizeOn 'orderByExp table $ do
               otherTableParser <- lift $ orderByExp remoteTable perms
               pure $ do
                 otherTableOrderBy <- join <$> P.fieldOptional fieldName Nothing (P.nullable otherTableParser)
-                pure $ fmap (map $ fmap $ RQL.AOCObjectRelation relationshipInfo newPerms) otherTableOrderBy
+                pure $ fmap (map $ fmap $ IR.AOCObjectRelation relationshipInfo newPerms) otherTableOrderBy
             ArrRel -> do
               let aggregateFieldName = fieldName <> $$(G.litName "_aggregate")
               aggregationParser <- lift $ orderByAggregation remoteTable perms
               pure $ do
                 aggregationOrderBy <- join <$> P.fieldOptional aggregateFieldName Nothing (P.nullable aggregationParser)
-                pure $ fmap (map $ fmap $ RQL.AOCArrayAggregation relationshipInfo newPerms) aggregationOrderBy
+                pure $ fmap (map $ fmap $ IR.AOCArrayAggregation relationshipInfo newPerms) aggregationOrderBy
         FIComputedField _ -> empty
         FIRemoteRelationship _ -> empty
 
@@ -78,14 +80,18 @@ orderByExp table selectPermissions = memoizeOn 'orderByExp table $ do
 
 -- local definitions
 
-type OrderInfo = (SQL.OrderType, SQL.NullsOrder)
+type OrderInfo = (PG.OrderType, PG.NullsOrder)
 
+
+-- FIXME!
+-- those parsers are directly using Postgres' SQL representation of
+-- order, rather than using a general intermediary representation
 
 orderByAggregation
   :: forall m n r. (MonadSchema n m, MonadTableInfo r m, MonadRole r m)
   => QualifiedTable
   -> SelPermInfo 'Postgres
-  -> m (Parser 'Input n [OrderByItemG (RQL.AnnAggregateOrderBy 'Postgres)])
+  -> m (Parser 'Input n [IR.OrderByItemG (IR.AnnAggregateOrderBy 'Postgres)])
 orderByAggregation table selectPermissions = do
   -- WIP NOTE
   -- there is heavy duplication between this and Select.tableAggregationFields
@@ -100,7 +106,7 @@ orderByAggregation table selectPermissions = do
       aggFields   = fmap (concat . catMaybes . concat) $ sequenceA $ catMaybes
         [ -- count
           Just $ P.fieldOptional $$(G.litName "count") Nothing orderByOperator
-            <&> pure . fmap (pure . mkOrderByItemG RQL.AAOCount) . join
+            <&> pure . fmap (pure . mkOrderByItemG IR.AAOCount) . join
         , -- operators on numeric columns
           if null numColumns then Nothing else Just $
           for numericAggOperators \operator ->
@@ -123,34 +129,34 @@ orderByAggregation table selectPermissions = do
       :: G.Name
       -> G.Name
       -> InputFieldsParser n [(ColumnInfo 'Postgres, OrderInfo)]
-      -> InputFieldsParser n (Maybe [OrderByItemG (RQL.AnnAggregateOrderBy 'Postgres)])
+      -> InputFieldsParser n (Maybe [IR.OrderByItemG (IR.AnnAggregateOrderBy 'Postgres)])
     parseOperator operator tableGQLName columns =
       let opText     = G.unName operator
           objectName = tableGQLName <> $$(G.litName "_") <> operator <> $$(G.litName "_order_by")
           objectDesc = Just $ G.Description $ "order by " <> opText <> "() on columns of table " <>> table
       in  P.fieldOptional operator Nothing (P.object objectName objectDesc columns)
-        `mapField` map (\(col, info) -> mkOrderByItemG (RQL.AAOOp opText col) info)
+        `mapField` map (\(col, info) -> mkOrderByItemG (IR.AAOOp opText col) info)
 
 orderByOperator :: MonadParse m => Parser 'Both m (Maybe OrderInfo)
 orderByOperator =
   P.nullable $ P.enum $$(G.litName "order_by") (Just "column ordering options") $ NE.fromList
     [ ( define $$(G.litName "asc") "in ascending order, nulls last"
-      , (SQL.OTAsc, SQL.NLast)
+      , (PG.OTAsc, PG.NLast)
       )
     , ( define $$(G.litName "asc_nulls_first") "in ascending order, nulls first"
-      , (SQL.OTAsc, SQL.NFirst)
+      , (PG.OTAsc, PG.NFirst)
       )
     , ( define $$(G.litName "asc_nulls_last") "in ascending order, nulls last"
-      , (SQL.OTAsc, SQL.NLast)
+      , (PG.OTAsc, PG.NLast)
       )
     , ( define $$(G.litName "desc") "in descending order, nulls first"
-      , (SQL.OTDesc, SQL.NFirst)
+      , (PG.OTDesc, PG.NFirst)
       )
     , ( define $$(G.litName "desc_nulls_first") "in descending order, nulls first"
-      , (SQL.OTDesc, SQL.NFirst)
+      , (PG.OTDesc, PG.NFirst)
       )
     , ( define $$(G.litName "desc_nulls_last") "in descending order, nulls last"
-      , (SQL.OTDesc, SQL.NLast)
+      , (PG.OTDesc, PG.NLast)
       )
     ]
   where
@@ -160,11 +166,11 @@ orderByOperator =
 
 -- local helpers
 
-mkOrderByItemG :: a -> OrderInfo -> OrderByItemG a
+mkOrderByItemG :: a -> OrderInfo -> IR.OrderByItemG a
 mkOrderByItemG column (orderType, nullsOrder) =
-  OrderByItemG { obiType   = Just $ RQL.OrderType orderType
+  IR.OrderByItemG { obiType   = Just $ IR.OrderType orderType
                , obiColumn = column
-               , obiNulls  = Just $ RQL.NullsOrder nullsOrder
+               , obiNulls  = Just $ IR.NullsOrder nullsOrder
                }
 
 aliasToName :: G.Name -> FieldName

--- a/server/src-lib/Hasura/GraphQL/Schema/Select.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema/Select.hs
@@ -19,12 +19,6 @@ module Hasura.GraphQL.Schema.Select
 
 import           Hasura.Prelude
 
-import           Control.Lens                          hiding (index)
-import           Data.Has
-import           Data.Int                              (Int32)
-import           Data.Parser.JSONPath
-import           Data.Traversable                      (mapAccumL)
-
 import qualified Data.Aeson                            as J
 import qualified Data.Aeson.Extended                   as J
 import qualified Data.Aeson.Internal                   as J
@@ -37,14 +31,21 @@ import qualified Data.Sequence.NonEmpty                as NESeq
 import qualified Data.Text                             as T
 import qualified Language.GraphQL.Draft.Syntax         as G
 
-import qualified Hasura.Backends.Postgres.SQL.DML      as SQL
+import           Control.Lens                          hiding (index)
+import           Data.Has
+import           Data.Int                              (Int32)
+import           Data.Parser.JSONPath
+import           Data.Text.Extended
+import           Data.Traversable                      (mapAccumL)
+
+import qualified Hasura.Backends.Postgres.SQL.DML      as PG
 import qualified Hasura.GraphQL.Execute.Types          as ET
 import qualified Hasura.GraphQL.Parser                 as P
 import qualified Hasura.GraphQL.Parser.Internal.Parser as P
-import qualified Hasura.RQL.IR.BoolExp                 as RQL
-import qualified Hasura.RQL.IR.Select                  as RQL
+import qualified Hasura.RQL.IR.BoolExp                 as IR
+import qualified Hasura.RQL.IR.OrderBy                 as IR
+import qualified Hasura.RQL.IR.Select                  as IR
 
-import           Data.Text.Extended
 import           Hasura.Backends.Postgres.SQL.Types
 import           Hasura.Backends.Postgres.SQL.Value
 import           Hasura.GraphQL.Parser                 (FieldParser, InputFieldsParser, Kind (..),
@@ -59,13 +60,14 @@ import           Hasura.GraphQL.Schema.Table
 import           Hasura.RQL.Types
 import           Hasura.Server.Utils                   (executeJSONPath)
 
-type SelectExp           b = RQL.AnnSimpleSelG b UnpreparedValue
-type AggSelectExp        b = RQL.AnnAggregateSelectG b UnpreparedValue
-type ConnectionSelectExp b = RQL.ConnectionSelect b UnpreparedValue
-type SelectArgs          b = RQL.SelectArgsG b UnpreparedValue
-type TablePerms          b = RQL.TablePermG b UnpreparedValue
-type AnnotatedFields     b = RQL.AnnFieldsG b UnpreparedValue
-type AnnotatedField      b = RQL.AnnFieldG b UnpreparedValue
+
+type SelectExp           b = IR.AnnSimpleSelG b UnpreparedValue
+type AggSelectExp        b = IR.AnnAggregateSelectG b UnpreparedValue
+type ConnectionSelectExp b = IR.ConnectionSelect b UnpreparedValue
+type SelectArgs          b = IR.SelectArgsG b UnpreparedValue
+type TablePerms          b = IR.TablePermG b UnpreparedValue
+type AnnotatedFields     b = IR.AnnFieldsG b UnpreparedValue
+type AnnotatedField      b = IR.AnnFieldG b UnpreparedValue
 
 
 
@@ -93,12 +95,12 @@ selectTable table fieldName description selectPermissions = do
   tableArgsParser    <- tableArgs table selectPermissions
   selectionSetParser <- tableSelectionList table selectPermissions
   pure $ P.subselection fieldName description tableArgsParser selectionSetParser
-    <&> \(args, fields) -> RQL.AnnSelectG
-      { RQL._asnFields   = fields
-      , RQL._asnFrom     = RQL.FromTable table
-      , RQL._asnPerm     = tablePermissionsInfo selectPermissions
-      , RQL._asnArgs     = args
-      , RQL._asnStrfyNum = stringifyNum
+    <&> \(args, fields) -> IR.AnnSelectG
+      { IR._asnFields   = fields
+      , IR._asnFrom     = IR.FromTable table
+      , IR._asnPerm     = tablePermissionsInfo selectPermissions
+      , IR._asnArgs     = args
+      , IR._asnStrfyNum = stringifyNum
       }
 
 -- | Simple table connection selection.
@@ -133,16 +135,16 @@ selectTableConnection table fieldName description pkeyColumns selectPermissions 
   selectArgsParser   <- tableConnectionArgs pkeyColumns table selectPermissions
   selectionSetParser <- P.nonNullableParser <$> tableConnectionSelectionSet table selectPermissions
   pure $ P.subselection fieldName description selectArgsParser selectionSetParser
-    <&> \((args, split, slice), fields) -> RQL.ConnectionSelect
-      { RQL._csPrimaryKeyColumns = pkeyColumns
-      , RQL._csSplit = split
-      , RQL._csSlice = slice
-      , RQL._csSelect = RQL.AnnSelectG
-        { RQL._asnFields   = fields
-        , RQL._asnFrom     = RQL.FromTable table
-        , RQL._asnPerm     = tablePermissionsInfo selectPermissions
-        , RQL._asnArgs     = args
-        , RQL._asnStrfyNum = stringifyNum
+    <&> \((args, split, slice), fields) -> IR.ConnectionSelect
+      { IR._csPrimaryKeyColumns = pkeyColumns
+      , IR._csSplit = split
+      , IR._csSlice = slice
+      , IR._csSelect = IR.AnnSelectG
+        { IR._asnFields   = fields
+        , IR._asnFrom     = IR.FromTable table
+        , IR._asnPerm     = tablePermissionsInfo selectPermissions
+        , IR._asnArgs     = args
+        , IR._asnStrfyNum = stringifyNum
         }
       }
 
@@ -177,14 +179,14 @@ selectTableByPk table fieldName description selectPermissions = runMaybeT do
     <&> \(boolExpr, fields) ->
       let defaultPerms = tablePermissionsInfo selectPermissions
           -- Do not account permission limit since the result is just a nullable object
-          permissions  = defaultPerms { RQL._tpLimit = Nothing }
+          permissions  = defaultPerms { IR._tpLimit = Nothing }
           whereExpr    = Just $ BoolAnd $ toList boolExpr
-      in RQL.AnnSelectG
-           { RQL._asnFields   = fields
-           , RQL._asnFrom     = RQL.FromTable table
-           , RQL._asnPerm     = permissions
-           , RQL._asnArgs     = RQL.noSelectArgs { RQL._saWhere = whereExpr }
-           , RQL._asnStrfyNum = stringifyNum
+      in IR.AnnSelectG
+           { IR._asnFields   = fields
+           , IR._asnFrom     = IR.FromTable table
+           , IR._asnPerm     = permissions
+           , IR._asnArgs     = IR.noSelectArgs { IR._saWhere = whereExpr }
+           , IR._asnStrfyNum = stringifyNum
            }
 
 -- | Table aggregation selection
@@ -213,18 +215,18 @@ selectTableAggregate table fieldName description selectPermissions = runMaybeT d
   nodesParser     <- lift $ tableSelectionList table selectPermissions
   let selectionName = tableGQLName <> $$(G.litName "_aggregate")
       aggregationParser = P.nonNullableParser $
-        parsedSelectionsToFields RQL.TAFExp <$>
+        parsedSelectionsToFields IR.TAFExp <$>
         P.selectionSet selectionName (Just $ G.Description $ "aggregated selection of " <>> table)
-        [ RQL.TAFNodes <$> P.subselection_ $$(G.litName "nodes") Nothing nodesParser
-        , RQL.TAFAgg <$> P.subselection_ $$(G.litName "aggregate") Nothing aggregateParser
+        [ IR.TAFNodes <$> P.subselection_ $$(G.litName "nodes") Nothing nodesParser
+        , IR.TAFAgg <$> P.subselection_ $$(G.litName "aggregate") Nothing aggregateParser
         ]
   pure $ P.subselection fieldName description tableArgsParser aggregationParser
-    <&> \(args, fields) -> RQL.AnnSelectG
-      { RQL._asnFields   = fields
-      , RQL._asnFrom     = RQL.FromTable table
-      , RQL._asnPerm     = tablePermissionsInfo selectPermissions
-      , RQL._asnArgs     = args
-      , RQL._asnStrfyNum = stringifyNum
+    <&> \(args, fields) -> IR.AnnSelectG
+      { IR._asnFields   = fields
+      , IR._asnFrom     = IR.FromTable table
+      , IR._asnPerm     = tablePermissionsInfo selectPermissions
+      , IR._asnArgs     = args
+      , IR._asnStrfyNum = stringifyNum
       }
 
 {- Note [Selectability of tables]
@@ -321,14 +323,14 @@ tableSelectionSet table selectPermissions = memoizeOn 'tableSelectionSet table d
     -- A relay table
     (ET.QueryRelay, Just pkeyColumns) -> do
       let nodeIdFieldParser =
-            P.selection_ $$(G.litName "id") Nothing P.identifier $> RQL.AFNodeId table pkeyColumns
+            P.selection_ $$(G.litName "id") Nothing P.identifier $> IR.AFNodeId table pkeyColumns
           allFieldParsers = fieldParsers <> [nodeIdFieldParser]
       nodeInterface <- node
       pure $ P.selectionSetObject tableGQLName description allFieldParsers [nodeInterface]
-            <&> parsedSelectionsToFields RQL.AFExpression
+            <&> parsedSelectionsToFields IR.AFExpression
     _                                 ->
       pure $ P.selectionSetObject tableGQLName description fieldParsers []
-            <&> parsedSelectionsToFields RQL.AFExpression
+            <&> parsedSelectionsToFields IR.AFExpression
 
 -- | List of table fields object.
 -- Just a @'nonNullableObjectList' wrapper over @'tableSelectionSet'.
@@ -376,50 +378,50 @@ tableConnectionSelectionSet
                    )
   => QualifiedTable
   -> SelPermInfo 'Postgres
-  -> m (Parser 'Output n (RQL.ConnectionFields 'Postgres UnpreparedValue))
+  -> m (Parser 'Output n (IR.ConnectionFields 'Postgres UnpreparedValue))
 tableConnectionSelectionSet table selectPermissions = do
   edgesParser  <- tableEdgesSelectionSet
   tableGQLName <- getTableGQLName table
   let connectionTypeName = tableGQLName <> $$(G.litName "Connection")
       pageInfo = P.subselection_ $$(G.litName "pageInfo") Nothing
-                 pageInfoSelectionSet <&> RQL.ConnectionPageInfo
+                 pageInfoSelectionSet <&> IR.ConnectionPageInfo
       edges = P.subselection_ $$(G.litName "edges") Nothing
-              edgesParser <&> RQL.ConnectionEdges
+              edgesParser <&> IR.ConnectionEdges
       connectionDescription = G.Description $ "A Relay connection object on " <>> table
   pure $ P.nonNullableParser $
          P.selectionSet connectionTypeName (Just connectionDescription) [pageInfo, edges]
-         <&> parsedSelectionsToFields RQL.ConnectionTypename
+         <&> parsedSelectionsToFields IR.ConnectionTypename
   where
-    pageInfoSelectionSet :: Parser 'Output n RQL.PageInfoFields
+    pageInfoSelectionSet :: Parser 'Output n IR.PageInfoFields
     pageInfoSelectionSet =
       let startCursorField     = P.selection_ $$(G.litName "startCursor") Nothing
-                                 P.string $> RQL.PageInfoStartCursor
+                                 P.string $> IR.PageInfoStartCursor
           endCursorField       = P.selection_ $$(G.litName "endCursor") Nothing
-                                 P.string $> RQL.PageInfoEndCursor
+                                 P.string $> IR.PageInfoEndCursor
           hasNextPageField     = P.selection_ $$(G.litName "hasNextPage") Nothing
-                                 P.boolean $> RQL.PageInfoHasNextPage
+                                 P.boolean $> IR.PageInfoHasNextPage
           hasPreviousPageField = P.selection_ $$(G.litName "hasPreviousPage") Nothing
-                                 P.boolean $> RQL.PageInfoHasPreviousPage
+                                 P.boolean $> IR.PageInfoHasPreviousPage
           allFields            =
             [ startCursorField, endCursorField
             , hasNextPageField, hasPreviousPageField
             ]
       in P.nonNullableParser $ P.selectionSet $$(G.litName "PageInfo") Nothing allFields
-         <&> parsedSelectionsToFields RQL.PageInfoTypename
+         <&> parsedSelectionsToFields IR.PageInfoTypename
 
 
     tableEdgesSelectionSet
-      :: m (Parser 'Output n (RQL.EdgeFields 'Postgres UnpreparedValue))
+      :: m (Parser 'Output n (IR.EdgeFields 'Postgres UnpreparedValue))
     tableEdgesSelectionSet = do
       tableGQLName        <- getTableGQLName table
       edgeNodeParser      <- P.nonNullableParser <$> tableSelectionSet table selectPermissions
       let edgesType = tableGQLName <> $$(G.litName "Edge")
           cursor    = P.selection_ $$(G.litName "cursor") Nothing
-                      P.string $> RQL.EdgeCursor
+                      P.string $> IR.EdgeCursor
           edgeNode  = P.subselection_ $$(G.litName "node") Nothing
-                      edgeNodeParser <&> RQL.EdgeNode
+                      edgeNodeParser <&> IR.EdgeNode
       pure $ nonNullableObjectList $ P.selectionSet edgesType Nothing [cursor, edgeNode]
-             <&> parsedSelectionsToFields RQL.EdgeTypename
+             <&> parsedSelectionsToFields IR.EdgeTypename
 
 -- | User-defined function (AKA custom function)
 selectFunction
@@ -437,12 +439,12 @@ selectFunction function fieldName description selectPermissions = do
   selectionSetParser <- tableSelectionList table selectPermissions
   let argsParser = liftA2 (,) functionArgsParser tableArgsParser
   pure $ P.subselection fieldName description argsParser selectionSetParser
-    <&> \((funcArgs, tableArgs'), fields) -> RQL.AnnSelectG
-      { RQL._asnFields   = fields
-      , RQL._asnFrom     = RQL.FromFunction (fiName function) funcArgs Nothing
-      , RQL._asnPerm     = tablePermissionsInfo selectPermissions
-      , RQL._asnArgs     = tableArgs'
-      , RQL._asnStrfyNum = stringifyNum
+    <&> \((funcArgs, tableArgs'), fields) -> IR.AnnSelectG
+      { IR._asnFields   = fields
+      , IR._asnFrom     = IR.FromFunction (fiName function) funcArgs Nothing
+      , IR._asnPerm     = tablePermissionsInfo selectPermissions
+      , IR._asnArgs     = tableArgs'
+      , IR._asnStrfyNum = stringifyNum
       }
 
 selectFunctionAggregate
@@ -463,19 +465,19 @@ selectFunctionAggregate function fieldName description selectPermissions = runMa
   selectionName      <- lift $ pure tableGQLName <&> (<> $$(G.litName "_aggregate"))
   nodesParser        <- lift $ tableSelectionList table selectPermissions
   let argsParser = liftA2 (,) functionArgsParser tableArgsParser
-      aggregationParser = fmap (parsedSelectionsToFields RQL.TAFExp) $
+      aggregationParser = fmap (parsedSelectionsToFields IR.TAFExp) $
         P.nonNullableParser $
         P.selectionSet selectionName Nothing
-        [ RQL.TAFNodes <$> P.subselection_ $$(G.litName "nodes") Nothing nodesParser
-        , RQL.TAFAgg <$> P.subselection_ $$(G.litName "aggregate") Nothing aggregateParser
+        [ IR.TAFNodes <$> P.subselection_ $$(G.litName "nodes") Nothing nodesParser
+        , IR.TAFAgg <$> P.subselection_ $$(G.litName "aggregate") Nothing aggregateParser
         ]
   pure $ P.subselection fieldName description argsParser aggregationParser
-    <&> \((funcArgs, tableArgs'), fields) -> RQL.AnnSelectG
-      { RQL._asnFields   = fields
-      , RQL._asnFrom     = RQL.FromFunction (fiName function) funcArgs Nothing
-      , RQL._asnPerm     = tablePermissionsInfo selectPermissions
-      , RQL._asnArgs     = tableArgs'
-      , RQL._asnStrfyNum = stringifyNum
+    <&> \((funcArgs, tableArgs'), fields) -> IR.AnnSelectG
+      { IR._asnFields   = fields
+      , IR._asnFrom     = IR.FromFunction (fiName function) funcArgs Nothing
+      , IR._asnPerm     = tablePermissionsInfo selectPermissions
+      , IR._asnArgs     = tableArgs'
+      , IR._asnStrfyNum = stringifyNum
       }
 
 selectFunctionConnection
@@ -494,16 +496,16 @@ selectFunctionConnection function fieldName description pkeyColumns selectPermis
   selectionSetParser <- tableConnectionSelectionSet table selectPermissions
   let argsParser = liftA2 (,) functionArgsParser tableConnectionArgsParser
   pure $ P.subselection fieldName description argsParser selectionSetParser
-    <&> \((funcArgs, (args, split, slice)), fields) -> RQL.ConnectionSelect
-      { RQL._csPrimaryKeyColumns = pkeyColumns
-      , RQL._csSplit = split
-      , RQL._csSlice = slice
-      , RQL._csSelect = RQL.AnnSelectG
-        { RQL._asnFields   = fields
-        , RQL._asnFrom     = RQL.FromFunction (fiName function) funcArgs Nothing
-        , RQL._asnPerm     = tablePermissionsInfo selectPermissions
-        , RQL._asnArgs     = args
-        , RQL._asnStrfyNum = stringifyNum
+    <&> \((funcArgs, (args, split, slice)), fields) -> IR.ConnectionSelect
+      { IR._csPrimaryKeyColumns = pkeyColumns
+      , IR._csSplit = split
+      , IR._csSlice = slice
+      , IR._csSelect = IR.AnnSelectG
+        { IR._asnFields   = fields
+        , IR._asnFrom     = IR.FromFunction (fiName function) funcArgs Nothing
+        , IR._asnPerm     = tablePermissionsInfo selectPermissions
+        , IR._asnArgs     = args
+        , IR._asnStrfyNum = stringifyNum
         }
       }
 
@@ -518,7 +520,7 @@ tableWhere
   :: forall m n r. (MonadSchema n m, MonadTableInfo r m, MonadRole r m)
   => QualifiedTable
   -> SelPermInfo 'Postgres
-  -> m (InputFieldsParser n (Maybe (RQL.AnnBoolExp 'Postgres UnpreparedValue)))
+  -> m (InputFieldsParser n (Maybe (IR.AnnBoolExp 'Postgres UnpreparedValue)))
 tableWhere table selectPermissions = do
   boolExpParser <- boolExp table (Just selectPermissions)
   pure $ fmap join $
@@ -533,7 +535,7 @@ tableOrderBy
   :: forall m n r. (MonadSchema n m, MonadTableInfo r m, MonadRole r m)
   => QualifiedTable
   -> SelPermInfo 'Postgres
-  -> m (InputFieldsParser n (Maybe (NonEmpty (RQL.AnnOrderByItemG 'Postgres UnpreparedValue))))
+  -> m (InputFieldsParser n (Maybe (NonEmpty (IR.AnnOrderByItemG 'Postgres UnpreparedValue))))
 tableOrderBy table selectPermissions = do
   orderByParser <- orderByExp table selectPermissions
   pure $ do
@@ -583,16 +585,16 @@ tableArgs table selectPermissions = do
         limit    <- fmap join $ P.fieldOptional limitName   limitDesc   $ P.nullable positiveInt
         offset   <- fmap join $ P.fieldOptional offsetName  offsetDesc  $ P.nullable fakeBigInt
         distinct <- distinctParser
-        pure $ RQL.SelectArgs
-          { RQL._saWhere    = whereF
-          , RQL._saOrderBy  = orderBy
-          , RQL._saLimit    = fromIntegral <$> limit
-          , RQL._saOffset   = txtEncoder <$> offset
-          , RQL._saDistinct = distinct
+        pure $ IR.SelectArgs
+          { IR._saWhere    = whereF
+          , IR._saOrderBy  = orderBy
+          , IR._saLimit    = fromIntegral <$> limit
+          , IR._saOffset   = txtEncoder <$> offset
+          , IR._saDistinct = distinct
           }
   pure $ selectArgs `P.bindFields`
    \args -> do
-      traverse_ (validateDistinctOn $ RQL._saOrderBy args) $ RQL._saDistinct args
+      traverse_ (validateDistinctOn $ IR._saOrderBy args) $ IR._saDistinct args
       pure args
   where
     -- TODO: THIS IS A TEMPORARY FIX
@@ -629,9 +631,9 @@ tableArgs table selectPermissions = do
       let colsLen = length distinctOnCols
           initOrderBys = take colsLen $ NE.toList orderByCols
           initOrdByCols = flip mapMaybe initOrderBys $ \ob ->
-            case obiColumn ob of
-              RQL.AOCColumn pgCol -> Just $ pgiColumn pgCol
-              _                   -> Nothing
+            case IR.obiColumn ob of
+              IR.AOCColumn pgCol -> Just $ pgiColumn pgCol
+              _                  -> Nothing
           isValid = (colsLen == length initOrdByCols)
                     && all (`elem` initOrdByCols) (toList distinctOnCols)
       unless isValid $ parseError
@@ -661,8 +663,8 @@ tableConnectionArgs
   -> SelPermInfo 'Postgres
   -> m ( InputFieldsParser n
          ( SelectArgs 'Postgres
-         , Maybe (NonEmpty (RQL.ConnectionSplit 'Postgres UnpreparedValue))
-         , Maybe RQL.ConnectionSlice
+         , Maybe (NonEmpty (IR.ConnectionSplit 'Postgres UnpreparedValue))
+         , Maybe IR.ConnectionSlice
          )
        )
 tableConnectionArgs pkeyColumns table selectPermissions = do
@@ -688,37 +690,37 @@ tableConnectionArgs pkeyColumns table selectPermissions = do
       rawSplit <- case (after, before) of
         (Nothing, Nothing) -> pure Nothing
         (Just _, Just _)   -> parseError "\"after\" and \"before\" are not allowed at once"
-        (Just v, Nothing)  -> pure $ Just (RQL.CSKAfter, v)
-        (Nothing, Just v)  -> pure $ Just (RQL.CSKBefore, v)
+        (Just v, Nothing)  -> pure $ Just (IR.CSKAfter, v)
+        (Nothing, Just v)  -> pure $ Just (IR.CSKBefore, v)
       for rawSplit (uncurry (parseConnectionSplit orderBy'))
 
     slice <- firstAndLast `P.bindFields` \case
       (Nothing, Nothing) -> pure Nothing
       (Just _, Just _)   -> parseError "\"first\" and \"last\" are not allowed at once"
-      (Just v, Nothing)  -> pure $ Just $ RQL.SliceFirst $ fromIntegral v
-      (Nothing, Just v)  -> pure $ Just $ RQL.SliceLast $ fromIntegral v
+      (Just v, Nothing)  -> pure $ Just $ IR.SliceFirst $ fromIntegral v
+      (Nothing, Just v)  -> pure $ Just $ IR.SliceLast $ fromIntegral v
 
-    pure ( RQL.SelectArgs whereF orderBy Nothing Nothing distinct
+    pure ( IR.SelectArgs whereF orderBy Nothing Nothing distinct
          , split
          , slice
          )
   where
     base64Text = base64Decode <$> P.string
 
-    appendPrimaryKeyOrderBy :: NonEmpty (RQL.AnnOrderByItemG 'Postgres v) -> NonEmpty (RQL.AnnOrderByItemG 'Postgres v)
+    appendPrimaryKeyOrderBy :: NonEmpty (IR.AnnOrderByItemG 'Postgres v) -> NonEmpty (IR.AnnOrderByItemG 'Postgres v)
     appendPrimaryKeyOrderBy orderBys@(h NE.:| t) =
       let orderByColumnNames =
-            orderBys ^.. traverse . to obiColumn . RQL._AOCColumn . to pgiColumn
+            orderBys ^.. traverse . to IR.obiColumn . IR._AOCColumn . to pgiColumn
           pkeyOrderBys = flip mapMaybe (toList pkeyColumns) $ \pgColumnInfo ->
                          if pgiColumn pgColumnInfo `elem` orderByColumnNames then Nothing
-                         else Just $ OrderByItemG Nothing (RQL.AOCColumn pgColumnInfo) Nothing
+                         else Just $ IR.OrderByItemG Nothing (IR.AOCColumn pgColumnInfo) Nothing
       in h NE.:| (t <> pkeyOrderBys)
 
     parseConnectionSplit
-      :: Maybe (NonEmpty (RQL.AnnOrderByItemG 'Postgres UnpreparedValue))
-      -> RQL.ConnectionSplitKind
+      :: Maybe (NonEmpty (IR.AnnOrderByItemG 'Postgres UnpreparedValue))
+      -> IR.ConnectionSplitKind
       -> BL.ByteString
-      -> n (NonEmpty (RQL.ConnectionSplit 'Postgres UnpreparedValue))
+      -> n (NonEmpty (IR.ConnectionSplit 'Postgres UnpreparedValue))
     parseConnectionSplit maybeOrderBys splitKind cursorSplit = do
       cursorValue <- J.eitherDecode cursorSplit `onLeft` const throwInvalidCursor
       case maybeOrderBys of
@@ -730,42 +732,42 @@ tableConnectionArgs pkeyColumns table selectPermissions = do
               `onNothing` throwInvalidCursor
             pgValue <- liftQErr $ parsePGScalarValue columnType pgColumnValue
             let unresolvedValue = flip UVParameter Nothing $ P.PGColumnValue columnType pgValue
-            pure $ RQL.ConnectionSplit splitKind unresolvedValue $
-                   OrderByItemG Nothing (RQL.AOCColumn pgColumnInfo) Nothing
+            pure $ IR.ConnectionSplit splitKind unresolvedValue $
+                   IR.OrderByItemG Nothing (IR.AOCColumn pgColumnInfo) Nothing
         Just orderBys ->
           forM orderBys $ \orderBy -> do
-            let OrderByItemG orderType annObCol nullsOrder = orderBy
+            let IR.OrderByItemG orderType annObCol nullsOrder = orderBy
                 columnType = getOrderByColumnType annObCol
             orderByItemValue <- iResultToMaybe (executeJSONPath (getPathFromOrderBy annObCol) cursorValue)
               `onNothing` throwInvalidCursor
             pgValue <- liftQErr $ parsePGScalarValue columnType orderByItemValue
             let unresolvedValue = flip UVParameter Nothing $ P.PGColumnValue columnType pgValue
-            pure $ RQL.ConnectionSplit splitKind unresolvedValue $
-                   OrderByItemG orderType (() <$ annObCol) nullsOrder
+            pure $ IR.ConnectionSplit splitKind unresolvedValue $
+                   IR.OrderByItemG orderType (() <$ annObCol) nullsOrder
       where
         throwInvalidCursor = parseError "the \"after\" or \"before\" cursor is invalid"
         liftQErr = either (parseError . qeError) pure . runExcept
 
         getPathFromOrderBy = \case
-          RQL.AOCColumn pgColInfo ->
+          IR.AOCColumn pgColInfo ->
             let pathElement = J.Key $ getPGColTxt $ pgiColumn pgColInfo
             in [pathElement]
-          RQL.AOCObjectRelation relInfo _ obCol ->
+          IR.AOCObjectRelation relInfo _ obCol ->
             let pathElement = J.Key $ relNameToTxt $ riName relInfo
             in pathElement : getPathFromOrderBy obCol
-          RQL.AOCArrayAggregation relInfo _ aggOb ->
+          IR.AOCArrayAggregation relInfo _ aggOb ->
             let fieldName = J.Key $ relNameToTxt (riName relInfo) <> "_aggregate"
             in fieldName : case aggOb of
-                 RQL.AAOCount    -> [J.Key "count"]
-                 RQL.AAOOp t col -> [J.Key t, J.Key $ getPGColTxt $ pgiColumn col]
+                 IR.AAOCount    -> [J.Key "count"]
+                 IR.AAOOp t col -> [J.Key t, J.Key $ getPGColTxt $ pgiColumn col]
 
         getOrderByColumnType = \case
-          RQL.AOCColumn pgColInfo -> pgiType pgColInfo
-          RQL.AOCObjectRelation _ _ obCol -> getOrderByColumnType obCol
-          RQL.AOCArrayAggregation _ _ aggOb ->
+          IR.AOCColumn pgColInfo -> pgiType pgColInfo
+          IR.AOCObjectRelation _ _ obCol -> getOrderByColumnType obCol
+          IR.AOCArrayAggregation _ _ aggOb ->
             case aggOb of
-              RQL.AAOCount        -> PGColumnScalar PGInteger
-              RQL.AAOOp _ colInfo -> pgiType colInfo
+              IR.AAOCount        -> PGColumnScalar PGInteger
+              IR.AAOOp _ colInfo -> pgiType colInfo
 
 -- | Aggregation fields
 --
@@ -784,7 +786,7 @@ tableAggregationFields
   :: forall m n r. (MonadSchema n m, MonadTableInfo r m, MonadRole r m)
   => QualifiedTable
   -> SelPermInfo 'Postgres
-  -> m (Parser 'Output n (RQL.AggregateFields 'Postgres))
+  -> m (Parser 'Output n (IR.AggregateFields 'Postgres))
 tableAggregationFields table selectPermissions = do
   tableGQLName  <- getTableGQLName table
   allColumns <- tableSelectColumns table selectPermissions
@@ -807,22 +809,22 @@ tableAggregationFields table selectPermissions = do
     ]
   let aggregateFields = count : numericAndComparable
   pure $ P.selectionSet selectName (Just description) aggregateFields
-        <&> parsedSelectionsToFields RQL.AFExp
+        <&> parsedSelectionsToFields IR.AFExp
   where
-    mkNumericAggFields :: G.Name -> [ColumnInfo 'Postgres] -> m [FieldParser n (RQL.ColFld 'Postgres)]
+    mkNumericAggFields :: G.Name -> [ColumnInfo 'Postgres] -> m [FieldParser n (IR.ColFld 'Postgres)]
     mkNumericAggFields name
       | name == $$(G.litName "sum") = traverse mkColumnAggField
       | otherwise                   = traverse \columnInfo ->
           pure $ P.selection_ (pgiName columnInfo) (pgiDescription columnInfo)
-                 (P.nullable P.float) $> RQL.CFCol (pgiColumn columnInfo)
+                 (P.nullable P.float) $> IR.CFCol (pgiColumn columnInfo)
 
-    mkColumnAggField :: ColumnInfo 'Postgres -> m (FieldParser n (RQL.ColFld 'Postgres))
+    mkColumnAggField :: ColumnInfo 'Postgres -> m (FieldParser n (IR.ColFld 'Postgres))
     mkColumnAggField columnInfo = do
       field <- P.column (pgiType columnInfo) (G.Nullability True)
       pure $ P.selection_ (pgiName columnInfo) (pgiDescription columnInfo) field
-        $> RQL.CFCol (pgiColumn columnInfo)
+        $> IR.CFCol (pgiColumn columnInfo)
 
-    countField :: m (FieldParser n (RQL.AggregateField 'Postgres))
+    countField :: m (FieldParser n (IR.AggregateField 'Postgres))
     countField = do
       columnsEnum <- tableSelectColumnsEnum table selectPermissions
       let columnsName  = $$(G.litName "columns")
@@ -831,25 +833,25 @@ tableAggregationFields table selectPermissions = do
             distinct <- P.fieldOptional distinctName Nothing P.boolean
             columns  <- maybe (pure Nothing) (P.fieldOptional columnsName Nothing . P.list) columnsEnum
             pure $ case columns of
-                     Nothing   -> SQL.CTStar
+                     Nothing   -> PG.CTStar
                      Just cols -> if Just True == distinct
-                                  then SQL.CTDistinct cols
-                                  else SQL.CTSimple   cols
-      pure $ RQL.AFCount <$> P.selection $$(G.litName "count") Nothing args P.int
+                                  then PG.CTDistinct cols
+                                  else PG.CTSimple   cols
+      pure $ IR.AFCount <$> P.selection $$(G.litName "count") Nothing args P.int
 
     parseAggOperator
       :: G.Name
       -> G.Name
-      -> [FieldParser n (RQL.ColFld 'Postgres)]
-      -> FieldParser n (RQL.AggregateField 'Postgres)
+      -> [FieldParser n (IR.ColFld 'Postgres)]
+      -> FieldParser n (IR.AggregateField 'Postgres)
     parseAggOperator operator tableGQLName columns =
       let opText  = G.unName operator
           setName = tableGQLName <> $$(G.litName "_") <> operator <> $$(G.litName "_fields")
           setDesc = Just $ G.Description $ "aggregate " <> opText <> " on columns"
           subselectionParser = P.selectionSet setName setDesc columns
-            <&> parsedSelectionsToFields RQL.CFExp
+            <&> parsedSelectionsToFields IR.CFExp
       in P.subselection_ operator Nothing subselectionParser
-         <&> (RQL.AFOp . RQL.AggregateOp opText)
+         <&> (IR.AFOp . IR.AggregateOp opText)
 
 lookupRemoteField'
   :: (MonadSchema n m, MonadTableInfo r m)
@@ -895,13 +897,13 @@ fieldSelection table maybePkeyColumns fieldInfo selectPermissions =
       if | fieldName == $$(G.litName "id") && queryType == ET.QueryRelay -> do
              pkeyColumns <- MaybeT $ pure maybePkeyColumns
              pure $ P.selection_ fieldName Nothing P.identifier
-                    $> RQL.AFNodeId table pkeyColumns
+                    $> IR.AFNodeId table pkeyColumns
          | otherwise -> do
              guard $ Set.member columnName (spiCols selectPermissions)
              let pathArg = jsonPathArg $ pgiType columnInfo
              field <- lift $ P.column (pgiType columnInfo) (G.Nullability $ pgiIsNullable columnInfo)
              pure $ P.selection fieldName (pgiDescription columnInfo) pathArg field
-               <&> RQL.mkAnnColumnField columnInfo
+               <&> IR.mkAnnColumnField columnInfo
 
     FIRelationship relationshipInfo ->
       concat . maybeToList <$> relationshipField relationshipInfo
@@ -929,14 +931,14 @@ relationshipField relationshipInfo = runMaybeT do
       selectionSetParser <- lift $ tableSelectionSet otherTable remotePerms
       pure $ pure $ (if nullable then id else P.nonNullableField) $
         P.subselection_ relFieldName desc selectionSetParser
-             <&> \fields -> RQL.AFObjectRelation $ RQL.AnnRelationSelectG relName colMapping $
-                    RQL.AnnObjectSelectG fields otherTable $
-                    RQL._tpFilter $ tablePermissionsInfo remotePerms
+             <&> \fields -> IR.AFObjectRelation $ IR.AnnRelationSelectG relName colMapping $
+                    IR.AnnObjectSelectG fields otherTable $
+                    IR._tpFilter $ tablePermissionsInfo remotePerms
     ArrRel -> do
       let arrayRelDesc = Just $ G.Description "An array relationship"
       otherTableParser <- lift $ selectTable otherTable relFieldName arrayRelDesc remotePerms
-      let arrayRelField = otherTableParser <&> \selectExp -> RQL.AFArrayRelation $
-            RQL.ASSimple $ RQL.AnnRelationSelectG relName colMapping selectExp
+      let arrayRelField = otherTableParser <&> \selectExp -> IR.AFArrayRelation $
+            IR.ASSimple $ IR.AnnRelationSelectG relName colMapping selectExp
           relAggFieldName = relFieldName <> $$(G.litName "_aggregate")
           relAggDesc      = Just $ G.Description "An aggregate relationship"
       remoteAggField <- lift $ selectTableAggregate otherTable relAggFieldName relAggDesc remotePerms
@@ -951,8 +953,8 @@ relationshipField relationshipInfo = runMaybeT do
         lift $ lift $ selectTableConnection otherTable relConnectionName
                       relConnectionDesc pkeyColumns remotePerms
       pure $ catMaybes [ Just arrayRelField
-                       , fmap (RQL.AFArrayRelation . RQL.ASAggregate . RQL.AnnRelationSelectG relName colMapping) <$> remoteAggField
-                       , fmap (RQL.AFArrayRelation . RQL.ASConnection . RQL.AnnRelationSelectG relName colMapping) <$> remoteConnectionField
+                       , fmap (IR.AFArrayRelation . IR.ASAggregate . IR.AnnRelationSelectG relName colMapping) <$> remoteAggField
+                       , fmap (IR.AFArrayRelation . IR.ASConnection . IR.AnnRelationSelectG relName colMapping) <$> remoteConnectionField
                        ]
 
 -- | Computed field parser
@@ -972,11 +974,11 @@ computedField ComputedFieldInfo{..} selectPermissions = runMaybeT do
       let fieldArgsParser = do
             args  <- functionArgsParser
             colOp <- jsonPathArg $ PGColumnScalar scalarReturnType
-            pure $ RQL.AFComputedField $ RQL.CFSScalar $ RQL.ComputedFieldScalarSelect
-              { RQL._cfssFunction  = _cffName _cfiFunction
-              , RQL._cfssType      = scalarReturnType
-              , RQL._cfssColumnOp  = colOp
-              , RQL._cfssArguments = args
+            pure $ IR.AFComputedField $ IR.CFSScalar $ IR.ComputedFieldScalarSelect
+              { IR._cfssFunction  = _cffName _cfiFunction
+              , IR._cfssType      = scalarReturnType
+              , IR._cfssColumnOp  = colOp
+              , IR._cfssArguments = args
               }
       dummyParser <- lift $ P.column (PGColumnScalar scalarReturnType) (G.Nullability True)
       pure $ P.selection fieldName (Just fieldDescription) fieldArgsParser dummyParser
@@ -987,12 +989,12 @@ computedField ComputedFieldInfo{..} selectPermissions = runMaybeT do
       let fieldArgsParser = liftA2 (,) functionArgsParser selectArgsParser
       pure $ P.subselection fieldName (Just fieldDescription) fieldArgsParser selectionSetParser <&>
         \((functionArgs', args), fields) ->
-          RQL.AFComputedField $ RQL.CFSTable RQL.JASMultipleRows $ RQL.AnnSelectG
-            { RQL._asnFields   = fields
-            , RQL._asnFrom     = RQL.FromFunction (_cffName _cfiFunction) functionArgs' Nothing
-            , RQL._asnPerm     = tablePermissionsInfo remotePerms
-            , RQL._asnArgs     = args
-            , RQL._asnStrfyNum = stringifyNum
+          IR.AFComputedField $ IR.CFSTable IR.JASMultipleRows $ IR.AnnSelectG
+            { IR._asnFields   = fields
+            , IR._asnFrom     = IR.FromFunction (_cffName _cfiFunction) functionArgs' Nothing
+            , IR._asnPerm     = tablePermissionsInfo remotePerms
+            , IR._asnArgs     = args
+            , IR._asnStrfyNum = stringifyNum
             }
   where
     fieldDescription =
@@ -1000,22 +1002,22 @@ computedField ComputedFieldInfo{..} selectPermissions = runMaybeT do
       in mkDescriptionWith (_cffDescription _cfiFunction) defaultDescription
 
     computedFieldFunctionArgs
-      :: ComputedFieldFunction -> m (InputFieldsParser n (RQL.FunctionArgsExpTableRow UnpreparedValue))
+      :: ComputedFieldFunction -> m (InputFieldsParser n (IR.FunctionArgsExpTableRow UnpreparedValue))
     computedFieldFunctionArgs ComputedFieldFunction{..} =
       functionArgs _cffName (IAUserProvided <$> _cffInputArgs) <&> fmap addTableAndSessionArgument
       where
-        tableRowArgument = RQL.AETableRow Nothing
+        tableRowArgument = IR.AETableRow Nothing
 
-        addTableAndSessionArgument args@(RQL.FunctionArgsExp positional named) =
+        addTableAndSessionArgument args@(IR.FunctionArgsExp positional named) =
           let withTable = case _cffTableArgument of
-                FTAFirst               -> RQL.FunctionArgsExp (tableRowArgument : positional) named
-                FTANamed argName index -> RQL.insertFunctionArg argName index tableRowArgument args
-              sessionArgVal = RQL.AESession UVSession
+                FTAFirst               -> IR.FunctionArgsExp (tableRowArgument : positional) named
+                FTANamed argName index -> IR.insertFunctionArg argName index tableRowArgument args
+              sessionArgVal = IR.AESession UVSession
           in
             case _cffSessionArgument of
               Nothing -> withTable
               Just (FunctionSessionArgument argName index) ->
-                RQL.insertFunctionArg argName index sessionArgVal withTable
+                IR.insertFunctionArg argName index sessionArgVal withTable
 
 -- | Remote relationship field parsers
 remoteRelationshipField
@@ -1040,7 +1042,7 @@ remoteRelationshipField remoteFieldInfo = runMaybeT do
   remoteFieldsArgumentsParser <-
     sequenceA <$> for (Map.toList $ _rfiParamMap remoteFieldInfo) \(name, inpValDefn) -> do
       parser <- lift $ inputValueDefinitionParser (_rfiSchemaIntrospect remoteFieldInfo) inpValDefn
-      pure $ parser `mapField` RQL.RemoteFieldArgument name
+      pure $ parser `mapField` IR.RemoteFieldArgument name
 
   -- This selection set parser, should be of the remote node's selection set parser, which comes
   -- from the fieldCall
@@ -1054,7 +1056,7 @@ remoteRelationshipField remoteFieldInfo = runMaybeT do
       pure $ pure $ P.unsafeRawField (P.mkDefinition fieldName Nothing fieldInfo')
         `P.bindField` \G.Field{ G._fArguments = args, G._fSelectionSet = selSet } -> do
           remoteArgs <- P.ifParser remoteFieldsArgumentsParser' $ P.GraphQLValue <$> args
-          pure $ RQL.AFRemote $ RQL.RemoteSelect
+          pure $ IR.AFRemote $ IR.RemoteSelect
             { _rselArgs          = remoteArgs
             , _rselSelection     = selSet
             , _rselHasuraColumns = _rfiHasuraFields remoteFieldInfo
@@ -1067,7 +1069,7 @@ remoteRelationshipField remoteFieldInfo = runMaybeT do
 customSQLFunctionArgs
   :: (MonadSchema n m, MonadTableInfo r m)
   => FunctionInfo
-  -> m (InputFieldsParser n (RQL.FunctionArgsExpTableRow UnpreparedValue))
+  -> m (InputFieldsParser n (IR.FunctionArgsExpTableRow UnpreparedValue))
 customSQLFunctionArgs FunctionInfo{..} = functionArgs fiName fiInputArgs
 
 -- | Parses the arguments to the underlying sql function of a computed field or
@@ -1085,7 +1087,7 @@ functionArgs
   :: forall m n r. (MonadSchema n m, MonadTableInfo r m)
   => QualifiedFunction
   -> Seq.Seq FunctionInputArgument
-  -> m (InputFieldsParser n (RQL.FunctionArgsExpTableRow UnpreparedValue))
+  -> m (InputFieldsParser n (IR.FunctionArgsExpTableRow UnpreparedValue))
 functionArgs functionName (toList -> inputArgs) = do
   -- First, we iterate through the original sql arguments in order, to find the
   -- corresponding graphql names. At the same time, we create the input field
@@ -1093,7 +1095,7 @@ functionArgs functionName (toList -> inputArgs) = do
   -- mandatory arguments. Optional arguments have a default value, mandatory
   -- arguments don't.
   let (names, session, optional, mandatory) = mconcat $ snd $ mapAccumL splitArguments 1 inputArgs
-      defaultArguments = RQL.FunctionArgsExp (snd <$> session) Map.empty
+      defaultArguments = IR.FunctionArgsExp (snd <$> session) Map.empty
 
   if | length session > 1 ->
          -- We somehow found more than one session argument; this should never
@@ -1130,21 +1132,21 @@ functionArgs functionName (toList -> inputArgs) = do
                -- We also fail if we find a mandatory argument that was not
                -- provided by the user.
                named <- Map.fromList . catMaybes <$> traverse (namedArgument foundArguments) left
-               pure $ RQL.FunctionArgsExp positional named
+               pure $ IR.FunctionArgsExp positional named
 
          pure $ P.field fieldName (Just fieldDesc) objectParser
 
   where
-    sessionPlaceholder :: RQL.ArgumentExp UnpreparedValue
-    sessionPlaceholder = RQL.AEInput P.UVSession
+    sessionPlaceholder :: IR.ArgumentExp UnpreparedValue
+    sessionPlaceholder = IR.AEInput P.UVSession
 
     splitArguments
       :: Int
       -> FunctionInputArgument
       -> (Int, ( [Text] -- graphql names, in order
-               , [(Text, RQL.ArgumentExp UnpreparedValue)] -- session argument
-               , [m (InputFieldsParser n (Maybe (Text, RQL.ArgumentExp UnpreparedValue)))] -- optional argument
-               , [m (InputFieldsParser n (Maybe (Text, RQL.ArgumentExp UnpreparedValue)))] -- mandatory argument
+               , [(Text, IR.ArgumentExp UnpreparedValue)] -- session argument
+               , [m (InputFieldsParser n (Maybe (Text, IR.ArgumentExp UnpreparedValue)))] -- optional argument
+               , [m (InputFieldsParser n (Maybe (Text, IR.ArgumentExp UnpreparedValue)))] -- mandatory argument
                )
          )
     splitArguments positionalIndex (IASessionVariables name) =
@@ -1158,7 +1160,7 @@ functionArgs functionName (toList -> inputArgs) = do
          then (newIndex, ([argName], [], [parseArgument arg argName], []))
          else (newIndex, ([argName], [], [], [parseArgument arg argName]))
 
-    parseArgument :: FunctionArg -> Text -> m (InputFieldsParser n (Maybe (Text, RQL.ArgumentExp UnpreparedValue)))
+    parseArgument :: FunctionArg -> Text -> m (InputFieldsParser n (Maybe (Text, IR.ArgumentExp UnpreparedValue)))
     parseArgument arg name = do
       columnParser <- P.column (PGColumnScalar $ _qptName $ faType arg) (G.Nullability True)
       fieldName    <- textToName name
@@ -1174,12 +1176,12 @@ functionArgs functionName (toList -> inputArgs) = do
       -- surprises, we prefer to reject the query if a mandatory argument is
       -- missing rather than filling the blanks for the user.
       let argParser = P.fieldOptional fieldName Nothing columnParser
-      pure $ argParser `mapField` ((name,) . RQL.AEInput . mkParameter)
+      pure $ argParser `mapField` ((name,) . IR.AEInput . mkParameter)
 
     namedArgument
-      :: HashMap Text (RQL.ArgumentExp UnpreparedValue)
+      :: HashMap Text (IR.ArgumentExp UnpreparedValue)
       -> (Text, InputArgument FunctionArg)
-      -> n (Maybe (Text, RQL.ArgumentExp UnpreparedValue))
+      -> n (Maybe (Text, IR.ArgumentExp UnpreparedValue))
     namedArgument dictionary (name, inputArgument) = case inputArgument of
       IASessionVariables _ -> pure $ Just (name, sessionPlaceholder)
       IAUserProvided arg   -> case Map.lookup name dictionary of
@@ -1191,7 +1193,7 @@ functionArgs functionName (toList -> inputArgs) = do
 
 
 -- | The "path" argument for json column fields
-jsonPathArg :: MonadParse n => PGColumnType -> InputFieldsParser n (Maybe (RQL.ColumnOp 'Postgres))
+jsonPathArg :: MonadParse n => PGColumnType -> InputFieldsParser n (Maybe (IR.ColumnOp 'Postgres))
 jsonPathArg columnType
   | isScalarColumnWhere isJSONType columnType =
       P.fieldOptional fieldName description P.string `P.bindFields` fmap join . traverse toColExp
@@ -1202,14 +1204,14 @@ jsonPathArg columnType
     toColExp textValue = case parseJSONPath textValue of
       Left err     -> parseError $ T.pack $ "parse json path error: " ++ err
       Right []     -> pure Nothing
-      Right jPaths -> pure $ Just $ RQL.ColumnOp SQL.jsonbPathOp $ SQL.SEArray $ map elToColExp jPaths
-    elToColExp (Key k)   = SQL.SELit k
-    elToColExp (Index i) = SQL.SELit $ T.pack (show i)
+      Right jPaths -> pure $ Just $ IR.ColumnOp PG.jsonbPathOp $ PG.SEArray $ map elToColExp jPaths
+    elToColExp (Key k)   = PG.SELit k
+    elToColExp (Index i) = PG.SELit $ T.pack (show i)
 
 tablePermissionsInfo :: SelPermInfo 'Postgres -> TablePerms 'Postgres
-tablePermissionsInfo selectPermissions = RQL.TablePerm
-  { RQL._tpFilter = fmapAnnBoolExp partialSQLExpToUnpreparedValue $ spiFilter selectPermissions
-  , RQL._tpLimit  = spiLimit selectPermissions
+tablePermissionsInfo selectPermissions = IR.TablePerm
+  { IR._tpFilter = fmapAnnBoolExp partialSQLExpToUnpreparedValue $ spiFilter selectPermissions
+  , IR._tpLimit  = spiLimit selectPermissions
   }
 
 ------------------------ Node interface from Relay ---------------------------
@@ -1312,18 +1314,18 @@ nodeField = do
         onNothing (Map.lookup table parseds) $
         withArgsPath $  throwInvalidNodeId $ "the table " <>> ident
       whereExp <- buildNodeIdBoolExp columnValues pkeyColumns
-      return $ RQL.AnnSelectG
-        { RQL._asnFields   = fields
-        , RQL._asnFrom     = RQL.FromTable table
-        , RQL._asnPerm     = tablePermissionsInfo perms
-        , RQL._asnArgs     = RQL.SelectArgs
-          { RQL._saWhere    = Just whereExp
-          , RQL._saOrderBy  = Nothing
-          , RQL._saLimit    = Nothing
-          , RQL._saOffset   = Nothing
-          , RQL._saDistinct = Nothing
+      return $ IR.AnnSelectG
+        { IR._asnFields   = fields
+        , IR._asnFrom     = IR.FromTable table
+        , IR._asnPerm     = tablePermissionsInfo perms
+        , IR._asnArgs     = IR.SelectArgs
+          { IR._saWhere    = Just whereExp
+          , IR._saOrderBy  = Nothing
+          , IR._saLimit    = Nothing
+          , IR._saOffset   = Nothing
+          , IR._saDistinct = Nothing
           }
-        , RQL._asnStrfyNum = stringifyNum
+        , IR._asnStrfyNum = stringifyNum
         }
   where
     parseNodeId :: Text -> n NodeId
@@ -1334,7 +1336,7 @@ nodeField = do
     buildNodeIdBoolExp
       :: NESeq.NESeq J.Value
       -> NESeq.NESeq (ColumnInfo 'Postgres)
-      -> n (RQL.AnnBoolExp 'Postgres UnpreparedValue)
+      -> n (IR.AnnBoolExp 'Postgres UnpreparedValue)
     buildNodeIdBoolExp columnValues pkeyColumns = do
         let firstPkColumn NESeq.:<|| remainingPkColumns = pkeyColumns
             firstColumnValue NESeq.:<|| remainingColumns = columnValues
@@ -1350,10 +1352,10 @@ nodeField = do
         let allTuples = (firstPkColumn, firstColumnValue):alignedTuples
 
         flip onLeft (parseErrorWith ParseFailed . qeError) $ runExcept $
-          fmap RQL.BoolAnd $ for allTuples $ \(columnInfo, columnValue) -> do
+          fmap IR.BoolAnd $ for allTuples $ \(columnInfo, columnValue) -> do
             let modifyErrFn t = "value of column " <> pgiColumn columnInfo
                                 <<> " in node id: " <> t
                 pgColumnType = pgiType columnInfo
             pgValue <- modifyErr modifyErrFn $ parsePGScalarValue pgColumnType columnValue
             let unpreparedValue = flip UVParameter Nothing $ P.PGColumnValue pgColumnType pgValue
-            pure $ RQL.BoolFld $ RQL.AVCol columnInfo [RQL.AEQ True unpreparedValue]
+            pure $ IR.BoolFld $ IR.AVCol columnInfo [IR.AEQ True unpreparedValue]

--- a/server/src-lib/Hasura/RQL/DML/Count.hs
+++ b/server/src-lib/Hasura/RQL/DML/Count.hs
@@ -21,6 +21,8 @@ import           Hasura.Backends.Postgres.SQL.Types
 import           Hasura.Backends.Postgres.Translate.BoolExp
 import           Hasura.EncJSON
 import           Hasura.RQL.DML.Internal
+import           Hasura.RQL.DML.Types
+import           Hasura.RQL.IR.BoolExp
 import           Hasura.RQL.Types
 import           Hasura.SQL.Types
 

--- a/server/src-lib/Hasura/RQL/DML/Delete.hs
+++ b/server/src-lib/Hasura/RQL/DML/Delete.hs
@@ -25,6 +25,7 @@ import           Hasura.Backends.Postgres.Execute.Mutation
 import           Hasura.Backends.Postgres.Translate.Returning
 import           Hasura.EncJSON
 import           Hasura.RQL.DML.Internal
+import           Hasura.RQL.DML.Types
 import           Hasura.RQL.IR.Delete
 import           Hasura.RQL.Types
 import           Hasura.Server.Version                        (HasVersion)

--- a/server/src-lib/Hasura/RQL/DML/Insert.hs
+++ b/server/src-lib/Hasura/RQL/DML/Insert.hs
@@ -18,10 +18,10 @@ import qualified Hasura.Backends.Postgres.SQL.DML             as S
 import           Hasura.Backends.Postgres.Connection
 import           Hasura.Backends.Postgres.Execute.Mutation
 import           Hasura.Backends.Postgres.SQL.Types
-import           Hasura.Backends.Postgres.Translate.Insert
 import           Hasura.Backends.Postgres.Translate.Returning
 import           Hasura.EncJSON
 import           Hasura.RQL.DML.Internal
+import           Hasura.RQL.DML.Types
 import           Hasura.RQL.IR.Insert
 import           Hasura.RQL.Types
 import           Hasura.Server.Version                        (HasVersion)
@@ -59,6 +59,71 @@ convObj prepFn defInsVals setInsVals fieldInfoMap insObj = do
       roleName <- _uiRole <$> askUserInfo
       throw400 NotSupported $ "column " <> c <<> " is not insertable"
         <> " for role " <>> roleName
+
+
+validateInpCols :: (MonadError QErr m) => [PGCol] -> [PGCol] -> m ()
+validateInpCols inpCols updColsPerm = forM_ inpCols $ \inpCol ->
+  unless (inpCol `elem` updColsPerm) $ throw400 ValidationFailed $
+    "column " <> inpCol <<> " is not updatable"
+
+buildConflictClause
+  :: (UserInfoM m, QErrM m)
+  => SessVarBldr 'Postgres m
+  -> TableInfo 'Postgres
+  -> [PGCol]
+  -> OnConflict
+  -> m (ConflictClauseP1 'Postgres S.SQLExp)
+buildConflictClause sessVarBldr tableInfo inpCols (OnConflict mTCol mTCons act) =
+  case (mTCol, mTCons, act) of
+    (Nothing, Nothing, CAIgnore)    -> return $ CP1DoNothing Nothing
+    (Just col, Nothing, CAIgnore)   -> do
+      validateCols col
+      return $ CP1DoNothing $ Just $ CTColumn $ getPGCols col
+    (Nothing, Just cons, CAIgnore)  -> do
+      validateConstraint cons
+      return $ CP1DoNothing $ Just $ CTConstraint cons
+    (Nothing, Nothing, CAUpdate)    -> throw400 UnexpectedPayload
+      "Expecting 'constraint' or 'constraint_on' when the 'action' is 'update'"
+    (Just col, Nothing, CAUpdate)   -> do
+      validateCols col
+      (updFltr, preSet) <- getUpdPerm
+      resolvedUpdFltr <- convAnnBoolExpPartialSQL sessVarBldr updFltr
+      resolvedPreSet <- mapM (convPartialSQLExp sessVarBldr) preSet
+      return $ CP1Update (CTColumn $ getPGCols col) inpCols resolvedPreSet resolvedUpdFltr
+    (Nothing, Just cons, CAUpdate)  -> do
+      validateConstraint cons
+      (updFltr, preSet) <- getUpdPerm
+      resolvedUpdFltr <- convAnnBoolExpPartialSQL sessVarBldr updFltr
+      resolvedPreSet <- mapM (convPartialSQLExp sessVarBldr) preSet
+      return $ CP1Update (CTConstraint cons) inpCols resolvedPreSet resolvedUpdFltr
+    (Just _, Just _, _)             -> throw400 UnexpectedPayload
+      "'constraint' and 'constraint_on' cannot be set at a time"
+  where
+    coreInfo = _tiCoreInfo tableInfo
+    fieldInfoMap = _tciFieldInfoMap coreInfo
+    -- toSQLBool = toSQLBoolExp (S.mkQual $ _tciName coreInfo)
+
+    validateCols c = do
+      let targetcols = getPGCols c
+      void $ withPathK "constraint_on" $ indexedForM targetcols $
+        \pgCol -> askPGType fieldInfoMap pgCol ""
+
+    validateConstraint c = do
+      let tableConsNames = maybe [] toList $
+                           fmap _cName <$> tciUniqueOrPrimaryKeyConstraints coreInfo
+      withPathK "constraint" $
+       unless (c `elem` tableConsNames) $
+       throw400 Unexpected $ "constraint " <> getConstraintTxt c
+                   <<> " for table " <> _tciName coreInfo
+                   <<> " does not exist"
+
+    getUpdPerm = do
+      upi <- askUpdPermInfo tableInfo
+      let updFiltr = upiFilter upi
+          preSet = upiSet upi
+          updCols = HS.toList $ upiCols upi
+      validateInpCols inpCols updCols
+      return (updFiltr, preSet)
 
 
 convInsertQuery

--- a/server/src-lib/Hasura/RQL/DML/Select.hs
+++ b/server/src-lib/Hasura/RQL/DML/Select.hs
@@ -23,6 +23,8 @@ import           Hasura.Backends.Postgres.SQL.Types
 import           Hasura.Backends.Postgres.Translate.Select
 import           Hasura.EncJSON
 import           Hasura.RQL.DML.Internal
+import           Hasura.RQL.DML.Types
+import           Hasura.RQL.IR.OrderBy
 import           Hasura.RQL.IR.Select
 import           Hasura.RQL.Types
 import           Hasura.SQL.Types

--- a/server/src-lib/Hasura/RQL/DML/Types.hs
+++ b/server/src-lib/Hasura/RQL/DML/Types.hs
@@ -1,14 +1,5 @@
-module Hasura.RQL.Types.DML
-       ( BoolExp(..)
-       , ColExp(..)
-       , DMLQuery(..)
-       , OrderType(..)
-       , NullsOrder(..)
-
-       , OrderByExp(..)
-       , OrderByItemG(..)
-       , OrderByItem
-       , OrderByCol(..)
+module Hasura.RQL.DML.Types
+       ( DMLQuery(..)
 
        , SelectG(..)
        , selectGToPairs
@@ -41,54 +32,21 @@ module Hasura.RQL.Types.DML
 import           Hasura.Prelude
 
 import qualified Data.Attoparsec.Text               as AT
-import qualified Data.Attoparsec.Text               as Atto
-import qualified Data.Attoparsec.Types              as AttoT
 import qualified Data.HashMap.Strict                as M
-import qualified Data.Text                          as T
 
-import           Control.Lens.TH
 import           Data.Aeson
 import           Data.Aeson.Casing
 import           Data.Aeson.TH
 import           Instances.TH.Lift                  ()
 import           Language.Haskell.TH.Syntax         (Lift)
 
-import qualified Hasura.Backends.Postgres.SQL.DML   as S
-
 import           Hasura.Backends.Postgres.SQL.Types
-import           Hasura.Incremental                 (Cacheable)
 import           Hasura.RQL.IR.BoolExp
+import           Hasura.RQL.IR.OrderBy
 import           Hasura.RQL.Instances               ()
 import           Hasura.RQL.Types.Common
 import           Hasura.SQL.Backend
 
-
-data ColExp
-  = ColExp
-  { ceCol :: !FieldName
-  , ceVal :: !Value
-  } deriving (Show, Eq, Lift, Data, Generic)
-instance NFData ColExp
-instance Cacheable ColExp
-
-newtype BoolExp (b :: Backend)
-  = BoolExp { unBoolExp :: GBoolExp b ColExp }
-  deriving (Show, Eq, Lift, Generic, NFData, Cacheable)
-
-$(makeWrapped ''BoolExp)
-
-instance ToJSON (BoolExp 'Postgres) where
-  toJSON (BoolExp gBoolExp) =
-    gBoolExpToJSON f gBoolExp
-    where
-      f (ColExp k v) =
-        (getFieldNameTxt k,  v)
-
-instance FromJSON (BoolExp 'Postgres) where
-  parseJSON =
-    fmap BoolExp . parseGBoolExp f
-    where
-      f (k, v) = ColExp (FieldName k) <$> parseJSON v
 
 data DMLQuery a
   = DMLQuery !QualifiedTable a
@@ -102,130 +60,7 @@ instance (FromJSON a) => FromJSON (DMLQuery a) where
   parseJSON _          =
     fail "Expected an object for query"
 
-newtype OrderType
-  = OrderType { unOrderType :: S.OrderType }
-  deriving (Show, Eq, Lift, Generic)
-instance Hashable OrderType
 
-instance FromJSON OrderType where
-  parseJSON =
-    fmap OrderType . f
-    where f = $(mkParseJSON
-                defaultOptions{constructorTagModifier = snakeCase . drop 2}
-                ''S.OrderType)
-
-newtype NullsOrder
-  = NullsOrder { unNullsOrder :: S.NullsOrder }
-  deriving (Show, Eq, Lift, Generic)
-instance Hashable NullsOrder
-
-instance FromJSON NullsOrder where
-  parseJSON =
-    fmap NullsOrder . f
-    where f = $(mkParseJSON
-                defaultOptions{constructorTagModifier = snakeCase . drop 1}
-                ''S.NullsOrder)
-
-instance ToJSON OrderType where
-  toJSON =
-    f . unOrderType
-    where f = $(mkToJSON
-                defaultOptions{constructorTagModifier = snakeCase . drop 2}
-                ''S.OrderType)
-
-instance ToJSON NullsOrder where
-  toJSON =
-    f . unNullsOrder
-    where f = $(mkToJSON
-                defaultOptions{constructorTagModifier = snakeCase . drop 1}
-                ''S.NullsOrder)
-
-data OrderByCol
-  = OCPG !FieldName
-  | OCRel !FieldName !OrderByCol
-  deriving (Show, Eq, Lift)
-
-orderByColToTxt :: OrderByCol -> Text
-orderByColToTxt = \case
-  OCPG pgCol      -> getFieldNameTxt pgCol
-  OCRel rel obCol -> getFieldNameTxt rel <> "." <> orderByColToTxt obCol
-
-instance ToJSON OrderByCol where
-  toJSON = toJSON . orderByColToTxt
-
-orderByColFromToks
-  :: (MonadFail m)
-  => [Text] -> m OrderByCol
-orderByColFromToks toks = do
-  when (any T.null toks) $ fail "col/rel cannot be empty"
-  case toks of
-    []   -> fail "failed to parse an OrderByCol: found empty cols"
-    x:xs -> return $ go (FieldName x) xs
-  where
-    go fld = \case
-      []   -> OCPG fld
-      x:xs -> OCRel fld $ go (FieldName x) xs
-
-orderByColFromTxt
-  :: (MonadFail m)
-  => Text -> m OrderByCol
-orderByColFromTxt =
-  orderByColFromToks . T.split (=='.')
-
-instance FromJSON OrderByCol where
-  parseJSON = \case
-    (String t) -> orderByColFromToks $ T.split (=='.') t
-    v          -> parseJSON v >>= orderByColFromToks
-
-data OrderByItemG a
-  = OrderByItemG
-  { obiType   :: !(Maybe OrderType)
-  , obiColumn :: !a
-  , obiNulls  :: !(Maybe NullsOrder)
-  } deriving (Show, Eq, Lift, Functor, Foldable, Traversable, Generic)
-instance (Hashable a) => Hashable (OrderByItemG a)
-
-type OrderByItem = OrderByItemG OrderByCol
-
-$(deriveToJSON (aesonDrop 3 snakeCase){omitNothingFields=True} ''OrderByItemG)
-
--- Can either be string / object
-instance FromJSON OrderByItem where
-  parseJSON (String t) =
-    case Atto.parseOnly orderByParser t of
-    Right r -> return r
-    Left _  ->
-      fail "string format for 'order_by' entry : {+/-}column Eg : +posted"
-
-  parseJSON (Object o) =
-    OrderByItemG
-    <$> o .:? "type"
-    <*> o .:  "column"
-    <*> o .:? "nulls"
-  parseJSON _ = fail "expecting an object or string for order by"
-
-newtype OrderByExp
-  = OrderByExp { getOrderByItems :: [OrderByItem] }
-  deriving (Show, Eq, ToJSON, Lift)
-
-instance FromJSON OrderByExp where
-  parseJSON v@(String _) =
-    OrderByExp . (:[]) <$> parseJSON v
-  parseJSON v@(Array _) =
-    OrderByExp <$> parseJSON v
-  parseJSON v@(Object _) =
-    OrderByExp . (:[]) <$> parseJSON v
-  parseJSON _ =
-    fail "Expecting : array/string/object"
-
-orderByParser :: AttoT.Parser Text OrderByItem
-orderByParser =
-  OrderByItemG <$> otP <*> colP <*> return Nothing
-  where
-    otP  = ("+" *> return (Just $ OrderType S.OTAsc))
-           <|> ("-" *> return (Just $ OrderType S.OTDesc))
-           <|> return Nothing
-    colP = Atto.takeText >>= orderByColFromTxt
 
 data SelectG a b c
   = SelectG

--- a/server/src-lib/Hasura/RQL/DML/Update.hs
+++ b/server/src-lib/Hasura/RQL/DML/Update.hs
@@ -22,6 +22,8 @@ import           Hasura.Backends.Postgres.SQL.Types
 import           Hasura.Backends.Postgres.Translate.Returning
 import           Hasura.EncJSON
 import           Hasura.RQL.DML.Internal
+import           Hasura.RQL.DML.Types
+import           Hasura.RQL.IR.BoolExp
 import           Hasura.RQL.IR.Update
 import           Hasura.RQL.Instances                         ()
 import           Hasura.RQL.Types

--- a/server/src-lib/Hasura/RQL/IR/OrderBy.hs
+++ b/server/src-lib/Hasura/RQL/IR/OrderBy.hs
@@ -1,0 +1,162 @@
+module Hasura.RQL.IR.OrderBy
+  ( OrderType(..)
+  , NullsOrder(..)
+  , OrderByExp(..)
+  , OrderByItemG(..)
+  , OrderByItem
+  , OrderByCol(..)
+  ) where
+
+import           Hasura.Prelude
+
+import qualified Data.Attoparsec.Text             as Atto
+import qualified Data.Attoparsec.Types            as AttoT
+import qualified Data.Text                        as T
+
+import           Data.Aeson
+import           Data.Aeson.Casing
+import           Data.Aeson.TH
+import           Instances.TH.Lift                ()
+import           Language.Haskell.TH.Syntax       (Lift)
+
+import qualified Hasura.Backends.Postgres.SQL.DML as S
+
+import           Hasura.RQL.Instances             ()
+import           Hasura.RQL.Types.Common
+
+
+-- order type
+
+newtype OrderType
+  = OrderType { unOrderType :: S.OrderType }
+  deriving (Show, Eq, Lift, Generic)
+instance Hashable OrderType
+
+instance FromJSON OrderType where
+  parseJSON =
+    fmap OrderType . f
+    where f = $(mkParseJSON
+                defaultOptions{constructorTagModifier = snakeCase . drop 2}
+                ''S.OrderType)
+
+
+-- nulls order
+
+newtype NullsOrder
+  = NullsOrder { unNullsOrder :: S.NullsOrder }
+  deriving (Show, Eq, Lift, Generic)
+instance Hashable NullsOrder
+
+instance FromJSON NullsOrder where
+  parseJSON =
+    fmap NullsOrder . f
+    where f = $(mkParseJSON
+                defaultOptions{constructorTagModifier = snakeCase . drop 1}
+                ''S.NullsOrder)
+
+instance ToJSON OrderType where
+  toJSON =
+    f . unOrderType
+    where f = $(mkToJSON
+                defaultOptions{constructorTagModifier = snakeCase . drop 2}
+                ''S.OrderType)
+
+instance ToJSON NullsOrder where
+  toJSON =
+    f . unNullsOrder
+    where f = $(mkToJSON
+                defaultOptions{constructorTagModifier = snakeCase . drop 1}
+                ''S.NullsOrder)
+
+
+-- order by col
+
+data OrderByCol
+  = OCPG !FieldName
+  | OCRel !FieldName !OrderByCol
+  deriving (Show, Eq, Lift)
+
+instance FromJSON OrderByCol where
+  parseJSON = \case
+    (String t) -> orderByColFromToks $ T.split (=='.') t
+    v          -> parseJSON v >>= orderByColFromToks
+
+instance ToJSON OrderByCol where
+  toJSON = toJSON . orderByColToTxt
+
+orderByColToTxt :: OrderByCol -> Text
+orderByColToTxt = \case
+  OCPG pgCol      -> getFieldNameTxt pgCol
+  OCRel rel obCol -> getFieldNameTxt rel <> "." <> orderByColToTxt obCol
+
+orderByColFromToks
+  :: (MonadFail m)
+  => [Text] -> m OrderByCol
+orderByColFromToks toks = do
+  when (any T.null toks) $ fail "col/rel cannot be empty"
+  case toks of
+    []   -> fail "failed to parse an OrderByCol: found empty cols"
+    x:xs -> return $ go (FieldName x) xs
+  where
+    go fld = \case
+      []   -> OCPG fld
+      x:xs -> OCRel fld $ go (FieldName x) xs
+
+orderByColFromTxt
+  :: (MonadFail m)
+  => Text -> m OrderByCol
+orderByColFromTxt =
+  orderByColFromToks . T.split (=='.')
+
+
+-- order by item
+
+data OrderByItemG a
+  = OrderByItemG
+  { obiType   :: !(Maybe OrderType)
+  , obiColumn :: !a
+  , obiNulls  :: !(Maybe NullsOrder)
+  } deriving (Show, Eq, Lift, Functor, Foldable, Traversable, Generic)
+instance (Hashable a) => Hashable (OrderByItemG a)
+
+type OrderByItem = OrderByItemG OrderByCol
+
+$(deriveToJSON (aesonDrop 3 snakeCase){omitNothingFields=True} ''OrderByItemG)
+
+-- Can either be string / object
+instance FromJSON OrderByItem where
+  parseJSON (String t) =
+    case Atto.parseOnly orderByParser t of
+    Right r -> return r
+    Left _  ->
+      fail "string format for 'order_by' entry : {+/-}column Eg : +posted"
+
+  parseJSON (Object o) =
+    OrderByItemG
+    <$> o .:? "type"
+    <*> o .:  "column"
+    <*> o .:? "nulls"
+  parseJSON _ = fail "expecting an object or string for order by"
+
+newtype OrderByExp
+  = OrderByExp { getOrderByItems :: [OrderByItem] }
+  deriving (Show, Eq, ToJSON, Lift)
+
+instance FromJSON OrderByExp where
+  parseJSON v@(String _) =
+    OrderByExp . (:[]) <$> parseJSON v
+  parseJSON v@(Array _) =
+    OrderByExp <$> parseJSON v
+  parseJSON v@(Object _) =
+    OrderByExp . (:[]) <$> parseJSON v
+  parseJSON _ =
+    fail "Expecting : array/string/object"
+
+orderByParser :: AttoT.Parser Text OrderByItem
+orderByParser =
+  OrderByItemG <$> otP <*> colP <*> return Nothing
+  where
+    otP  = ("+" *> return (Just $ OrderType S.OTAsc))
+           <|> ("-" *> return (Just $ OrderType S.OTDesc))
+           <|> return Nothing
+    colP = Atto.takeText >>= orderByColFromTxt

--- a/server/src-lib/Hasura/RQL/IR/Select.hs
+++ b/server/src-lib/Hasura/RQL/IR/Select.hs
@@ -18,9 +18,9 @@ import qualified Hasura.Backends.Postgres.SQL.DML    as S
 import           Hasura.Backends.Postgres.SQL.Types
 import           Hasura.GraphQL.Parser.Schema
 import           Hasura.RQL.IR.BoolExp
+import           Hasura.RQL.IR.OrderBy
 import           Hasura.RQL.Types.Column
 import           Hasura.RQL.Types.Common
-import           Hasura.RQL.Types.DML
 import           Hasura.RQL.Types.Function
 import           Hasura.RQL.Types.RemoteRelationship
 import           Hasura.RQL.Types.RemoteSchema

--- a/server/src-lib/Hasura/RQL/Types.hs
+++ b/server/src-lib/Hasura/RQL/Types.hs
@@ -54,7 +54,6 @@ import           Hasura.RQL.Types.Column             as R
 import           Hasura.RQL.Types.Common             as R
 import           Hasura.RQL.Types.ComputedField      as R
 import           Hasura.RQL.Types.CustomTypes        as R
-import           Hasura.RQL.Types.DML                as R
 import           Hasura.RQL.Types.Error              as R
 import           Hasura.RQL.Types.EventTrigger       as R
 import           Hasura.RQL.Types.Function           as R

--- a/server/src-lib/Hasura/RQL/Types/Permission.hs
+++ b/server/src-lib/Hasura/RQL/Types/Permission.hs
@@ -3,11 +3,11 @@ module Hasura.RQL.Types.Permission where
 import           Hasura.Backends.Postgres.SQL.Types (PGCol, TableName, getTableTxt)
 import           Hasura.Incremental                 (Cacheable)
 import           Hasura.Prelude
+import           Hasura.RQL.IR.BoolExp
 import           Hasura.RQL.Types.Common
 import           Hasura.RQL.Types.ComputedField
-import           Hasura.RQL.Types.DML
-import           Hasura.Session
 import           Hasura.SQL.Backend
+import           Hasura.Session
 
 import           Control.Lens                       (makeLenses)
 import           Data.Aeson

--- a/server/src-lib/Hasura/Server/API/Query.hs
+++ b/server/src-lib/Hasura/Server/API/Query.hs
@@ -34,6 +34,7 @@ import           Hasura.RQL.DML.Count
 import           Hasura.RQL.DML.Delete
 import           Hasura.RQL.DML.Insert
 import           Hasura.RQL.DML.Select
+import           Hasura.RQL.DML.Types
 import           Hasura.RQL.DML.Update
 import           Hasura.RQL.Types
 import           Hasura.RQL.Types.Run


### PR DESCRIPTION
_(Note: this PR is on top of #6082 and #6091.)_

### Description
This PR is in the continuation of our IR work. It splits `RQL.Types.DML` in several distinct parts:
- `RQL.DML.Types`, which contains types specific to the RQL query language, and is isolated from the rest of the code base
- `RQL.IR.OrderBy`
- `RQL.IR.BoolExp` (which was already introduced in #6082)

Additionally, it fixes a few mistakes with the previous PRs and starts renaming some imports.