### PR TITLE
server: generalize table name IR

### DIFF
--- a/server/src-lib/Hasura/Backends/Postgres/Execute/Mutation.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Execute/Mutation.hs
@@ -35,21 +35,21 @@ import           Hasura.Backends.Postgres.Translate.Select
 import           Hasura.Backends.Postgres.Translate.Update
 import           Hasura.EncJSON
 import           Hasura.RQL.DML.Internal
-import           Hasura.RQL.Instances                         ()
 import           Hasura.RQL.IR.Delete
 import           Hasura.RQL.IR.Insert
 import           Hasura.RQL.IR.Returning
 import           Hasura.RQL.IR.Select
 import           Hasura.RQL.IR.Update
+import           Hasura.RQL.Instances                         ()
 import           Hasura.RQL.Types
+import           Hasura.SQL.Types
 import           Hasura.Server.Version                        (HasVersion)
 import           Hasura.Session
-import           Hasura.SQL.Types
 
 
 type MutationRemoteJoinCtx = (HTTP.Manager, [N.Header], UserInfo)
 
-data Mutation (b :: Backend)
+data Mutation (b :: BackendType)
   = Mutation
   { _mTable       :: !QualifiedTable
   , _mQuery       :: !(MutationCTE, DS.Seq Q.PrepArg)

--- a/server/src-lib/Hasura/Backends/Postgres/Translate/BoolExp.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Translate/BoolExp.hs
@@ -24,7 +24,7 @@ type OpRhsParser m v =
 
 -- | Represents a reference to a Postgres column, possibly casted an arbitrary
 -- number of times. Used within 'parseOperationsExpression' for bookkeeping.
-data ColumnReference (b :: Backend)
+data ColumnReference (b :: BackendType)
   = ColumnReferenceColumn !(ColumnInfo b)
   | ColumnReferenceCast !(ColumnReference b) !(ColumnType b)
 

--- a/server/src-lib/Hasura/GraphQL/Context.hs
+++ b/server/src-lib/Hasura/GraphQL/Context.hs
@@ -94,7 +94,7 @@ data QueryDB b v
   | QDBAggregation (RQL.AnnAggregateSelectG b v)
   | QDBConnection  (RQL.ConnectionSelect    b v)
 
-data ActionQuery (b :: Backend) v
+data ActionQuery (b :: BackendType) v
   = AQQuery !(RQL.AnnActionExecution b v)
   | AQAsync !(RQL.AnnActionAsyncQuery b v)
 
@@ -102,12 +102,12 @@ type RemoteField = (RQL.RemoteSchemaInfo, G.Field G.NoFragments G.Name)
 
 type QueryRootField v = RootField (QueryDB 'Postgres v) RemoteField (ActionQuery 'Postgres v) J.Value
 
-data MutationDB (b :: Backend) v
+data MutationDB (b :: BackendType) v
   = MDBInsert (AnnInsert   b v)
   | MDBUpdate (RQL.AnnUpdG b v)
   | MDBDelete (RQL.AnnDelG b v)
 
-data ActionMutation (b :: Backend) v
+data ActionMutation (b :: BackendType) v
   = AMSync !(RQL.AnnActionExecution b v)
   | AMAsync !RQL.AnnActionMutationAsync
 

--- a/server/src-lib/Hasura/GraphQL/Execute/Query.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/Query.hs
@@ -71,7 +71,7 @@ instance J.ToJSON RootFieldPlan where
     RFPPostgres pgPlan -> J.toJSON pgPlan
     RFPActionQuery _   -> J.String "Action Execution Tx"
 
-data ActionQueryPlan (b :: Backend)
+data ActionQueryPlan (b :: BackendType)
   = AQPAsyncQuery !(DS.AnnSimpleSel b) -- ^ Cacheable plan
   | AQPQuery !ActionExecuteTx -- ^ Non cacheable transaction
 

--- a/server/src-lib/Hasura/GraphQL/Schema/Insert.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema/Insert.hs
@@ -30,14 +30,14 @@ import           Hasura.SQL.Backend
 -- quite likely that some of the information stored in those structures is
 -- redundant, and that they can be simplified.
 
-data AnnInsert (b :: Backend) v
+data AnnInsert (b :: BackendType) v
   = AnnInsert
   { _aiFieldName :: !Text
   , _aiIsSingle  :: Bool
   , _aiData      :: AnnMultiInsert b v
   }
 
-data AnnIns (b :: Backend) a v
+data AnnIns (b :: BackendType) a v
   = AnnIns
   { _aiInsObj         :: !a
   , _aiTableName      :: !QualifiedTable
@@ -59,7 +59,7 @@ data RelIns a
 type ObjRelIns b v = RelIns (SingleObjIns b v)
 type ArrRelIns b v = RelIns (MultiObjIns  b v)
 
-data AnnInsObj (b :: Backend) v
+data AnnInsObj (b :: BackendType) v
   = AnnInsObj
   { _aioColumns :: ![(Column b, v)]
   , _aioObjRels :: ![ObjRelIns b v]

--- a/server/src-lib/Hasura/RQL/DDL/Metadata/Generator.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Metadata/Generator.hs
@@ -122,28 +122,28 @@ instance Arbitrary J.Value where
 instance Arbitrary ColExp where
   arbitrary = genericArbitrary
 
-instance Arbitrary (GExists b ColExp) where
+instance Arbitrary (GExists 'Postgres ColExp) where
   arbitrary = genericArbitrary
 
-instance Arbitrary (GBoolExp b ColExp) where
+instance Arbitrary (GBoolExp 'Postgres ColExp) where
   arbitrary = genericArbitrary
 
-instance Arbitrary (BoolExp b) where
+instance Arbitrary (BoolExp 'Postgres) where
   arbitrary = genericArbitrary
 
 instance Arbitrary PermColSpec where
   arbitrary = genericArbitrary
 
-instance Arbitrary (InsPerm b) where
+instance Arbitrary (InsPerm 'Postgres) where
   arbitrary = genericArbitrary
 
-instance Arbitrary (SelPerm b) where
+instance Arbitrary (SelPerm 'Postgres) where
   arbitrary = genericArbitrary
 
-instance Arbitrary (UpdPerm b) where
+instance Arbitrary (UpdPerm 'Postgres) where
   arbitrary = genericArbitrary
 
-instance Arbitrary (DelPerm b) where
+instance Arbitrary (DelPerm 'Postgres) where
   arbitrary = genericArbitrary
 
 instance Arbitrary SubscribeColumns where

--- a/server/src-lib/Hasura/RQL/DDL/Schema/Diff.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Diff.hs
@@ -82,7 +82,7 @@ data ComputedFieldDiff
   , _cfdOverloaded :: [(ComputedFieldName, QualifiedFunction)]
   } deriving (Show, Eq)
 
-data TableDiff (b :: Backend)
+data TableDiff (b :: BackendType)
   = TableDiff
   { _tdNewName         :: !(Maybe QualifiedTable)
   , _tdDroppedCols     :: ![Column b]
@@ -166,7 +166,7 @@ getTableChangeDeps tn tableDiff = do
     TableDiff _ droppedCols _ _ droppedFKeyConstraints computedFieldDiff _ _ = tableDiff
     droppedComputedFieldDeps = map (SOTableObj tn . TOComputedField) $ _cfdDropped computedFieldDiff
 
-data SchemaDiff (b :: Backend)
+data SchemaDiff (b :: BackendType)
   = SchemaDiff
   { _sdDroppedTables :: ![QualifiedTable]
   , _sdAlteredTables :: ![(QualifiedTable, TableDiff b)]

--- a/server/src-lib/Hasura/RQL/DML/Select.hs
+++ b/server/src-lib/Hasura/RQL/DML/Select.hs
@@ -37,7 +37,7 @@ type SelectQExt b = SelectG (ExtCol b) (BoolExp b) Int
 -- it is specific to this module; however the generalization work was
 -- already done, and there's no particular reason to force this to be
 -- specific.
-data ExtCol (b :: Backend)
+data ExtCol (b :: BackendType)
   = ECSimple !(Column b)
   | ECRel !RelName !(Maybe RelName) !(SelectQExt b)
 deriving instance Lift (ExtCol 'Postgres)

--- a/server/src-lib/Hasura/RQL/DML/Types.hs
+++ b/server/src-lib/Hasura/RQL/DML/Types.hs
@@ -100,7 +100,7 @@ parseWildcard =
     fromList   = foldr1 (\_ x -> StarDot x)
 
 -- Columns in RQL
-data SelCol (b :: Backend)
+data SelCol (b :: BackendType)
   = SCStar !Wildcard
   | SCExtSimple !(Column b)
   | SCExtRel !RelName !(Maybe RelName) !(SelectQ b)

--- a/server/src-lib/Hasura/RQL/IR/BoolExp.hs
+++ b/server/src-lib/Hasura/RQL/IR/BoolExp.hs
@@ -77,14 +77,14 @@ data GExists (b :: Backend) a
   { _geTable :: !(TableName b)
   , _geWhere :: !(GBoolExp b a)
   } deriving (Functor, Foldable, Traversable, Generic)
-deriving instance (Representation b, Show a) => Show (GExists b a)
-deriving instance (Representation b, Eq a) => Eq (GExists b a)
-deriving instance (Representation b, Lift a) => Lift (GExists b a)
-deriving instance (Representation b, Typeable a, Data a) => Data (GExists b a)
-instance (Representation b, NFData a) => NFData (GExists b a)
-instance (Representation b, Data a) => Plated (GExists b a)
-instance (Representation b, Cacheable a) => Cacheable (GExists b a)
-instance (Representation b, Hashable a) => Hashable (GExists b a)
+deriving instance (BackendImplementation b, Show a) => Show (GExists b a)
+deriving instance (BackendImplementation b, Eq a) => Eq (GExists b a)
+deriving instance (BackendImplementation b, Lift a) => Lift (GExists b a)
+deriving instance (BackendImplementation b, Typeable a, Data a) => Data (GExists b a)
+instance (BackendImplementation b, NFData a) => NFData (GExists b a)
+instance (BackendImplementation b, Data a) => Plated (GExists b a)
+instance (BackendImplementation b, Cacheable a) => Cacheable (GExists b a)
+instance (BackendImplementation b, Hashable a) => Hashable (GExists b a)
 
 gExistsToJSON :: (a -> (Text, Value)) -> GExists 'Postgres a -> Value
 gExistsToJSON f (GExists qt wh) =
@@ -109,10 +109,10 @@ data GBoolExp (b :: Backend) a
   | BoolExists !(GExists b a)
   | BoolFld !a
   deriving (Show, Eq, Lift, Functor, Foldable, Traversable, Data, Generic)
-instance (Representation b, NFData a) => NFData (GBoolExp b a)
-instance (Representation b, Data a) => Plated (GBoolExp b a)
-instance (Representation b, Cacheable a) => Cacheable (GBoolExp b a)
-instance (Representation b, Hashable a) => Hashable (GBoolExp b a)
+instance (BackendImplementation b, NFData a) => NFData (GBoolExp b a)
+instance (BackendImplementation b, Data a) => Plated (GBoolExp b a)
+instance (BackendImplementation b, Cacheable a) => Cacheable (GBoolExp b a)
+instance (BackendImplementation b, Hashable a) => Hashable (GBoolExp b a)
 
 gBoolExpTrue :: GBoolExp b a
 gBoolExpTrue = BoolAnd []

--- a/server/src-lib/Hasura/RQL/IR/Delete.hs
+++ b/server/src-lib/Hasura/RQL/IR/Delete.hs
@@ -9,7 +9,7 @@ import           Hasura.RQL.Types.Common
 import           Hasura.SQL.Backend
 
 
-data AnnDelG (b :: Backend) v
+data AnnDelG (b :: BackendType) v
   = AnnDel
   { dqp1Table   :: !(TableName b)
   , dqp1Where   :: !(AnnBoolExp b v, AnnBoolExp b v)

--- a/server/src-lib/Hasura/RQL/IR/Delete.hs
+++ b/server/src-lib/Hasura/RQL/IR/Delete.hs
@@ -2,7 +2,6 @@ module Hasura.RQL.IR.Delete where
 
 import           Hasura.Prelude
 
-import           Hasura.Backends.Postgres.SQL.Types
 import           Hasura.RQL.IR.BoolExp
 import           Hasura.RQL.IR.Returning
 import           Hasura.RQL.Types.Column
@@ -12,7 +11,7 @@ import           Hasura.SQL.Backend
 
 data AnnDelG (b :: Backend) v
   = AnnDel
-  { dqp1Table   :: !QualifiedTable
+  { dqp1Table   :: !(TableName b)
   , dqp1Where   :: !(AnnBoolExp b v, AnnBoolExp b v)
   , dqp1Output  :: !(MutationOutputG b v)
   , dqp1AllCols :: ![ColumnInfo b]

--- a/server/src-lib/Hasura/RQL/IR/Insert.hs
+++ b/server/src-lib/Hasura/RQL/IR/Insert.hs
@@ -3,7 +3,8 @@ module Hasura.RQL.IR.Insert where
 
 import           Hasura.Prelude
 
-import           Hasura.Backends.Postgres.SQL.Types
+import qualified Hasura.Backends.Postgres.SQL.Types as PG
+
 import           Hasura.RQL.IR.BoolExp
 import           Hasura.RQL.IR.Returning
 import           Hasura.RQL.Types.Column
@@ -12,8 +13,8 @@ import           Hasura.SQL.Backend
 
 
 data ConflictTarget
-  = CTColumn ![PGCol]
-  | CTConstraint !ConstraintName
+  = CTColumn ![PG.PGCol]
+  | CTConstraint !PG.ConstraintName
   deriving (Show, Eq)
 
 data ConflictClauseP1 (b :: Backend) v
@@ -25,7 +26,7 @@ data ConflictClauseP1 (b :: Backend) v
 
 data InsertQueryP1 (b :: Backend)
   = InsertQueryP1
-  { iqp1Table     :: !QualifiedTable
+  { iqp1Table     :: !(TableName b)
   , iqp1Cols      :: ![Column b]
   , iqp1Tuples    :: ![[SQLExp b]]
   , iqp1Conflict  :: !(Maybe (ConflictClauseP1 b (SQLExp b)))

--- a/server/src-lib/Hasura/RQL/IR/Insert.hs
+++ b/server/src-lib/Hasura/RQL/IR/Insert.hs
@@ -17,14 +17,14 @@ data ConflictTarget
   | CTConstraint !PG.ConstraintName
   deriving (Show, Eq)
 
-data ConflictClauseP1 (b :: Backend) v
+data ConflictClauseP1 (b :: BackendType) v
   = CP1DoNothing !(Maybe ConflictTarget)
   | CP1Update !ConflictTarget ![Column b] !(PreSetColsG b v) (AnnBoolExp b v)
   deriving (Functor, Foldable, Traversable)
 
 
 
-data InsertQueryP1 (b :: Backend)
+data InsertQueryP1 (b :: BackendType)
   = InsertQueryP1
   { iqp1Table     :: !(TableName b)
   , iqp1Cols      :: ![Column b]

--- a/server/src-lib/Hasura/RQL/IR/RemoteJoin.hs
+++ b/server/src-lib/Hasura/RQL/IR/RemoteJoin.hs
@@ -12,7 +12,7 @@ import           Hasura.RQL.Types
 
 
 -- | A 'RemoteJoin' represents the context of remote relationship to be extracted from 'AnnFieldG's.
-data RemoteJoin (b :: Backend)
+data RemoteJoin (b :: BackendType)
   = RemoteJoin
   { _rjName          :: !FieldName -- ^ The remote join field name.
   , _rjArgs          :: ![RemoteFieldArgument] -- ^ User-provided arguments with variables.

--- a/server/src-lib/Hasura/RQL/IR/Returning.hs
+++ b/server/src-lib/Hasura/RQL/IR/Returning.hs
@@ -13,7 +13,7 @@ import           Hasura.SQL.Backend
 import qualified Hasura.Backends.Postgres.SQL.DML as S
 
 
-data MutFldG (b :: Backend) v
+data MutFldG (b :: BackendType) v
   = MCount
   | MExp !Text
   | MRet !(AnnFieldsG b v)
@@ -22,7 +22,7 @@ type MutFld b = MutFldG b (SQLExp b)
 
 type MutFldsG b v = Fields (MutFldG b v)
 
-data MutationOutputG (b :: Backend) v
+data MutationOutputG (b :: BackendType) v
   = MOutMultirowFields !(MutFldsG b v)
   | MOutSinglerowObject !(AnnFieldsG b v)
 

--- a/server/src-lib/Hasura/RQL/IR/Select.hs
+++ b/server/src-lib/Hasura/RQL/IR/Select.hs
@@ -33,14 +33,14 @@ data JsonAggSelect
   deriving (Show, Eq, Generic)
 instance Hashable JsonAggSelect
 
-data AnnAggregateOrderBy (b :: Backend)
+data AnnAggregateOrderBy (b :: BackendType)
   = AAOCount
   | AAOOp !Text !(ColumnInfo b)
   deriving (Generic)
 deriving instance Eq (AnnAggregateOrderBy 'Postgres)
 instance Hashable (AnnAggregateOrderBy 'Postgres)
 
-data AnnOrderByElementG (b :: Backend) v
+data AnnOrderByElementG (b :: BackendType) v
   = AOCColumn !(ColumnInfo b)
   | AOCObjectRelation !RelInfo !v !(AnnOrderByElementG b v)
   | AOCArrayAggregation !RelInfo !v !(AnnAggregateOrderBy b)
@@ -77,7 +77,7 @@ type AnnOrderByItem b = AnnOrderByItemG b (SQLExp b)
 type OrderByItemExp b =
   OrderByItemG (AnnOrderByElement b (SQLExp b), (PG.Alias, (SQLExp b)))
 
-data AnnRelationSelectG (b :: Backend) a
+data AnnRelationSelectG (b :: BackendType) a
   = AnnRelationSelectG
   { aarRelationshipName :: !RelName -- Relationship name
   , aarColumnMapping    :: !(HashMap (Column b) (Column b)) -- Column of left table to join with
@@ -89,7 +89,7 @@ type ArrayAggregateSelectG b v = AnnRelationSelectG b (AnnAggregateSelectG b v)
 type ArrayConnectionSelect b v = AnnRelationSelectG b (ConnectionSelect b v)
 type ArrayAggregateSelect b = ArrayAggregateSelectG b (SQLExp b)
 
-data AnnObjectSelectG (b :: Backend) v
+data AnnObjectSelectG (b :: BackendType) v
   = AnnObjectSelectG
   { _aosFields      :: !(AnnFieldsG b v)
   , _aosTableFrom   :: !(TableName b)
@@ -111,7 +111,7 @@ traverseAnnObjectSelect f (AnnObjectSelectG fields fromTable permissionFilter) =
 type ObjectRelationSelectG b v = AnnRelationSelectG b (AnnObjectSelectG b v)
 type ObjectRelationSelect b = ObjectRelationSelectG b (SQLExp b)
 
-data ComputedFieldScalarSelect (b :: Backend) v
+data ComputedFieldScalarSelect (b :: BackendType) v
   = ComputedFieldScalarSelect
   { _cfssFunction  :: !PG.QualifiedFunction
   , _cfssArguments :: !(FunctionArgsExpTableRow v)
@@ -121,7 +121,7 @@ data ComputedFieldScalarSelect (b :: Backend) v
 deriving instance Show v => Show (ComputedFieldScalarSelect 'Postgres v)
 deriving instance Eq   v => Eq   (ComputedFieldScalarSelect 'Postgres v)
 
-data ComputedFieldSelect (b :: Backend) v
+data ComputedFieldSelect (b :: BackendType) v
   = CFSScalar !(ComputedFieldScalarSelect b v)
   | CFSTable !JsonAggSelect !(AnnSimpleSelG b v)
 
@@ -135,7 +135,7 @@ traverseComputedFieldSelect fv = \case
 
 type Fields a = [(FieldName, a)]
 
-data ArraySelectG (b :: Backend) v
+data ArraySelectG (b :: BackendType) v
   = ASSimple !(ArrayRelationSelectG b v)
   | ASAggregate !(ArrayAggregateSelectG b v)
   | ASConnection !(ArrayConnectionSelect b v)
@@ -157,7 +157,7 @@ type ArraySelect b = ArraySelectG b (SQLExp b)
 
 type ArraySelectFieldsG b v = Fields (ArraySelectG b v)
 
-data ColumnOp (b :: Backend)
+data ColumnOp (b :: BackendType)
   = ColumnOp
   { _colOp  :: PG.SQLOp
   , _colExp :: (SQLExp b)
@@ -165,7 +165,7 @@ data ColumnOp (b :: Backend)
 deriving instance Show (ColumnOp 'Postgres)
 deriving instance Eq   (ColumnOp 'Postgres)
 
-data AnnColumnField (b :: Backend)
+data AnnColumnField (b :: BackendType)
   = AnnColumnField
   { _acfInfo   :: !(ColumnInfo b)
   , _acfAsText :: !Bool
@@ -181,7 +181,7 @@ data RemoteFieldArgument
   , _rfaValue    :: !(InputValue Variable)
   } deriving (Eq,Show)
 
-data RemoteSelect (b :: Backend)
+data RemoteSelect (b :: BackendType)
   = RemoteSelect
   { _rselArgs          :: ![RemoteFieldArgument]
   , _rselSelection     :: !(G.SelectionSet G.NoFragments Variable)
@@ -190,7 +190,7 @@ data RemoteSelect (b :: Backend)
   , _rselRemoteSchema  :: !RemoteSchemaInfo
   }
 
-data AnnFieldG (b :: Backend) v
+data AnnFieldG (b :: BackendType) v
   = AFColumn !(AnnColumnField b)
   | AFObjectRelation !(ObjectRelationSelectG b v)
   | AFArrayRelation !(ArraySelectG b v)
@@ -221,7 +221,7 @@ traverseAnnField f = \case
 
 type AnnField b = AnnFieldG b (SQLExp b)
 
-data SelectArgsG (b :: Backend) v
+data SelectArgsG (b :: BackendType) v
   = SelectArgs
   { _saWhere    :: !(Maybe (AnnBoolExp b v))
   , _saOrderBy  :: !(Maybe (NE.NonEmpty (AnnOrderByItemG b v)))
@@ -249,7 +249,7 @@ type SelectArgs b = SelectArgsG b (SQLExp b)
 noSelectArgs :: SelectArgsG backend v
 noSelectArgs = SelectArgs Nothing Nothing Nothing Nothing Nothing
 
-data ColFld (b :: Backend)
+data ColFld (b :: BackendType)
   = CFCol !(Column b)
   | CFExp !Text
 {-
@@ -259,13 +259,13 @@ deriving instance Show (Column b) => Show (ColFld b)
 
 type ColumnFields b = Fields (ColFld b)
 
-data AggregateOp (b :: Backend)
+data AggregateOp (b :: BackendType)
   = AggregateOp
   { _aoOp     :: !Text
   , _aoFields :: !(ColumnFields b)
   }
 
-data AggregateField (b :: Backend)
+data AggregateField (b :: BackendType)
   = AFCount !PG.CountType
   | AFOp !(AggregateOp b)
   | AFExp !Text
@@ -280,7 +280,7 @@ traverseAnnFields f = traverse (traverse (traverseAnnField f))
 
 type AnnFields b = AnnFieldsG b (SQLExp b)
 
-data TableAggregateFieldG (b :: Backend) v
+data TableAggregateFieldG (b :: BackendType) v
   = TAFAgg !(AggregateFields b)
   | TAFNodes !(AnnFieldsG b v)
   | TAFExp !Text
@@ -294,7 +294,7 @@ data PageInfoField
   deriving (Show, Eq)
 type PageInfoFields = Fields PageInfoField
 
-data EdgeField (b :: Backend) v
+data EdgeField (b :: BackendType) v
   = EdgeTypename !Text
   | EdgeCursor
   | EdgeNode !(AnnFieldsG b v)
@@ -308,7 +308,7 @@ traverseEdgeField f = \case
   EdgeCursor      -> pure EdgeCursor
   EdgeNode fields -> EdgeNode <$> traverseAnnFields f fields
 
-data ConnectionField (b :: Backend) v
+data ConnectionField (b :: BackendType) v
   = ConnectionTypename !Text
   | ConnectionPageInfo !PageInfoFields
   | ConnectionEdges !(EdgeFields b v)
@@ -344,7 +344,7 @@ instance (Hashable v) => Hashable (ArgumentExp v)
 
 type FunctionArgsExpTableRow v = FunctionArgsExpG (ArgumentExp v)
 
-data SelectFromG (b :: Backend) v
+data SelectFromG (b :: BackendType) v
   = FromTable !(TableName b)
   | FromIdentifier !PG.Identifier
   | FromFunction !PG.QualifiedFunction
@@ -356,7 +356,7 @@ instance (Hashable v) => Hashable (SelectFromG 'Postgres v)
 
 type SelectFrom b = SelectFromG b (SQLExp b)
 
-data TablePermG (b :: Backend) v
+data TablePermG (b :: BackendType) v
   = TablePerm
   { _tpFilter :: !(AnnBoolExp b v)
   , _tpLimit  :: !(Maybe Int)
@@ -379,7 +379,7 @@ noTablePermissions =
 
 type TablePerm b = TablePermG b (SQLExp b)
 
-data AnnSelectG (b :: Backend) a v
+data AnnSelectG (b :: BackendType) a v
   = AnnSelectG
   { _asnFields   :: !a
   , _asnFrom     :: !(SelectFromG b v)
@@ -431,7 +431,7 @@ data ConnectionSplitKind
   deriving (Show, Eq, Generic)
 instance Hashable ConnectionSplitKind
 
-data ConnectionSplit (b :: Backend) v
+data ConnectionSplit (b :: BackendType) v
   = ConnectionSplit
   { _csKind    :: !ConnectionSplitKind
   , _csValue   :: !v
@@ -445,7 +445,7 @@ traverseConnectionSplit
 traverseConnectionSplit f (ConnectionSplit k v ob) =
   ConnectionSplit k <$> f v <*> pure ob
 
-data ConnectionSelect (b :: Backend) v
+data ConnectionSelect (b :: BackendType) v
   = ConnectionSelect
   { _csPrimaryKeyColumns :: !(PrimaryKeyColumns b)
   , _csSplit             :: !(Maybe (NE.NonEmpty (ConnectionSplit b v)))
@@ -502,7 +502,7 @@ data SourcePrefixes
   } deriving (Show, Eq, Generic)
 instance Hashable SourcePrefixes
 
-data SelectSource (b :: Backend)
+data SelectSource (b :: BackendType)
   = SelectSource
   { _ssPrefix   :: !PG.Identifier
   , _ssFrom     :: !PG.FromItem
@@ -516,7 +516,7 @@ instance Hashable (SelectSource 'Postgres)
 deriving instance Show (SelectSource 'Postgres)
 deriving instance Eq   (SelectSource 'Postgres)
 
-data SelectNode (b :: Backend)
+data SelectNode (b :: BackendType)
   = SelectNode
   { _snExtractors :: !(HM.HashMap PG.Alias (SQLExp b))
   , _snJoinTree   :: !(JoinTree b)
@@ -538,7 +538,7 @@ objectSelectSourceToSelectSource :: ObjectSelectSource -> (SelectSource backend)
 objectSelectSourceToSelectSource ObjectSelectSource{..} =
   SelectSource _ossPrefix _ossFrom Nothing _ossWhere Nothing Nothing Nothing
 
-data ObjectRelationSource (b :: Backend)
+data ObjectRelationSource (b :: BackendType)
   = ObjectRelationSource
   { _orsRelationshipName :: !RelName
   , _orsRelationMapping  :: !(HM.HashMap (Column b) (Column b))
@@ -547,7 +547,7 @@ data ObjectRelationSource (b :: Backend)
 instance Hashable (ObjectRelationSource 'Postgres)
 deriving instance Eq (Column b) => Eq (ObjectRelationSource b)
 
-data ArrayRelationSource (b :: Backend)
+data ArrayRelationSource (b :: BackendType)
   = ArrayRelationSource
   { _arsAlias           :: !PG.Alias
   , _arsRelationMapping :: !(HM.HashMap (Column b) (Column b))
@@ -556,7 +556,7 @@ data ArrayRelationSource (b :: Backend)
 instance Hashable (ArrayRelationSource 'Postgres)
 deriving instance Eq (ArrayRelationSource 'Postgres)
 
-data ArraySelectNode (b :: Backend)
+data ArraySelectNode (b :: BackendType)
   = ArraySelectNode
   { _asnTopExtractors :: ![PG.Extractor]
   , _asnSelectNode    :: !(SelectNode b)
@@ -566,7 +566,7 @@ instance Semigroup (ArraySelectNode 'Postgres) where
   ArraySelectNode lTopExtrs lSelNode <> ArraySelectNode rTopExtrs rSelNode =
     ArraySelectNode (lTopExtrs <> rTopExtrs) (lSelNode <> rSelNode)
 
-data ComputedFieldTableSetSource (b :: Backend)
+data ComputedFieldTableSetSource (b :: BackendType)
   = ComputedFieldTableSetSource
   { _cftssFieldName    :: !FieldName
   , _cftssSelectType   :: !JsonAggSelect
@@ -576,7 +576,7 @@ instance Hashable (ComputedFieldTableSetSource 'Postgres)
 deriving instance Show (ComputedFieldTableSetSource 'Postgres)
 deriving instance Eq   (ComputedFieldTableSetSource 'Postgres)
 
-data ArrayConnectionSource (b :: Backend)
+data ArrayConnectionSource (b :: BackendType)
   = ArrayConnectionSource
   { _acsAlias           :: !PG.Alias
   , _acsRelationMapping :: !(HM.HashMap (Column b) (Column b))
@@ -588,7 +588,7 @@ deriving instance Eq (ArrayConnectionSource 'Postgres)
 
 instance Hashable (ArrayConnectionSource 'Postgres)
 
-data JoinTree (b :: Backend)
+data JoinTree (b :: BackendType)
   = JoinTree
   { _jtObjectRelations        :: !(HM.HashMap (ObjectRelationSource b) (SelectNode b))
   , _jtArrayRelations         :: !(HM.HashMap (ArrayRelationSource b) (ArraySelectNode b))

--- a/server/src-lib/Hasura/RQL/IR/Update.hs
+++ b/server/src-lib/Hasura/RQL/IR/Update.hs
@@ -3,7 +3,6 @@ module Hasura.RQL.IR.Update where
 
 import           Hasura.Prelude
 
-import           Hasura.Backends.Postgres.SQL.Types
 import           Hasura.RQL.IR.BoolExp
 import           Hasura.RQL.IR.Returning
 import           Hasura.RQL.Types.Column
@@ -13,7 +12,7 @@ import           Hasura.SQL.Backend
 
 data AnnUpdG (b :: Backend) v
   = AnnUpd
-  { uqp1Table   :: !QualifiedTable
+  { uqp1Table   :: !(TableName b)
   , uqp1OpExps  :: ![(Column b, UpdOpExpG v)]
   , uqp1Where   :: !(AnnBoolExp b v, AnnBoolExp b v)
   , uqp1Check   :: !(AnnBoolExp b v)

--- a/server/src-lib/Hasura/RQL/IR/Update.hs
+++ b/server/src-lib/Hasura/RQL/IR/Update.hs
@@ -10,7 +10,7 @@ import           Hasura.RQL.Types.Common
 import           Hasura.SQL.Backend
 
 
-data AnnUpdG (b :: Backend) v
+data AnnUpdG (b :: BackendType) v
   = AnnUpd
   { uqp1Table   :: !(TableName b)
   , uqp1OpExps  :: ![(Column b, UpdOpExpG v)]

--- a/server/src-lib/Hasura/RQL/Types/Action.hs
+++ b/server/src-lib/Hasura/RQL/Types/Action.hs
@@ -184,7 +184,7 @@ getActionOutputFields :: AnnotatedObjectType backend -> ActionOutputFields
 getActionOutputFields =
   Map.fromList . map ( (unObjectFieldName . _ofdName) &&& (fst . _ofdType)) . toList . _otdFields
 
-data ActionInfo (b :: Backend)
+data ActionInfo (b :: BackendType)
   = ActionInfo
   { _aiName         :: !ActionName
   , _aiOutputObject :: !(AnnotatedObjectType b)
@@ -262,7 +262,7 @@ instance J.FromJSON ActionMetadata where
 
 ----------------- Resolve Types ----------------
 
-data AnnActionExecution (b :: Backend) v
+data AnnActionExecution (b :: BackendType) v
   = AnnActionExecution
   { _aaeName                 :: !ActionName
   , _aaeOutputType           :: !GraphQLType -- ^ output type
@@ -284,7 +284,7 @@ data AnnActionMutationAsync
   , _aamaPayload :: !J.Value -- ^ jsonified input arguments
   } deriving (Show, Eq)
 
-data AsyncActionQueryFieldG (b :: Backend) v
+data AsyncActionQueryFieldG (b :: BackendType) v
   = AsyncTypename !Text
   | AsyncOutput !(AnnFieldsG b v)
   | AsyncId
@@ -293,7 +293,7 @@ data AsyncActionQueryFieldG (b :: Backend) v
 
 type AsyncActionQueryFieldsG b v = Fields (AsyncActionQueryFieldG b v)
 
-data AnnActionAsyncQuery (b :: Backend) v
+data AnnActionAsyncQuery (b :: BackendType) v
   = AnnActionAsyncQuery
   { _aaaqName           :: !ActionName
   , _aaaqActionId       :: !v

--- a/server/src-lib/Hasura/RQL/Types/Catalog.hs
+++ b/server/src-lib/Hasura/RQL/Types/Catalog.hs
@@ -146,7 +146,7 @@ instance NFData CatalogFunction
 instance Cacheable CatalogFunction
 $(deriveFromJSON (aesonDrop 3 snakeCase) ''CatalogFunction)
 
-data CatalogCustomTypes (b :: Backend)
+data CatalogCustomTypes (b :: BackendType)
   = CatalogCustomTypes
   { _cctCustomTypes :: !CustomTypes
   , _cctPgScalars   :: !(HashSet (ScalarType b))

--- a/server/src-lib/Hasura/RQL/Types/Column.hs
+++ b/server/src-lib/Hasura/RQL/Types/Column.hs
@@ -94,7 +94,7 @@ instance ToTxt PGColumnType where
     PGColumnScalar scalar                             -> toTxt scalar
     PGColumnEnumReference (EnumReference tableName _) -> toTxt tableName
 
-type family ColumnType (b :: Backend) where
+type family ColumnType (b :: BackendType) where
   ColumnType 'Postgres = PGColumnType
   ColumnType 'MySQL    = Void -- TODO
 
@@ -147,7 +147,7 @@ parseTxtEncodedPGValue colTy val =
 -- | “Raw” column info, as stored in the catalog (but not in the schema cache). Instead of
 -- containing a 'PGColumnType', it only contains a 'PGScalarType', which is combined with the
 -- 'pcirReferences' field and other table data to eventually resolve the type to a 'PGColumnType'.
-data RawColumnInfo (b :: Backend)
+data RawColumnInfo (b :: BackendType)
   = RawColumnInfo
   { prciName        :: !(Column b)
   , prciPosition    :: !Int
@@ -168,7 +168,7 @@ instance FromJSON (RawColumnInfo 'Postgres) where
 
 -- | “Resolved” column info, produced from a 'RawColumnInfo' value that has been combined with
 -- other schema information to produce a 'PGColumnType'.
-data ColumnInfo (b :: Backend)
+data ColumnInfo (b :: BackendType)
   = ColumnInfo
   { pgiColumn      :: !(Column b)
   , pgiName        :: !G.Name

--- a/server/src-lib/Hasura/RQL/Types/Common.hs
+++ b/server/src-lib/Hasura/RQL/Types/Common.hs
@@ -310,12 +310,8 @@ unsafeNonNegativeInt = NonNegativeInt
 instance FromJSON NonNegativeInt where
   parseJSON = withScientific "NonNegativeInt" $ \t -> do
     case t >= 0 of
-      True  -> NonNegativeInt <$> maybeInt (toBoundedInteger t)
+      True  -> maybe (fail "integer passed is out of bounds") (pure . NonNegativeInt) $ toBoundedInteger t
       False -> fail "negative value not allowed"
-    where
-      maybeInt x = case x of
-        Just v  -> return v
-        Nothing -> fail "integer passed is out of bounds"
 
 newtype NonNegativeDiffTime = NonNegativeDiffTime { unNonNegativeDiffTime :: DiffTime }
   deriving (Show, Eq,ToJSON,Generic, NFData, Cacheable, Num)

--- a/server/src-lib/Hasura/RQL/Types/Common.hs
+++ b/server/src-lib/Hasura/RQL/Types/Common.hs
@@ -9,7 +9,7 @@ module Hasura.RQL.Types.Common
        , ScalarType
        , Column
        , SQLExp
-       , BackendImplementation (..)
+       , Backend (..)
 
        , FieldName(..)
        , fromPGCol
@@ -91,16 +91,16 @@ import           Hasura.RQL.Types.Error
 import           Hasura.SQL.Backend
 
 
-type family ScalarType (b :: Backend) where
+type family ScalarType (b :: BackendType) where
   ScalarType 'Postgres = PG.PGScalarType
 
-type family ColumnType (b :: Backend) where
+type family ColumnType (b :: BackendType) where
   ColumnType 'Postgres = PG.PGType
 
-type family Column (b :: Backend) where
+type family Column (b :: BackendType) where
   Column 'Postgres = PG.PGCol
 
-type family SQLExp (b :: Backend) where
+type family SQLExp (b :: BackendType) where
   SQLExp 'Postgres = PG.SQLExp
 
 
@@ -123,10 +123,10 @@ class
   , Hashable (TableName b)
   , Data (TableName b)
   , Typeable b
-  ) => BackendImplementation (b :: Backend) where
+  ) => Backend (b :: BackendType) where
   type TableName b :: Type
 
-instance BackendImplementation 'Postgres where
+instance Backend 'Postgres where
   type TableName 'Postgres = PG.QualifiedTable
 
 

--- a/server/src-lib/Hasura/RQL/Types/Common.hs
+++ b/server/src-lib/Hasura/RQL/Types/Common.hs
@@ -9,7 +9,7 @@ module Hasura.RQL.Types.Common
        , ScalarType
        , Column
        , SQLExp
-       , Representation (..)
+       , BackendImplementation (..)
 
        , FieldName(..)
        , fromPGCol
@@ -103,6 +103,17 @@ type family Column (b :: Backend) where
 type family SQLExp (b :: Backend) where
   SQLExp 'Postgres = PG.SQLExp
 
+
+-- | Mapping from abstract types to concrete backend representation
+--
+-- The RQL IR, used as the output of GraphQL parsers and of the RQL parsers, is
+-- backend-agnostic: it uses an abstract representation of the structure of a
+-- query, and delegates to the backends the task of choosing an appropriate
+-- concrete representation.
+--
+-- Additionally, grouping all those types under one typeclass rather than having
+-- dedicated type families allows to explicitly list all typeclass requirements,
+-- which simplifies the instance declarations of all IR types.
 class
   ( Show (TableName b)
   , Eq (TableName b)
@@ -112,10 +123,10 @@ class
   , Hashable (TableName b)
   , Data (TableName b)
   , Typeable b
-  ) => Representation (b :: Backend) where
+  ) => BackendImplementation (b :: Backend) where
   type TableName b :: Type
 
-instance Representation 'Postgres where
+instance BackendImplementation 'Postgres where
   type TableName 'Postgres = PG.QualifiedTable
 
 

--- a/server/src-lib/Hasura/RQL/Types/ComputedField.hs
+++ b/server/src-lib/Hasura/RQL/Types/ComputedField.hs
@@ -72,7 +72,7 @@ instance Cacheable FunctionSessionArgument
 instance ToJSON FunctionSessionArgument where
   toJSON (FunctionSessionArgument argName _) = toJSON argName
 
-data ComputedFieldReturn (b :: Backend)
+data ComputedFieldReturn (b :: BackendType)
   = CFRScalar !(ScalarType b)
   | CFRSetofTable !QualifiedTable
   deriving (Generic)
@@ -101,7 +101,7 @@ data ComputedFieldFunction
 instance Cacheable ComputedFieldFunction
 $(deriveToJSON (aesonDrop 4 snakeCase) ''ComputedFieldFunction)
 
-data ComputedFieldInfo (b :: Backend)
+data ComputedFieldInfo (b :: BackendType)
   = ComputedFieldInfo
   { _cfiName       :: !ComputedFieldName
   , _cfiFunction   :: !ComputedFieldFunction

--- a/server/src-lib/Hasura/RQL/Types/CustomTypes.hs
+++ b/server/src-lib/Hasura/RQL/Types/CustomTypes.hs
@@ -267,7 +267,7 @@ type AnnotatedObjectType b =
 
 type AnnotatedObjects b = Map.HashMap G.Name (AnnotatedObjectType b)
 
-data AnnotatedCustomTypes (b :: Backend)
+data AnnotatedCustomTypes (b :: BackendType)
   = AnnotatedCustomTypes
     { _actNonObjects :: !NonObjectTypeMap
     , _actObjects    :: !(AnnotatedObjects b)

--- a/server/src-lib/Hasura/RQL/Types/Permission.hs
+++ b/server/src-lib/Hasura/RQL/Types/Permission.hs
@@ -119,7 +119,7 @@ instance (ToJSON a) => ToAesonPairs (PermDef a) where
   ]
 
 -- Insert permission
-data InsPerm (b :: Backend)
+data InsPerm (b :: BackendType)
   = InsPerm
   { ipCheck       :: !(BoolExp b)
   , ipSet         :: !(Maybe (ColumnValues Value))
@@ -135,7 +135,7 @@ instance ToJSON (InsPerm 'Postgres) where
 type InsPermDef    b = PermDef    (InsPerm b)
 
 -- Select constraint
-data SelPerm (b :: Backend)
+data SelPerm (b :: BackendType)
   = SelPerm
   { spColumns           :: !PermColSpec         -- ^ Allowed columns
   , spFilter            :: !(BoolExp b)         -- ^ Filter expression
@@ -159,7 +159,7 @@ instance FromJSON (SelPerm 'Postgres) where
 type SelPermDef b = PermDef (SelPerm b)
 
 -- Delete permission
-data DelPerm (b :: Backend)
+data DelPerm (b :: BackendType)
   = DelPerm { dcFilter :: !(BoolExp b) }
   deriving (Show, Eq, Lift, Generic)
 instance Cacheable (DelPerm 'Postgres)
@@ -171,7 +171,7 @@ instance ToJSON (DelPerm 'Postgres) where
 type DelPermDef    b = PermDef    (DelPerm b)
 
 -- Update constraint
-data UpdPerm (b :: Backend)
+data UpdPerm (b :: BackendType)
   = UpdPerm
   { ucColumns :: !PermColSpec -- Allowed columns
   , ucSet     :: !(Maybe (ColumnValues Value)) -- Preset columns

--- a/server/src-lib/Hasura/RQL/Types/Permission.hs
+++ b/server/src-lib/Hasura/RQL/Types/Permission.hs
@@ -1,13 +1,10 @@
 module Hasura.RQL.Types.Permission where
 
-import           Hasura.Backends.Postgres.SQL.Types (PGCol, TableName, getTableTxt)
-import           Hasura.Incremental                 (Cacheable)
 import           Hasura.Prelude
-import           Hasura.RQL.IR.BoolExp
-import           Hasura.RQL.Types.Common
-import           Hasura.RQL.Types.ComputedField
-import           Hasura.SQL.Backend
-import           Hasura.Session
+
+import qualified Data.Text                          as T
+import qualified Database.PG.Query                  as Q
+import qualified PostgreSQL.Binary.Decoding         as PD
 
 import           Control.Lens                       (makeLenses)
 import           Data.Aeson
@@ -17,9 +14,15 @@ import           Data.Hashable
 import           Instances.TH.Lift                  ()
 import           Language.Haskell.TH.Syntax         (Lift)
 
-import qualified Data.Text                          as T
-import qualified Database.PG.Query                  as Q
-import qualified PostgreSQL.Binary.Decoding         as PD
+import           Hasura.Backends.Postgres.SQL.Types (PGCol, TableName, getTableTxt)
+import           Hasura.Incremental                 (Cacheable)
+import           Hasura.RQL.IR.BoolExp
+import           Hasura.RQL.Types.Common            hiding (TableName)
+import           Hasura.RQL.Types.ComputedField
+import           Hasura.SQL.Backend
+import           Hasura.Session
+
+
 
 data PermType
   = PTInsert

--- a/server/src-lib/Hasura/RQL/Types/RemoteRelationship.hs
+++ b/server/src-lib/Hasura/RQL/Types/RemoteRelationship.hs
@@ -52,7 +52,7 @@ fromRemoteRelationship :: RemoteRelationshipName -> FieldName
 fromRemoteRelationship = FieldName . remoteRelationshipNameToText
 
 -- | Resolved remote relationship
-data RemoteFieldInfo (b :: Backend)
+data RemoteFieldInfo (b :: BackendType)
   = RemoteFieldInfo
   { _rfiName             :: !RemoteRelationshipName
     -- ^ Field name to which we'll map the remote in hasura; this becomes part

--- a/server/src-lib/Hasura/RQL/Types/RemoteRelationship.hs
+++ b/server/src-lib/Hasura/RQL/Types/RemoteRelationship.hs
@@ -152,9 +152,7 @@ instance FromJSON RemoteArguments where
         bleh <-
           traverse
           (\(key, value) -> do
-              name <- case G.mkName key of
-                Nothing    -> fail $ T.unpack key <> " is an invalid key name"
-                Just name' -> pure name'
+              name <- G.mkName key `onNothing` fail (T.unpack key <> " is an invalid key name")
               parsedValue <- parseValueAsGValue value
               pure (name,parsedValue))
              (HM.toList hashMap)

--- a/server/src-lib/Hasura/RQL/Types/Table.hs
+++ b/server/src-lib/Hasura/RQL/Types/Table.hs
@@ -106,9 +106,9 @@ import           Hasura.RQL.Types.Error
 import           Hasura.RQL.Types.EventTrigger
 import           Hasura.RQL.Types.Permission
 import           Hasura.RQL.Types.RemoteRelationship
+import           Hasura.SQL.Backend
 import           Hasura.Server.Utils                 (duplicates, englishList)
 import           Hasura.Session
-import           Hasura.SQL.Backend
 
 
 data TableCustomRootFields
@@ -165,7 +165,7 @@ emptyCustomRootFields =
   , _tcrfDeleteByPk      = Nothing
   }
 
-data FieldInfo (b :: Backend)
+data FieldInfo (b :: BackendType)
   = FIColumn !(ColumnInfo b)
   | FIRelationship !RelInfo
   | FIComputedField !(ComputedFieldInfo b)
@@ -227,7 +227,7 @@ isPGColInfo :: FieldInfo backend -> Bool
 isPGColInfo (FIColumn _) = True
 isPGColInfo _            = False
 
-data InsPermInfo (b :: Backend)
+data InsPermInfo (b :: BackendType)
   = InsPermInfo
   { ipiCols            :: !(HS.HashSet (Column b))
   , ipiCheck           :: !(AnnBoolExpPartialSQL b)
@@ -241,7 +241,7 @@ instance Cacheable (InsPermInfo 'Postgres)
 instance ToJSON (InsPermInfo 'Postgres) where
   toJSON = genericToJSON $ aesonDrop 3 snakeCase
 
-data SelPermInfo (b :: Backend)
+data SelPermInfo (b :: BackendType)
   = SelPermInfo
   { spiCols                 :: !(HS.HashSet (Column b))
   , spiScalarComputedFields :: !(HS.HashSet ComputedFieldName)
@@ -256,7 +256,7 @@ instance Cacheable (SelPermInfo 'Postgres)
 instance ToJSON (SelPermInfo 'Postgres) where
   toJSON = genericToJSON $ aesonDrop 3 snakeCase
 
-data UpdPermInfo (b :: Backend)
+data UpdPermInfo (b :: BackendType)
   = UpdPermInfo
   { upiCols            :: !(HS.HashSet (Column b))
   , upiTable           :: !QualifiedTable
@@ -271,7 +271,7 @@ instance Cacheable (UpdPermInfo 'Postgres)
 instance ToJSON (UpdPermInfo 'Postgres) where
   toJSON = genericToJSON $ aesonDrop 3 snakeCase
 
-data DelPermInfo (b :: Backend)
+data DelPermInfo (b :: BackendType)
   = DelPermInfo
   { dpiTable           :: !QualifiedTable
   , dpiFilter          :: !(AnnBoolExpPartialSQL b)
@@ -286,7 +286,7 @@ instance ToJSON (DelPermInfo 'Postgres) where
 mkRolePermInfo :: RolePermInfo backend
 mkRolePermInfo = RolePermInfo Nothing Nothing Nothing Nothing
 
-data RolePermInfo (b :: Backend)
+data RolePermInfo (b :: BackendType)
   = RolePermInfo
   { _permIns :: !(Maybe (InsPermInfo b))
   , _permSel :: !(Maybe (SelPermInfo b))
@@ -440,7 +440,7 @@ tciUniqueOrPrimaryKeyConstraints info = NE.nonEmpty $
   maybeToList (_pkConstraint <$> _tciPrimaryKey info)
   <> toList (_tciUniqueConstraints info)
 
-data TableInfo (b :: Backend)
+data TableInfo (b :: BackendType)
   = TableInfo
   { _tiCoreInfo            :: TableCoreInfo b
   , _tiRolePermInfoMap     :: !(RolePermInfoMap b)

--- a/server/src-lib/Hasura/SQL/Backend.hs
+++ b/server/src-lib/Hasura/SQL/Backend.hs
@@ -1,3 +1,3 @@
 module Hasura.SQL.Backend where
 
-data Backend = Postgres | MySQL -- | Misc
+data BackendType = Postgres | MySQL -- | Misc


### PR DESCRIPTION
### Description
This PR is in the continuation of our IR work. It generalizes table names throughout the IR code. It uses a slightly different representation than the one we've been using so far, to avoid having an explosion of instance declarations for every type that uses it.

Additionally, this starts fixing a few imports.