### PR TITLE
server: avoid two circular imports

### DIFF
--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -455,9 +455,11 @@ library
                      , Hasura.GraphQL.Context
                      , Hasura.GraphQL.Parser
                      , Hasura.GraphQL.Parser.Class
+                     , Hasura.GraphQL.Parser.Class.Parse
                      , Hasura.GraphQL.Parser.Collect
                      , Hasura.GraphQL.Parser.Column
                      , Hasura.GraphQL.Parser.Internal.Parser
+                     , Hasura.GraphQL.Parser.Internal.Types
                      , Hasura.GraphQL.Parser.Monad
                      , Hasura.GraphQL.Parser.Schema
                      , Hasura.GraphQL.Schema

--- a/server/src-lib/Hasura/GraphQL/Parser.hs
+++ b/server/src-lib/Hasura/GraphQL/Parser.hs
@@ -50,5 +50,6 @@ module Hasura.GraphQL.Parser
 import           Hasura.GraphQL.Parser.Class
 import           Hasura.GraphQL.Parser.Column
 import           Hasura.GraphQL.Parser.Internal.Parser
+import           Hasura.GraphQL.Parser.Internal.Types
 import           Hasura.GraphQL.Parser.Monad
 import           Hasura.GraphQL.Parser.Schema

--- a/server/src-lib/Hasura/GraphQL/Parser.hs
+++ b/server/src-lib/Hasura/GraphQL/Parser.hs
@@ -50,6 +50,5 @@ module Hasura.GraphQL.Parser
 import           Hasura.GraphQL.Parser.Class
 import           Hasura.GraphQL.Parser.Column
 import           Hasura.GraphQL.Parser.Internal.Parser
-import           Hasura.GraphQL.Parser.Internal.Types
 import           Hasura.GraphQL.Parser.Monad
 import           Hasura.GraphQL.Parser.Schema

--- a/server/src-lib/Hasura/GraphQL/Parser/Class.hs
+++ b/server/src-lib/Hasura/GraphQL/Parser/Class.hs
@@ -1,5 +1,10 @@
 -- | Classes for monads used during schema construction and query parsing.
-module Hasura.GraphQL.Parser.Class where
+module Hasura.GraphQL.Parser.Class
+  ( MonadParse(..)
+  , parseError
+  , QueryReusability(..)
+  , module Hasura.GraphQL.Parser.Class
+  ) where
 
 import                          Hasura.Prelude
 
@@ -8,14 +13,14 @@ import                qualified Language.Haskell.TH                   as TH
 import                qualified Language.GraphQL.Draft.Syntax         as G
 
 import                          Data.Has
-import                          Data.Parser.JSONPath
 import                          Data.Text.Extended
 import                          Data.Tuple.Extended
 import                          GHC.Stack                             (HasCallStack)
 import                          Type.Reflection                       (Typeable)
 
 import                          Hasura.Backends.Postgres.SQL.Types
-import {-# SOURCE #-}           Hasura.GraphQL.Parser.Internal.Parser
+import                          Hasura.GraphQL.Parser.Class.Parse
+import                          Hasura.GraphQL.Parser.Internal.Types
 import                          Hasura.RQL.Types.Error
 import                          Hasura.RQL.Types.Table
 import                          Hasura.SQL.Backend
@@ -173,41 +178,3 @@ memoize4
   -> (a -> b -> c -> d -> m (Parser k n e))
   -> (a -> b -> c -> d -> m (Parser k n e))
 memoize4 name = curry4 . memoize name . uncurry4
-
--- | A class that provides functionality for parsing GraphQL queries, i.e.
--- running a fully-constructed 'Parser'.
-class Monad m => MonadParse m where
-  withPath :: (JSONPath -> JSONPath) -> m a -> m a
-  -- | Not the full power of 'MonadError' because parse errors cannot be
-  -- caught.
-  parseErrorWith :: Code -> Text -> m a
-  -- | See 'QueryReusability'.
-  markNotReusable :: m ()
-
-parseError :: MonadParse m => Text -> m a
-parseError = parseErrorWith ValidationFailed
-
--- | Tracks whether or not a query is /reusable/. Reusable queries are nice,
--- since we can cache their resolved ASTs and avoid re-resolving them if we
--- receive an identical query. However, we can’t always safely reuse queries if
--- they have variables, since some variable values can affect the generated SQL.
--- For example, consider the following query:
---
--- > query users_where($condition: users_bool_exp!) {
--- >   users(where: $condition) {
--- >     id
--- >   }
--- > }
---
--- Different values for @$condition@ will produce completely different queries,
--- so we can’t reuse its plan (unless the variable values were also all
--- identical, of course, but we don’t bother caching those).
-data QueryReusability = Reusable | NotReusable
-
-instance Semigroup QueryReusability where
-  NotReusable <> _           = NotReusable
-  _           <> NotReusable = NotReusable
-  Reusable    <> Reusable    = Reusable
-
-instance Monoid QueryReusability where
-  mempty = Reusable

--- a/server/src-lib/Hasura/GraphQL/Parser/Class.hs
+++ b/server/src-lib/Hasura/GraphQL/Parser/Class.hs
@@ -145,7 +145,7 @@ getTableGQLName
 getTableGQLName table = do
   tableInfo <- askTableInfo table
   let tableCustomName = _tcCustomName . _tciCustomConfig . _tiCoreInfo $ tableInfo
-  maybe (qualifiedObjectToName table) pure tableCustomName
+  tableCustomName `onNothing` qualifiedObjectToName table
 
 -- | A wrapper around 'memoizeOn' that memoizes a function by using its argument
 -- as the key.

--- a/server/src-lib/Hasura/GraphQL/Parser/Class.hs
+++ b/server/src-lib/Hasura/GraphQL/Parser/Class.hs
@@ -6,25 +6,25 @@ module Hasura.GraphQL.Parser.Class
   , module Hasura.GraphQL.Parser.Class
   ) where
 
-import                          Hasura.Prelude
+import           Hasura.Prelude
 
-import                qualified Data.HashMap.Strict                   as Map
-import                qualified Language.Haskell.TH                   as TH
-import                qualified Language.GraphQL.Draft.Syntax         as G
+import qualified Data.HashMap.Strict                  as Map
+import qualified Language.GraphQL.Draft.Syntax        as G
+import qualified Language.Haskell.TH                  as TH
 
-import                          Data.Has
-import                          Data.Text.Extended
-import                          Data.Tuple.Extended
-import                          GHC.Stack                             (HasCallStack)
-import                          Type.Reflection                       (Typeable)
+import           Data.Has
+import           Data.Text.Extended
+import           Data.Tuple.Extended
+import           GHC.Stack                            (HasCallStack)
+import           Type.Reflection                      (Typeable)
 
-import                          Hasura.Backends.Postgres.SQL.Types
-import                          Hasura.GraphQL.Parser.Class.Parse
-import                          Hasura.GraphQL.Parser.Internal.Types
-import                          Hasura.RQL.Types.Error
-import                          Hasura.RQL.Types.Table
-import                          Hasura.SQL.Backend
-import                          Hasura.Session                        (RoleName)
+import           Hasura.Backends.Postgres.SQL.Types
+import           Hasura.GraphQL.Parser.Class.Parse
+import           Hasura.GraphQL.Parser.Internal.Types
+import           Hasura.RQL.Types.Error
+import           Hasura.RQL.Types.Table
+import           Hasura.SQL.Backend
+import           Hasura.Session                       (RoleName)
 
 {- Note [Tying the knot]
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/server/src-lib/Hasura/GraphQL/Parser/Class.hs-boot
+++ b/server/src-lib/Hasura/GraphQL/Parser/Class.hs-boot
@@ -1,5 +1,0 @@
-module Hasura.GraphQL.Parser.Class where
-
-import Data.Kind (Type)
-
-class MonadParse (m :: Type -> Type)

--- a/server/src-lib/Hasura/GraphQL/Parser/Class/Parse.hs
+++ b/server/src-lib/Hasura/GraphQL/Parser/Class/Parse.hs
@@ -1,0 +1,46 @@
+-- | Classes for monads used during schema construction and query parsing.
+module Hasura.GraphQL.Parser.Class.Parse where
+
+import           Hasura.Prelude
+
+import           Data.Parser.JSONPath
+
+import           Hasura.RQL.Types.Error
+
+-- | A class that provides functionality for parsing GraphQL queries, i.e.
+-- running a fully-constructed 'Parser'.
+class Monad m => MonadParse m where
+  withPath :: (JSONPath -> JSONPath) -> m a -> m a
+  -- | Not the full power of 'MonadError' because parse errors cannot be
+  -- caught.
+  parseErrorWith :: Code -> Text -> m a
+  -- | See 'QueryReusability'.
+  markNotReusable :: m ()
+
+parseError :: MonadParse m => Text -> m a
+parseError = parseErrorWith ValidationFailed
+
+-- | Tracks whether or not a query is /reusable/. Reusable queries are nice,
+-- since we can cache their resolved ASTs and avoid re-resolving them if we
+-- receive an identical query. However, we can’t always safely reuse queries if
+-- they have variables, since some variable values can affect the generated SQL.
+-- For example, consider the following query:
+--
+-- > query users_where($condition: users_bool_exp!) {
+-- >   users(where: $condition) {
+-- >     id
+-- >   }
+-- > }
+--
+-- Different values for @$condition@ will produce completely different queries,
+-- so we can’t reuse its plan (unless the variable values were also all
+-- identical, of course, but we don’t bother caching those).
+data QueryReusability = Reusable | NotReusable
+
+instance Semigroup QueryReusability where
+  NotReusable <> _           = NotReusable
+  _           <> NotReusable = NotReusable
+  Reusable    <> Reusable    = Reusable
+
+instance Monoid QueryReusability where
+  mempty = Reusable

--- a/server/src-lib/Hasura/GraphQL/Parser/Collect.hs
+++ b/server/src-lib/Hasura/GraphQL/Parser/Collect.hs
@@ -22,7 +22,8 @@ import                          Language.GraphQL.Draft.Syntax
 
 import                          Data.Text.Extended
 import                          Hasura.GraphQL.Parser.Class
-import {-# SOURCE #-}           Hasura.GraphQL.Parser.Internal.Parser (boolean, runParser)
+import                          Hasura.GraphQL.Parser.Internal.Types
+import {-# SOURCE #-}           Hasura.GraphQL.Parser.Internal.Parser (boolean)
 import                          Hasura.GraphQL.Parser.Schema
 import                          Hasura.GraphQL.Utils                  (showNames)
 

--- a/server/src-lib/Hasura/GraphQL/Parser/Collect.hs
+++ b/server/src-lib/Hasura/GraphQL/Parser/Collect.hs
@@ -12,20 +12,18 @@ module Hasura.GraphQL.Parser.Collect
   ( collectFields
   ) where
 
-import                          Hasura.Prelude
+import           Hasura.Prelude
 
-import                qualified Data.HashMap.Strict.Extended          as Map
-import                qualified Data.HashMap.Strict.InsOrd            as OMap
+import qualified Data.HashMap.Strict.Extended  as Map
+import qualified Data.HashMap.Strict.InsOrd    as OMap
 
-import                          Data.List.Extended                    (duplicates)
-import                          Language.GraphQL.Draft.Syntax
+import           Data.List.Extended            (duplicates)
+import           Language.GraphQL.Draft.Syntax
 
-import                          Data.Text.Extended
-import                          Hasura.GraphQL.Parser.Class
-import                          Hasura.GraphQL.Parser.Internal.Types
-import {-# SOURCE #-}           Hasura.GraphQL.Parser.Internal.Parser (boolean)
-import                          Hasura.GraphQL.Parser.Schema
-import                          Hasura.GraphQL.Utils                  (showNames)
+import           Data.Text.Extended
+import           Hasura.GraphQL.Parser.Class
+import           Hasura.GraphQL.Parser.Schema
+import           Hasura.GraphQL.Utils          (showNames)
 
 -- | Collects the effective set of fields queried by a selection set by
 -- flattening fragments and merging duplicate fields.
@@ -34,10 +32,12 @@ collectFields
   => t Name
   -- ^ The names of the object types and interface types the 'SelectionSet' is
   -- selecting against.
+  -> (InputValue Variable -> m Bool)
+  -- ^ Please pass 'runParser boolean' here (passed explicitly to avoid cyclic imports)
   -> SelectionSet NoFragments Variable
   -> m (InsOrdHashMap Name (Field NoFragments Variable))
-collectFields objectTypeNames selectionSet =
-  mergeFields =<< flattenSelectionSet objectTypeNames selectionSet
+collectFields objectTypeNames boolParser selectionSet =
+  mergeFields =<< flattenSelectionSet objectTypeNames boolParser selectionSet
 
 -- | Flattens inline fragments in a selection set. For example,
 --
@@ -93,9 +93,11 @@ flattenSelectionSet
   :: (MonadParse m, Foldable t)
   => t Name
   -- ^ The name of the object type the 'SelectionSet' is selecting against.
+  -> (InputValue Variable -> m Bool)
+  -- ^ Please pass 'runParser boolean' here (passed explicitly to avoid cyclic imports)
   -> SelectionSet NoFragments Variable
   -> m [Field NoFragments Variable]
-flattenSelectionSet objectTypeNames = fmap concat . traverse flattenSelection
+flattenSelectionSet objectTypeNames boolParser = fmap concat . traverse flattenSelection
   where
     -- The easy case: just a single field.
     flattenSelection (SelectionField field) = do
@@ -131,7 +133,7 @@ flattenSelectionSet objectTypeNames = fmap concat . traverse flattenSelection
 
     flattenInlineFragment InlineFragment{ _ifDirectives, _ifSelectionSet  } = do
       validateDirectives _ifDirectives
-      flattenSelectionSet objectTypeNames _ifSelectionSet
+      flattenSelectionSet objectTypeNames boolParser _ifSelectionSet
 
     applyInclusionDirectives directives continue
       | Just directive <- find ((== $$(litName "include")) . _dName) directives
@@ -143,7 +145,7 @@ flattenSelectionSet objectTypeNames = fmap concat . traverse flattenSelection
     applyInclusionDirective adjust Directive{ _dName, _dArguments } continue = do
       ifArgument <- Map.lookup $$(litName "if") _dArguments `onNothing`
         parseError ("missing \"if\" argument for " <> _dName <<> " directive")
-      value <- runParser boolean $ GraphQLValue ifArgument
+      value <- boolParser $ GraphQLValue ifArgument
       if adjust value then continue else pure []
 
     validateDirectives directives =

--- a/server/src-lib/Hasura/GraphQL/Parser/Internal/Parser.hs
+++ b/server/src-lib/Hasura/GraphQL/Parser/Internal/Parser.hs
@@ -13,20 +13,20 @@ module Hasura.GraphQL.Parser.Internal.Parser
 
 import           Hasura.Prelude
 
-import qualified Data.Aeson                         as A
-import qualified Data.HashMap.Strict.Extended       as M
-import qualified Data.HashMap.Strict.InsOrd         as OMap
-import qualified Data.HashSet                       as S
-import qualified Data.List.Extended                 as LE
-import qualified Data.Text                          as T
+import qualified Data.Aeson                           as A
+import qualified Data.HashMap.Strict.Extended         as M
+import qualified Data.HashMap.Strict.InsOrd           as OMap
+import qualified Data.HashSet                         as S
+import qualified Data.List.Extended                   as LE
+import qualified Data.Text                            as T
 
-import           Control.Lens.Extended              hiding (enum, index)
-import           Data.Int                           (Int32, Int64)
+import           Control.Lens.Extended                hiding (enum, index)
+import           Data.Int                             (Int32, Int64)
 import           Data.Parser.JSONPath
-import           Data.Scientific                    (toBoundedInteger)
+import           Data.Scientific                      (toBoundedInteger)
 import           Data.Text.Extended
 import           Data.Type.Equality
-import           Language.GraphQL.Draft.Syntax      hiding (Definition)
+import           Language.GraphQL.Draft.Syntax        hiding (Definition)
 
 import           Hasura.Backends.Postgres.SQL.Value
 import           Hasura.GraphQL.Parser.Class.Parse
@@ -35,7 +35,7 @@ import           Hasura.GraphQL.Parser.Internal.Types
 import           Hasura.GraphQL.Parser.Schema
 import           Hasura.RQL.Types.CustomTypes
 import           Hasura.RQL.Types.Error
-import           Hasura.Server.Utils                (englishList)
+import           Hasura.Server.Utils                  (englishList)
 
 
 -- | The constraint @(''Input' '<:' k)@ entails @('ParserInput' k ~ 'Value')@,
@@ -602,7 +602,7 @@ selectionSetObject name description parsers implementsInterfaces = Parser
 
       -- TODO(PDV) This probably accepts invalid queries, namely queries that use
       -- type names that do not exist.
-      fields <- collectFields (name:parsedInterfaceNames) input
+      fields <- collectFields (name:parsedInterfaceNames) (runParser boolean) input
       for fields \selectionField@Field{ _fName, _fAlias } -> if
         | _fName == $$(litName "__typename") ->
             pure $ SelectTypename name

--- a/server/src-lib/Hasura/GraphQL/Parser/Internal/Parser.hs
+++ b/server/src-lib/Hasura/GraphQL/Parser/Internal/Parser.hs
@@ -3,7 +3,13 @@
 {-# LANGUAGE StrictData          #-}
 
 -- | Defines the 'Parser' type and its primitive combinators.
-module Hasura.GraphQL.Parser.Internal.Parser where
+module Hasura.GraphQL.Parser.Internal.Parser
+  ( module Hasura.GraphQL.Parser.Internal.Parser
+  , Parser(..)
+  , parserType
+  , runParser
+  , ParserInput
+  ) where
 
 import           Hasura.Prelude
 
@@ -23,144 +29,14 @@ import           Data.Type.Equality
 import           Language.GraphQL.Draft.Syntax      hiding (Definition)
 
 import           Hasura.Backends.Postgres.SQL.Value
-import           Hasura.GraphQL.Parser.Class
+import           Hasura.GraphQL.Parser.Class.Parse
 import           Hasura.GraphQL.Parser.Collect
+import           Hasura.GraphQL.Parser.Internal.Types
 import           Hasura.GraphQL.Parser.Schema
 import           Hasura.RQL.Types.CustomTypes
 import           Hasura.RQL.Types.Error
 import           Hasura.Server.Utils                (englishList)
 
-
--- -----------------------------------------------------------------------------
--- type definitions
-
--- | A 'Parser' that corresponds to a type in the GraphQL schema. A 'Parser' is
--- really two things at once:
---
---   1. As its name implies, a 'Parser' can be used to parse GraphQL queries
---      (via 'runParser').
---
---   2. Less obviously, a 'Parser' represents a slice of the GraphQL schema,
---      since every 'Parser' corresponds to a particular GraphQL type, and
---      information about that type can be recovered (via 'parserType').
---
--- A natural way to view this is that 'Parser's support a sort of dynamic
--- reflection: in addition to running a 'Parser' on an input query, you can ask
--- it to tell you about what type of input it expects. Importantly, you can do
--- this even if you don’t have a query to parse; this is necessary to implement
--- GraphQL introspection, which provides precisely this sort of reflection on
--- types.
---
--- Another way of viewing a 'Parser' is a little more quantum: just as light
--- “sometimes behaves like a particle and sometimes behaves like a wave,” a
--- 'Parser' “sometimes behaves like a query parser and sometimes behaves like a
--- type.” In this way, you can think of a function that produces a 'Parser' as
--- simultaneously both a function that constructs a GraphQL schema and a
--- function that parses a GraphQL query. 'Parser' constructors therefore
--- interleave two concerns: information about a type definition (like the type’s
--- name and description) and information about how to parse a query on that type.
---
--- Notably, these two concerns happen at totally different phases in the
--- program: GraphQL schema construction happens when @graphql-engine@ first
--- starts up, before it receives any GraphQL queries at all. But query parsing
--- obviously can’t happen until there is actually a query to parse. For that
--- reason, it’s useful to take care to distinguish which effects are happening
--- at which phase during 'Parser' construction, since otherwise you may get
--- mixed up!
---
--- For some more information about how to interpret the meaning of a 'Parser',
--- see Note [The meaning of Parser 'Output].
-data Parser k m a = Parser
-  { pType   :: ~(Type k)
-  -- ^ Lazy for knot-tying reasons; see Note [Tying the knot] in
-  -- Hasura.GraphQL.Parser.Class.
-  , pParser :: ParserInput k -> m a
-  } deriving (Functor)
-
-parserType :: Parser k m a -> Type k
-parserType = pType
-
-runParser :: Parser k m a -> ParserInput k -> m a
-runParser = pParser
-
-instance HasName (Parser k m a) where
-  getName = getName . pType
-
-instance HasDefinition (Parser k m a) (TypeInfo k) where
-  definitionLens f parser = definitionLens f (pType parser) <&> \pType -> parser { pType }
-
-type family ParserInput k where
-  -- see Note [The 'Both kind] in Hasura.GraphQL.Parser.Schema
-  ParserInput 'Both = InputValue Variable
-  ParserInput 'Input = InputValue Variable
-  -- see Note [The meaning of Parser 'Output]
-  ParserInput 'Output = SelectionSet NoFragments Variable
-
-{- Note [The meaning of Parser 'Output]
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The ParserInput type family determines what a Parser accepts as input during
-query parsing, which varies based on its Kind. A `Parser 'Input`,
-unsurprisingly, parses GraphQL input values, much in the same way aeson
-`Parser`s parse JSON values.
-
-Therefore, one might naturally conclude that `Parser 'Output` ought to parse
-GraphQL output values. But it doesn’t---a Parser is used to parse GraphQL
-*queries*, and output values don’t show up in queries anywhere! Rather, the
-output values are the results of executing the query, not something the user
-sends us, so we don’t have to parse those at all.
-
-What output types really correspond to in GraphQL queries is selection sets. For
-example, if we have the GraphQL types
-
-    type User {
-      posts(filters: PostFilters): [Post]
-    }
-
-    input PostFilters {
-      newer_than: Date
-    }
-
-    type Post {
-      id: Int
-      title: String
-      body: String
-    }
-
-then we might receive a query that looks like this:
-
-    query list_user_posts($user_id: Int, $date: Date) {
-      user_by_id(id: $user_id) {
-        posts(filters: {newer_than: $date}) {
-          id
-          title
-        }
-      }
-    }
-
-We have Parsers to represent each of these types: a `Parser 'Input` for
-PostFilters, and two `Parser 'Output`s for User and Post. When we parse the
-query, we pass the `{newer_than: $date}` input value to the PostFilters parser,
-as expected. But what do we pass to the User parser? The answer is this
-selection set:
-
-    {
-      posts(filters: {newer_than: $date}) {
-        id
-        title
-      }
-    }
-
-Likewise, the Post parser eventually receives the inner selection set:
-
-    {
-      id
-      title
-    }
-
-These Parsers handle interpreting the fields of the selection sets. This is why
-`ParserInput 'Output` is SelectionSet---the GraphQL *type* associated with the
-Parser is an output type, but the part of the *query* that corresponds to that
-output type isn’t an output value but a selection set. -}
 
 -- | The constraint @(''Input' '<:' k)@ entails @('ParserInput' k ~ 'Value')@,
 -- but GHC can’t figure that out on its own, so we have to be explicit to give

--- a/server/src-lib/Hasura/GraphQL/Parser/Internal/Parser.hs-boot
+++ b/server/src-lib/Hasura/GraphQL/Parser/Internal/Parser.hs-boot
@@ -1,9 +1,0 @@
-module Hasura.GraphQL.Parser.Internal.Parser where
-
-import           Hasura.Prelude
-
-import           Hasura.GraphQL.Parser.Class.Parse
-import           Hasura.GraphQL.Parser.Internal.Types
-import           Hasura.GraphQL.Parser.Schema
-
-boolean :: MonadParse m => Parser 'Both m Bool

--- a/server/src-lib/Hasura/GraphQL/Parser/Internal/Parser.hs-boot
+++ b/server/src-lib/Hasura/GraphQL/Parser/Internal/Parser.hs-boot
@@ -2,22 +2,8 @@ module Hasura.GraphQL.Parser.Internal.Parser where
 
 import           Hasura.Prelude
 
-import qualified Data.Kind                     as K
-
-import           Language.GraphQL.Draft.Syntax
-
-
-import {-# SOURCE #-} Hasura.GraphQL.Parser.Class
+import           Hasura.GraphQL.Parser.Class.Parse
+import           Hasura.GraphQL.Parser.Internal.Types
 import           Hasura.GraphQL.Parser.Schema
-
-type role Parser nominal representational nominal
-data Parser (k :: Kind) (m :: K.Type -> K.Type) (a :: K.Type)
-
-runParser :: Parser k m a -> ParserInput k -> m a
-
-type family ParserInput k where
-  ParserInput 'Both = InputValue Variable
-  ParserInput 'Input = InputValue Variable
-  ParserInput 'Output = SelectionSet NoFragments Variable
 
 boolean :: MonadParse m => Parser 'Both m Bool

--- a/server/src-lib/Hasura/GraphQL/Parser/Internal/Types.hs
+++ b/server/src-lib/Hasura/GraphQL/Parser/Internal/Types.hs
@@ -1,0 +1,142 @@
+{-# LANGUAGE StrictData          #-}
+
+-- | Defines the 'Parser' type and its primitive combinators.
+module Hasura.GraphQL.Parser.Internal.Types where
+
+import           Hasura.Prelude
+
+import           Language.GraphQL.Draft.Syntax      hiding (Definition)
+
+import           Hasura.GraphQL.Parser.Schema
+
+
+-- -----------------------------------------------------------------------------
+-- type definitions
+
+-- | A 'Parser' that corresponds to a type in the GraphQL schema. A 'Parser' is
+-- really two things at once:
+--
+--   1. As its name implies, a 'Parser' can be used to parse GraphQL queries
+--      (via 'runParser').
+--
+--   2. Less obviously, a 'Parser' represents a slice of the GraphQL schema,
+--      since every 'Parser' corresponds to a particular GraphQL type, and
+--      information about that type can be recovered (via 'parserType').
+--
+-- A natural way to view this is that 'Parser's support a sort of dynamic
+-- reflection: in addition to running a 'Parser' on an input query, you can ask
+-- it to tell you about what type of input it expects. Importantly, you can do
+-- this even if you don’t have a query to parse; this is necessary to implement
+-- GraphQL introspection, which provides precisely this sort of reflection on
+-- types.
+--
+-- Another way of viewing a 'Parser' is a little more quantum: just as light
+-- “sometimes behaves like a particle and sometimes behaves like a wave,” a
+-- 'Parser' “sometimes behaves like a query parser and sometimes behaves like a
+-- type.” In this way, you can think of a function that produces a 'Parser' as
+-- simultaneously both a function that constructs a GraphQL schema and a
+-- function that parses a GraphQL query. 'Parser' constructors therefore
+-- interleave two concerns: information about a type definition (like the type’s
+-- name and description) and information about how to parse a query on that type.
+--
+-- Notably, these two concerns happen at totally different phases in the
+-- program: GraphQL schema construction happens when @graphql-engine@ first
+-- starts up, before it receives any GraphQL queries at all. But query parsing
+-- obviously can’t happen until there is actually a query to parse. For that
+-- reason, it’s useful to take care to distinguish which effects are happening
+-- at which phase during 'Parser' construction, since otherwise you may get
+-- mixed up!
+--
+-- For some more information about how to interpret the meaning of a 'Parser',
+-- see Note [The meaning of Parser 'Output].
+data Parser k m a = Parser
+  { pType   :: ~(Type k)
+  -- ^ Lazy for knot-tying reasons; see Note [Tying the knot] in
+  -- Hasura.GraphQL.Parser.Class.
+  , pParser :: ParserInput k -> m a
+  } deriving (Functor)
+
+instance HasName (Parser k m a) where
+  getName = getName . pType
+
+instance HasDefinition (Parser k m a) (TypeInfo k) where
+  definitionLens f parser = definitionLens f (pType parser) <&> \pType -> parser { pType }
+
+type family ParserInput k where
+  -- see Note [The 'Both kind] in Hasura.GraphQL.Parser.Schema
+  ParserInput 'Both = InputValue Variable
+  ParserInput 'Input = InputValue Variable
+  -- see Note [The meaning of Parser 'Output]
+  ParserInput 'Output = SelectionSet NoFragments Variable
+
+parserType :: Parser k m a -> Type k
+parserType = pType
+
+runParser :: Parser k m a -> ParserInput k -> m a
+runParser = pParser
+
+{- Note [The meaning of Parser 'Output]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ParserInput type family determines what a Parser accepts as input during
+query parsing, which varies based on its Kind. A `Parser 'Input`,
+unsurprisingly, parses GraphQL input values, much in the same way aeson
+`Parser`s parse JSON values.
+
+Therefore, one might naturally conclude that `Parser 'Output` ought to parse
+GraphQL output values. But it doesn’t---a Parser is used to parse GraphQL
+*queries*, and output values don’t show up in queries anywhere! Rather, the
+output values are the results of executing the query, not something the user
+sends us, so we don’t have to parse those at all.
+
+What output types really correspond to in GraphQL queries is selection sets. For
+example, if we have the GraphQL types
+
+    type User {
+      posts(filters: PostFilters): [Post]
+    }
+
+    input PostFilters {
+      newer_than: Date
+    }
+
+    type Post {
+      id: Int
+      title: String
+      body: String
+    }
+
+then we might receive a query that looks like this:
+
+    query list_user_posts($user_id: Int, $date: Date) {
+      user_by_id(id: $user_id) {
+        posts(filters: {newer_than: $date}) {
+          id
+          title
+        }
+      }
+    }
+
+We have Parsers to represent each of these types: a `Parser 'Input` for
+PostFilters, and two `Parser 'Output`s for User and Post. When we parse the
+query, we pass the `{newer_than: $date}` input value to the PostFilters parser,
+as expected. But what do we pass to the User parser? The answer is this
+selection set:
+
+    {
+      posts(filters: {newer_than: $date}) {
+        id
+        title
+      }
+    }
+
+Likewise, the Post parser eventually receives the inner selection set:
+
+    {
+      id
+      title
+    }
+
+These Parsers handle interpreting the fields of the selection sets. This is why
+`ParserInput 'Output` is SelectionSet---the GraphQL *type* associated with the
+Parser is an output type, but the part of the *query* that corresponds to that
+output type isn’t an output value but a selection set. -}


### PR DESCRIPTION
Ever seen this?
```
Build profile: -w ghc-8.10.2 -O1
In order, the following will be built (use -v for more details):
 - ci-info-0.1.0.0 (lib) (configuration changed)
 - graphql-parser-0.2.0.0 (lib) (configuration changed)
 - resource-pool-0.2.3.2 (lib) (configuration changed)
 - pg-client-0.1.0 (lib:pg-client) (configuration changed)
 - graphql-engine-1.0.0 (lib) (configuration changed)
 - graphql-engine-1.0.0 (exe:graphql-engine) (configuration changed)
Configuring library for ci-info-0.1.0.0..
Configuring library for resource-pool-0.2.3.2..
Configuring library for graphql-parser-0.2.0.0..
Preprocessing library for graphql-parser-0.2.0.0..
Building library for graphql-parser-0.2.0.0..
Preprocessing library for ci-info-0.1.0.0..
Building library for ci-info-0.1.0.0..
Preprocessing library for resource-pool-0.2.3.2..
Building library for resource-pool-0.2.3.2..
Configuring pg-client-0.1.0...
Preprocessing library for pg-client-0.1.0..
Building library for pg-client-0.1.0..
Configuring library for graphql-engine-1.0.0..
Preprocessing library for graphql-engine-1.0.0..
Building library for graphql-engine-1.0.0..
[ 82 of 200] Compiling Hasura.GraphQL.Parser.Class ( src-lib/Hasura/GraphQL/Parser/Class.hs, /home/vamshi/hasura/graphql-engine/server/dist-newstyle/build/x86_64-linux/ghc-8.10.2/graphql-engine-1.0.0/noopt/build/Hasura/GraphQL/Parser/Class.o, /home/vamshi/hasura/graphql-engine/server/dist-newstyle/build/x86_64-linux/ghc-8.10.2/graphql-engine-1.0.0/noopt/build/Hasura/GraphQL/Parser/Class.dyn_o ) [missing old dependency]
Configuring executable 'graphql-engine' for graphql-engine-1.0.0..
```
Yeah. So have all of us.

Due to some circular dependencies in `Hasura.GraphQL.Parser`, we kept seeing `Hasura.GraphQL.Parser.Class` getting pulled into cabal's build plan.

This fixes that, by avoiding the need for two `hs-boot` files: `server/src-lib/Hasura/GraphQL/Parser/Internal/Parser.hs-boot`, and `server/src-lib/Hasura/GraphQL/Parser/Class.hs-boot`.

Crucially, the `MonadParse` type class, the `QueryReusability` and `Parser` types, and the `ParserInput` type family have been moved to separate files to break some import loops. The remaining dependency of `Hasura.GraphQL.Parser.Collect` on `Hasura.GraphQL.Parser.Internal.Parser` has been avoided by passing the required definitions in `Hasura.GraphQL.Parser.Internal.Parser` as _arguments_ to `Hasura.GraphQL.Parser.Collect`, thus avoiding an import in the other direction.
