### PR TITLE
ci: bump cli builder version (close #5462)

### DIFF
--- a/.circleci/cli-builder.dockerfile
+++ b/.circleci/cli-builder.dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.13
+FROM golang:1.14
 
-ARG upx_version="3.94"
+ARG upx_version="3.96"
 
 # install go dependencies
 RUN	go get github.com/mitchellh/gox \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,7 +374,7 @@ jobs:
   # test and build cli
   test_and_build_cli:
     docker:
-    - image: hasura/graphql-engine-cli-builder:20191205
+    - image: hasura/graphql-engine-cli-builder:20201105
     - image: circleci/postgres:10-alpine
       environment:
         POSTGRES_USER: gql_test


### PR DESCRIPTION
### Description

use `upx 3.96` which includes a bug fix, that should resolve issues running CLI binary in MacOS 11 (detailed in https://github.com/hasura/graphql-engine/issues/5462)

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Build System
