### PR TITLE
server: add hlint hints to replace case analysis with combinators

### DIFF
--- a/server/.hlint.yaml
+++ b/server/.hlint.yaml
@@ -101,6 +101,14 @@
     - warn: {lhs: "onNothing x (pure y)", rhs: "pure (fromMaybe y x)"}
     - warn: {lhs: "onLeft x (return . f)", rhs: "return (either f id x)"}
     - warn: {lhs: "onLeft x (pure . f)", rhs: "pure (either f id x)"}
+    - warn: {lhs: "case x of {Right a -> pure a; Left c -> d}", rhs: "onLeft x (\\ c -> d)"}
+    - warn: {lhs: "case x of {Left c -> d; Right a -> pure a}", rhs: "onLeft x (\\ c -> d)"}
+    - warn: {lhs: "case x of {Right a -> return a; Left c -> d}", rhs: "onLeft x (\\ c -> d)"}
+    - warn: {lhs: "case x of {Left c -> d; Right a -> return a}", rhs: "onLeft x (\\ c -> d)"}
+    - warn: {lhs: "case x of {Nothing -> a; Just b -> pure b}", rhs: "onNothing x a"}
+    - warn: {lhs: "case x of {Just b -> pure b; Nothing -> a}", rhs: "onNothing x a"}
+    - warn: {lhs: "case x of {Nothing -> a; Just b -> return b}", rhs: "onNothing x a"}
+    - warn: {lhs: "case x of {Just b -> return b; Nothing -> a}", rhs: "onNothing x a"}
 
 - group:
     name: data-text-extended

--- a/server/src-lib/Hasura/Prelude.hs
+++ b/server/src-lib/Hasura/Prelude.hs
@@ -17,7 +17,6 @@ module Hasura.Prelude
   , liftEitherM
   -- * Efficient coercions
   , coerce
-  , coerceSet
   , findWithIndex
   , mapFromL
   , oMapFromL
@@ -81,13 +80,11 @@ import qualified Data.ByteString.Lazy              as BL
 import           Data.Coerce
 import qualified Data.HashMap.Strict               as Map
 import qualified Data.HashMap.Strict.InsOrd        as OMap
-import qualified Data.Set                          as Set
 import qualified Data.Text                         as T
 import qualified Data.Text.Encoding                as TE
 import qualified Data.Text.Encoding.Error          as TE
 import qualified GHC.Clock                         as Clock
 import qualified Test.QuickCheck                   as QC
-import           Unsafe.Coerce
 
 alphabet :: String
 alphabet = ['a'..'z'] ++ ['A'..'Z']
@@ -141,16 +138,6 @@ spanMaybeM f = go . toList
     go l@(x:xs) = f x >>= \case
       Just y  -> first (y:) <$> go xs
       Nothing -> pure ([], l)
-
--- | Efficiently coerce a set from one type to another.
---
--- This has the same safety properties as 'Set.mapMonotonic', and is equivalent
--- to @Set.mapMonotonic coerce@ but is more efficient. This is safe to use when
--- both @a@ and @b@ have automatically derived @Ord@ instances.
---
--- https://stackoverflow.com/q/57963881/176841
-coerceSet :: Coercible a b=> Set.Set a -> Set.Set b
-coerceSet = unsafeCoerce
 
 findWithIndex :: (a -> Bool) -> [a] -> Maybe (a, Int)
 findWithIndex p l = do


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
This PR implements 8 new hlint hints that enforce usage of our `onNothing` and `onLeft` combinators. Thus it further improves on #6126. Example hints provided by these new hlint hints:

```
src-lib/Hasura/RQL/Types/Common.hs:(292,20)-(294,57): Warning: Use onNothing
Found:
  case x of
    Just v -> return v
    Nothing -> fail "integer passed is out of bounds"
Perhaps:
  onNothing x (fail "integer passed is out of bounds")
```
```
src-lib/Hasura/RQL/DDL/RemoteRelationship/Validate.hs:(434,7)-(436,25): Warning: Use onLeft
Found:
  case eitherScalar of
    Left _ -> throwError $ InvalidGraphQLName $ toSQLTxt scalarType
    Right s -> pure s
Perhaps:
  onLeft
    eitherScalar
    (\ _c -> throwError $ InvalidGraphQLName $ toSQLTxt scalarType)
```

These new hints are triggered 23 times on the current master codebase.

This PR also removes some dead code, namely `coerceSet`, from `Hasura.Prelude`.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [x] Tests

