### PR TITLE
server: move MutationCTE code to Backends.Postgres.Translate

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Execute/Insert.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/Insert.hs
@@ -5,24 +5,25 @@ module Hasura.GraphQL.Execute.Insert
 
 import           Hasura.Prelude
 
-import qualified Data.Aeson                                  as J
-import qualified Data.Environment                            as Env
-import qualified Data.HashMap.Strict                         as Map
-import qualified Data.Sequence                               as Seq
-import qualified Data.Text                                   as T
-import qualified Database.PG.Query                           as Q
+import qualified Data.Aeson                                   as J
+import qualified Data.Environment                             as Env
+import qualified Data.HashMap.Strict                          as Map
+import qualified Data.Sequence                                as Seq
+import qualified Data.Text                                    as T
+import qualified Database.PG.Query                            as Q
 
 import           Data.Text.Extended
 
-import qualified Hasura.Backends.Postgres.Execute.Mutation   as RQL
-import qualified Hasura.Backends.Postgres.Execute.RemoteJoin as RQL
-import qualified Hasura.Backends.Postgres.SQL.DML            as S
-import qualified Hasura.Backends.Postgres.Translate.BoolExp  as RQL
-import qualified Hasura.Backends.Postgres.Translate.Insert   as RQL
-import qualified Hasura.Backends.Postgres.Translate.Mutation as RQL
-import qualified Hasura.RQL.IR.Insert                        as RQL
-import qualified Hasura.RQL.IR.Returning                     as RQL
-import qualified Hasura.Tracing                              as Tracing
+import qualified Hasura.Backends.Postgres.Execute.Mutation    as PGE
+import qualified Hasura.Backends.Postgres.Execute.RemoteJoin  as PGE
+import qualified Hasura.Backends.Postgres.SQL.DML             as S
+import qualified Hasura.Backends.Postgres.Translate.BoolExp   as PGT
+import qualified Hasura.Backends.Postgres.Translate.Insert    as PGT
+import qualified Hasura.Backends.Postgres.Translate.Mutation  as PGT
+import qualified Hasura.Backends.Postgres.Translate.Returning as PGT
+import qualified Hasura.RQL.IR.Insert                         as IR
+import qualified Hasura.RQL.IR.Returning                      as IR
+import qualified Hasura.Tracing                               as Tracing
 
 import           Hasura.Backends.Postgres.Connection
 import           Hasura.Backends.Postgres.SQL.Types
@@ -30,7 +31,7 @@ import           Hasura.Backends.Postgres.SQL.Value
 import           Hasura.EncJSON
 import           Hasura.GraphQL.Schema.Insert
 import           Hasura.RQL.Types
-import           Hasura.Server.Version                       (HasVersion)
+import           Hasura.Server.Version                        (HasVersion)
 
 
 traverseAnnInsert
@@ -42,7 +43,7 @@ traverseAnnInsert f (AnnInsert fieldName isSingle (annIns, mutationOutput)) =
   AnnInsert fieldName isSingle
   <$> ( (,)
         <$> traverseMulti annIns
-        <*> RQL.traverseMutationOutput f mutationOutput
+        <*> IR.traverseMutationOutput f mutationOutput
       )
   where
     traverseMulti (AnnIns objs tableName conflictClause checkCond columns defaultValues) = AnnIns
@@ -76,13 +77,13 @@ convertToSQLTransaction
   :: (HasVersion, MonadTx m, MonadIO m, Tracing.MonadTrace m)
   => Env.Environment
   -> AnnInsert 'Postgres S.SQLExp
-  -> RQL.MutationRemoteJoinCtx
+  -> PGE.MutationRemoteJoinCtx
   -> Seq.Seq Q.PrepArg
   -> Bool
   -> m EncJSON
 convertToSQLTransaction env (AnnInsert fieldName isSingle (annIns, mutationOutput)) remoteJoinCtx planVars stringifyNum =
   if null $ _aiInsObj annIns
-  then pure $ RQL.buildEmptyMutResp mutationOutput
+  then pure $ IR.buildEmptyMutResp mutationOutput
   else withPaths ["selectionSet", fieldName, "args", suffix] $
     insertMultipleObjects env annIns [] remoteJoinCtx mutationOutput planVars stringifyNum
   where
@@ -94,8 +95,8 @@ insertMultipleObjects
   => Env.Environment
   -> MultiObjIns 'Postgres S.SQLExp
   -> [(PGCol, S.SQLExp)]
-  -> RQL.MutationRemoteJoinCtx
-  -> RQL.MutationOutput 'Postgres
+  -> PGE.MutationRemoteJoinCtx
+  -> IR.MutationOutput 'Postgres
   -> Seq.Seq Q.PrepArg
   -> Bool
   -> m EncJSON
@@ -112,7 +113,7 @@ insertMultipleObjects env multiObjIns additionalColumns remoteJoinCtx mutationOu
         validateInsert (map fst column) [] (map fst additionalColumns)
       let columnValues = map (mkSQLRow defVals) $ union additionalColumns . _aioColumns <$> insObjs
           columnNames  = Map.keys defVals
-          insertQuery  = RQL.InsertQueryP1
+          insertQuery  = IR.InsertQueryP1
             table
             columnNames
             columnValues
@@ -123,7 +124,7 @@ insertMultipleObjects env multiObjIns additionalColumns remoteJoinCtx mutationOu
           rowCount = T.pack . show . length $ _aiInsObj multiObjIns
       Tracing.trace ("Insert (" <> rowCount <> ") " <> qualifiedObjectToText table) do
         Tracing.attachMetadata [("count", rowCount)]
-        RQL.execInsertQuery env stringifyNum (Just remoteJoinCtx) (insertQuery, planVars)
+        PGE.execInsertQuery env stringifyNum (Just remoteJoinCtx) (insertQuery, planVars)
 
     withRelsInsert = do
       insertRequests <- indexedForM insObjs \obj -> do
@@ -131,9 +132,9 @@ insertMultipleObjects env multiObjIns additionalColumns remoteJoinCtx mutationOu
         insertObject env singleObj additionalColumns remoteJoinCtx planVars stringifyNum
       let affectedRows = sum $ map fst insertRequests
           columnValues = mapMaybe snd insertRequests
-      selectExpr <- RQL.mkSelectExpFromColumnValues table columnInfos columnValues
-      let (mutOutputRJ, remoteJoins) = RQL.getRemoteJoinsMutationOutput mutationOutput
-      RQL.executeMutationOutputQuery env table columnInfos (Just affectedRows) (RQL.MCSelectValues selectExpr)
+      selectExpr <- PGT.mkSelectExpFromColumnValues table columnInfos columnValues
+      let (mutOutputRJ, remoteJoins) = PGE.getRemoteJoinsMutationOutput mutationOutput
+      PGE.executeMutationOutputQuery env table columnInfos (Just affectedRows) (PGT.MCSelectValues selectExpr)
         mutOutputRJ stringifyNum [] $ (, remoteJoinCtx) <$> remoteJoins
 
 insertObject
@@ -141,7 +142,7 @@ insertObject
   => Env.Environment
   -> SingleObjIns 'Postgres S.SQLExp
   -> [(PGCol, S.SQLExp)]
-  -> RQL.MutationRemoteJoinCtx
+  -> PGE.MutationRemoteJoinCtx
   -> Seq.Seq Q.PrepArg
   -> Bool
   -> m (Int, Maybe (ColumnValues TxtEncodedPGVal))
@@ -159,7 +160,7 @@ insertObject env singleObjIns additionalColumns remoteJoinCtx planVars stringify
   cte <- mkInsertQ table onConflict finalInsCols defaultValues checkCond
 
   MutateResp affRows colVals <- liftTx $
-    RQL.mutateAndFetchCols table allColumns (RQL.MCCheckConstraint cte, planVars) stringifyNum
+    PGE.mutateAndFetchCols table allColumns (PGT.MCCheckConstraint cte, planVars) stringifyNum
   colValM <- asSingleObject colVals
 
   arrRelAffRows <- bool (withArrRels colValM) (return 0) $ null arrayRels
@@ -192,7 +193,7 @@ insertObjRel
   :: (HasVersion, MonadTx m, MonadIO m, Tracing.MonadTrace m)
   => Env.Environment
   -> Seq.Seq Q.PrepArg
-  -> RQL.MutationRemoteJoinCtx
+  -> PGE.MutationRemoteJoinCtx
   -> Bool
   -> ObjRelIns 'Postgres S.SQLExp
   -> m (Int, [(PGCol, S.SQLExp)])
@@ -221,7 +222,7 @@ insertArrRel
   :: (HasVersion, MonadTx m, MonadIO m, Tracing.MonadTrace m)
   => Env.Environment
   -> [(PGCol, S.SQLExp)]
-  -> RQL.MutationRemoteJoinCtx
+  -> PGE.MutationRemoteJoinCtx
   -> Seq.Seq Q.PrepArg
   -> Bool
   -> ArrRelIns 'Postgres S.SQLExp
@@ -239,7 +240,7 @@ insertArrRel env resCols remoteJoinCtx planVars stringifyNum arrRelIns =
   where
     RelIns multiObjIns relInfo = arrRelIns
     mapping   = riMapping relInfo
-    mutOutput = RQL.MOutMultirowFields [("affected_rows", RQL.MCount)]
+    mutOutput = IR.MOutMultirowFields [("affected_rows", IR.MCount)]
 
 -- | validate an insert object based on insert columns,
 -- | insert object relations and additional columns from parent
@@ -271,13 +272,13 @@ validateInsert insCols objRels addCols = do
 mkInsertQ
   :: MonadError QErr m
   => QualifiedTable
-  -> Maybe (RQL.ConflictClauseP1 'Postgres S.SQLExp)
+  -> Maybe (IR.ConflictClauseP1 'Postgres S.SQLExp)
   -> [(PGCol, S.SQLExp)]
   -> Map.HashMap PGCol S.SQLExp
   -> (AnnBoolExpSQL 'Postgres, Maybe (AnnBoolExpSQL 'Postgres))
   -> m S.CTE
 mkInsertQ table onConflictM insCols defVals (insCheck, updCheck) = do
-  let sqlConflict = RQL.toSQLConflict table <$> onConflictM
+  let sqlConflict = PGT.toSQLConflict table <$> onConflictM
       sqlExps = mkSQLRow defVals insCols
       valueExp = S.ValuesExp [S.TupleExp sqlExps]
       tableCols = Map.keys defVals
@@ -286,9 +287,9 @@ mkInsertQ table onConflictM insCols defVals (insCheck, updCheck) = do
           . Just
           $ S.RetExp
             [ S.selectStar
-            , RQL.insertOrUpdateCheckExpr table onConflictM
-              (RQL.toSQLBoolExp (S.QualTable table) insCheck)
-              (fmap (RQL.toSQLBoolExp (S.QualTable table)) updCheck)
+            , PGT.insertOrUpdateCheckExpr table onConflictM
+              (PGT.toSQLBoolExp (S.QualTable table) insCheck)
+              (fmap (PGT.toSQLBoolExp (S.QualTable table)) updCheck)
             ]
   pure $ S.CTEInsert sqlInsert
 

--- a/server/src-lib/Hasura/RQL/IR/Returning.hs
+++ b/server/src-lib/Hasura/RQL/IR/Returning.hs
@@ -2,15 +2,13 @@ module Hasura.RQL.IR.Returning where
 
 import           Hasura.Prelude
 
-import qualified Data.Aeson                       as J
-import qualified Data.HashMap.Strict.InsOrd       as OMap
+import qualified Data.Aeson                 as J
+import qualified Data.HashMap.Strict.InsOrd as OMap
 
 import           Hasura.EncJSON
 import           Hasura.RQL.IR.Select
 import           Hasura.RQL.Types.Common
 import           Hasura.SQL.Backend
-
-import qualified Hasura.Backends.Postgres.SQL.DML as S
 
 
 data MutFldG (b :: Backend) v
@@ -80,24 +78,3 @@ hasNestedFld = \case
       AFObjectRelation _ -> True
       AFArrayRelation _  -> True
       _                  -> False
-
--- | The postgres common table expression (CTE) for mutation queries.
--- This CTE expression is used to generate mutation field output expression,
--- see Note [Mutation output expression].
-data MutationCTE
-  = MCCheckConstraint !S.CTE -- ^ A Mutation with check constraint validation (Insert or Update)
-  | MCSelectValues !S.Select -- ^ A Select statement which emits mutated table rows
-  | MCDelete !S.SQLDelete -- ^ A Delete statement
-  deriving (Show, Eq)
-
-getMutationCTE :: MutationCTE -> S.CTE
-getMutationCTE = \case
-  MCCheckConstraint cte -> cte
-  MCSelectValues select -> S.CTESelect select
-  MCDelete delete       -> S.CTEDelete delete
-
-checkPermissionRequired :: MutationCTE -> Bool
-checkPermissionRequired = \case
-  MCCheckConstraint _ -> True
-  MCSelectValues _    -> False
-  MCDelete _          -> False


### PR DESCRIPTION
### Description
This PR fixes an oversight of #6123: namely, it introduced postgres-specific code in `RQL.IR`, which is where our (soon to be) backend-agnostic query representation lives. This PR moves the code back to `Backends.Postgres`, and also fixes the imports of the impacted file.

I am not sure about adding this in `Postgres.Translate.Returning`, though? Maybe a new `Postgres.Translate.Types`?