### PR TITLE
server: remove postgres-specific code in Insert IR

### DIFF
--- a/server/src-lib/Hasura/GraphQL/Schema/Mutation.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema/Mutation.hs
@@ -36,7 +36,7 @@ import           Hasura.GraphQL.Schema.Common
 import           Hasura.GraphQL.Schema.Insert
 import           Hasura.GraphQL.Schema.Select
 import           Hasura.GraphQL.Schema.Table
-import           Hasura.RQL.Types
+import           Hasura.RQL.Types                    hiding (ConstraintName)
 
 
 

--- a/server/src-lib/Hasura/RQL/DDL/Schema/Diff.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Diff.hs
@@ -33,7 +33,8 @@ import           Data.Aeson.TH
 import           Data.List.Extended                 (duplicates)
 
 import           Hasura.Backends.Postgres.SQL.Types
-import           Hasura.RQL.Types                   hiding (fmFunction, tmComputedFields, tmTable)
+import           Hasura.RQL.Types                   hiding (ConstraintName, fmFunction,
+                                                     tmComputedFields, tmTable)
 import           Hasura.RQL.Types.Catalog
 
 data FunctionMeta

--- a/server/src-lib/Hasura/RQL/DML/Types.hs
+++ b/server/src-lib/Hasura/RQL/DML/Types.hs
@@ -44,7 +44,7 @@ import           Hasura.Backends.Postgres.SQL.Types
 import           Hasura.RQL.IR.BoolExp
 import           Hasura.RQL.IR.OrderBy
 import           Hasura.RQL.Instances               ()
-import           Hasura.RQL.Types.Common
+import           Hasura.RQL.Types.Common            hiding (ConstraintName)
 import           Hasura.SQL.Backend
 
 

--- a/server/src-lib/Hasura/RQL/IR/BoolExp.hs
+++ b/server/src-lib/Hasura/RQL/IR/BoolExp.hs
@@ -55,6 +55,7 @@ import           Instances.TH.Lift                  ()
 import           Language.Haskell.TH.Syntax         (Lift)
 
 import qualified Hasura.Backends.Postgres.SQL.Types as PG
+
 import           Hasura.Incremental                 (Cacheable)
 import           Hasura.RQL.Types.Column
 import           Hasura.RQL.Types.Common

--- a/server/src-lib/Hasura/RQL/IR/Insert.hs
+++ b/server/src-lib/Hasura/RQL/IR/Insert.hs
@@ -3,8 +3,6 @@ module Hasura.RQL.IR.Insert where
 
 import           Hasura.Prelude
 
-import qualified Hasura.Backends.Postgres.SQL.Types as PG
-
 import           Hasura.RQL.IR.BoolExp
 import           Hasura.RQL.IR.Returning
 import           Hasura.RQL.Types.Column
@@ -12,14 +10,15 @@ import           Hasura.RQL.Types.Common
 import           Hasura.SQL.Backend
 
 
-data ConflictTarget
-  = CTColumn ![PG.PGCol]
-  | CTConstraint !PG.ConstraintName
-  deriving (Show, Eq)
+data ConflictTarget (b :: BackendType)
+  = CTColumn ![Column b]
+  | CTConstraint !(ConstraintName b)
+deriving instance Backend b => Show (ConflictTarget b)
+deriving instance Backend b => Eq   (ConflictTarget b)
 
 data ConflictClauseP1 (b :: BackendType) v
-  = CP1DoNothing !(Maybe ConflictTarget)
-  | CP1Update !ConflictTarget ![Column b] !(PreSetColsG b v) (AnnBoolExp b v)
+  = CP1DoNothing !(Maybe (ConflictTarget b))
+  | CP1Update !(ConflictTarget b) ![Column b] !(PreSetColsG b v) (AnnBoolExp b v)
   deriving (Functor, Foldable, Traversable)
 
 

--- a/server/src-lib/Hasura/RQL/Types/Common.hs
+++ b/server/src-lib/Hasura/RQL/Types/Common.hs
@@ -7,7 +7,6 @@ module Hasura.RQL.Types.Common
        , RelInfo(..)
 
        , ScalarType
-       , Column
        , SQLExp
        , Backend (..)
 
@@ -97,9 +96,6 @@ type family ScalarType (b :: BackendType) where
 type family ColumnType (b :: BackendType) where
   ColumnType 'Postgres = PG.PGType
 
-type family Column (b :: BackendType) where
-  Column 'Postgres = PG.PGCol
-
 type family SQLExp (b :: BackendType) where
   SQLExp 'Postgres = PG.SQLExp
 
@@ -116,7 +112,11 @@ type family SQLExp (b :: BackendType) where
 -- which simplifies the instance declarations of all IR types.
 class
   ( Show (TableName b)
+  , Show (ConstraintName b)
+  , Show (Column b)
   , Eq (TableName b)
+  , Eq (ConstraintName b)
+  , Eq (Column b)
   , Lift (TableName b)
   , NFData (TableName b)
   , Cacheable (TableName b)
@@ -124,10 +124,14 @@ class
   , Data (TableName b)
   , Typeable b
   ) => Backend (b :: BackendType) where
-  type TableName b :: Type
+  type TableName      b :: Type
+  type ConstraintName b :: Type
+  type Column         b :: Type
 
 instance Backend 'Postgres where
-  type TableName 'Postgres = PG.QualifiedTable
+  type TableName      'Postgres = PG.QualifiedTable
+  type ConstraintName 'Postgres = PG.ConstraintName
+  type Column         'Postgres = PG.PGCol
 
 
 adminText :: NonEmptyText

--- a/server/src-lib/Hasura/RQL/Types/Permission.hs
+++ b/server/src-lib/Hasura/RQL/Types/Permission.hs
@@ -23,7 +23,6 @@ import           Hasura.SQL.Backend
 import           Hasura.Session
 
 
-
 data PermType
   = PTInsert
   | PTSelect

--- a/server/src-lib/Hasura/RQL/Types/SchemaCacheTypes.hs
+++ b/server/src-lib/Hasura/RQL/Types/SchemaCacheTypes.hs
@@ -11,7 +11,7 @@ import           Data.Aeson.Types
 import           Data.Text.NonEmpty
 
 import           Hasura.Backends.Postgres.SQL.Types
-import           Hasura.RQL.Types.Common
+import           Hasura.RQL.Types.Common             hiding (ConstraintName)
 import           Hasura.RQL.Types.ComputedField
 import           Hasura.RQL.Types.EventTrigger
 import           Hasura.RQL.Types.Permission


### PR DESCRIPTION
_(Note: this PR is on top of #6127.)_

### Description
This PR is one further step in our work to make the IR backend-agnostic; this time, tacking the representation of inserts. This PR does not change any behaviour, and therefore does not require a changelog.