### PR TITLE
ci: add a github action that detects forbidden imports

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -38,3 +38,32 @@ jobs:
           then
             echo "$CHANGED_HS_FILES" | xargs ${{env.working-directory}}/hlint --json --hint=${{env.working-directory}}/.hlint.yaml | jq -r "$JQ_SCRIPT"
           fi
+
+  import-checks:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Check imports
+        shell: bash
+        run: |
+          FOUND_ERRORS=0
+          function check_imports() {
+              rootfolder="$1"
+              forbidden="$2"
+              message="$3"
+              for match in $(find "server/src-lib/$rootfolder" -type f -iname "*.hs" | xargs grep -Hn -E "^import.*$forbidden" | cut -d ':' -f 1,2); do
+                  filename=$(echo $match | cut -d ':' -f 1)
+                  line=$(echo $match | cut -d ':' -f 2)
+                  echo "::error file=$filename,line=$line::Forbiden import: $message"
+                  FOUND_ERRORS=1
+              done
+          }
+          check_imports "Hasura/RQL/IR" "Hasura.RQL.DML"  "the IR is backend-agnostic and cannot use RQL's DML."
+          check_imports "Hasura/RQL/IR" "Hasura.Backends" "the IR is backend-agnostic."
+          check_imports "Hasura/SQL"    "Hasura.RQL"      "SQL is a dependency of RQL."
+          check_imports "Hasura/SQL"    "Hasura.GraphQL"  "SQL is a dependency of GraphQL."
+          exit $FOUND_ERRORS


### PR DESCRIPTION
### Description
As we clean and contribute to the codebase, we will want to maintain some invariants that cannot be expressed at the language level. One such invariant is the fact that different subdirectories are meant to be dependencies of one another, with clear separation of purposes; and as such, some imports are "unlawful": they introduce an unwanted edge in the import graph, and are a code smell.

This PR introduces a new linter step on all PRs, that flags some uncontroversial edges as errors. **THIS SHOULD NOT BE SUBMITTED YET** as, at time of writing, this would break all open PRs: some ongoing work on the IR needs to be merged first to remove some of the unlawful edges.

### Limitations
The grepping mechanism is quite straightforward, and as such cannot be used yet to express something a bit more refined than "A isn't allowed in B". For instance, it's not possible to express "no file in Data is allowed to import a file in Hasura _except for Hasura.Prelude_" yet. Arguably, the Prelude could be considered an exception and grepped out of all matches?