### PR TITLE
server: split and clean IR.Select

### DIFF
--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -312,6 +312,7 @@ library
                      , Hasura.Backends.Postgres.Translate.Mutation
                      , Hasura.Backends.Postgres.Translate.Returning
                      , Hasura.Backends.Postgres.Translate.Select
+                     , Hasura.Backends.Postgres.Translate.Types
                      , Hasura.Backends.Postgres.Translate.Update
                      , Hasura.Backends.Postgres.SQL.DML
                      , Hasura.Backends.Postgres.SQL.Error

--- a/server/src-lib/Hasura/Backends/Postgres/Execute/RemoteJoin.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Execute/RemoteJoin.hs
@@ -45,7 +45,7 @@ import           Hasura.RQL.DML.Internal
 import           Hasura.RQL.IR.RemoteJoin
 import           Hasura.RQL.IR.Returning
 import           Hasura.RQL.IR.Select
-import           Hasura.RQL.Types
+import           Hasura.RQL.Types                       hiding (Alias)
 import           Hasura.Server.Version                  (HasVersion)
 import           Hasura.Session
 

--- a/server/src-lib/Hasura/Backends/Postgres/Execute/RemoteJoin.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Execute/RemoteJoin.hs
@@ -127,7 +127,7 @@ parseGraphQLName txt = onNothing (G.mkName txt) (throw400 RemoteSchemaError $ er
 
 -- | Generate the alias for remote field.
 pathToAlias :: (MonadError QErr m) => FieldPath -> Counter -> m Alias
-pathToAlias path counter = do
+pathToAlias path counter =
   parseGraphQLName $ T.intercalate "_" (map getFieldNameTxt $ unFieldPath path)
                  <> "__" <> (T.pack . show . unCounter) counter
 
@@ -333,7 +333,7 @@ traverseQueryResponseJSON rjm =
           counter <- getCounter
           let RemoteJoin fieldName inputArgs selSet hasuraFields fieldCall rsi _ = remoteJoin
           hasuraFieldVariables <- mapM (parseGraphQLName . getFieldNameTxt) $ toList hasuraFields
-          siblingFieldArgsVars <- mapM (\(k,val) -> do
+          siblingFieldArgsVars <- mapM (\(k,val) ->
                                           (,) <$> parseGraphQLName k <*> ordJSONValueToGValue val)
                                   $ siblingFields
           let siblingFieldArgs = Map.fromList $ siblingFieldArgsVars
@@ -606,9 +606,8 @@ substituteVariables values = traverse go
   where
     go = \case
       G.VVariable variableName ->
-        case Map.lookup variableName values of
-          Nothing    -> Failure ["Value for variable " <> variableName <<> " not provided"]
-          Just value -> pure value
+        Map.lookup variableName values
+        `onNothing` Failure ["Value for variable " <> variableName <<> " not provided"]
       G.VList listValue ->
         fmap G.VList (traverse go listValue)
       G.VObject objectValue ->

--- a/server/src-lib/Hasura/Backends/Postgres/Translate/BoolExp.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Translate/BoolExp.hs
@@ -258,14 +258,14 @@ parseOperationsExpression rhsParser fim columnInfo =
 
 -- This convoluted expression instead of col = val
 -- to handle the case of col : null
-equalsBoolExpBuilder :: SQLExp 'Postgres -> SQLExp 'Postgres -> S.BoolExp
+equalsBoolExpBuilder :: SQLExpression 'Postgres -> SQLExpression 'Postgres -> S.BoolExp
 equalsBoolExpBuilder qualColExp rhsExp =
   S.BEBin S.OrOp (S.BECompare S.SEQ qualColExp rhsExp)
     (S.BEBin S.AndOp
       (S.BENull qualColExp)
       (S.BENull rhsExp))
 
-notEqualsBoolExpBuilder :: SQLExp 'Postgres -> SQLExp 'Postgres -> S.BoolExp
+notEqualsBoolExpBuilder :: SQLExpression 'Postgres -> SQLExpression 'Postgres -> S.BoolExp
 notEqualsBoolExpBuilder qualColExp rhsExp =
   S.BEBin S.OrOp (S.BECompare S.SNE qualColExp rhsExp)
     (S.BEBin S.AndOp
@@ -377,13 +377,13 @@ foldBoolExp f = \case
   BoolFld ce           -> f ce
 
 mkFieldCompExp
-  :: S.Qual -> FieldName -> OpExpG 'Postgres (SQLExp 'Postgres) -> S.BoolExp
+  :: S.Qual -> FieldName -> OpExpG 'Postgres (SQLExpression 'Postgres) -> S.BoolExp
 mkFieldCompExp qual lhsField = mkCompExp (mkQField lhsField)
   where
     mkQCol = S.SEQIdentifier . S.QIdentifier qual . toIdentifier
     mkQField = S.SEQIdentifier . S.QIdentifier qual . Identifier . getFieldNameTxt
 
-    mkCompExp :: SQLExp 'Postgres -> OpExpG 'Postgres (SQLExp 'Postgres) -> S.BoolExp
+    mkCompExp :: SQLExpression 'Postgres -> OpExpG 'Postgres (SQLExpression 'Postgres) -> S.BoolExp
     mkCompExp lhs = \case
       ACast casts      -> mkCastsExp casts
       AEQ False val    -> equalsBoolExpBuilder lhs val

--- a/server/src-lib/Hasura/Backends/Postgres/Translate/Returning.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Translate/Returning.hs
@@ -22,7 +22,7 @@ import           Hasura.Backends.Postgres.Translate.Select
 import           Hasura.RQL.DML.Internal
 import           Hasura.RQL.IR.Returning
 import           Hasura.RQL.IR.Select
-import           Hasura.RQL.Types
+import           Hasura.RQL.Types                          hiding (Identifier)
 
 
 -- | The postgres common table expression (CTE) for mutation queries.

--- a/server/src-lib/Hasura/Backends/Postgres/Translate/Select.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Translate/Select.hs
@@ -25,12 +25,13 @@ import qualified Hasura.Backends.Postgres.SQL.DML           as S
 import           Hasura.Backends.Postgres.SQL.Rewrite
 import           Hasura.Backends.Postgres.SQL.Types
 import           Hasura.Backends.Postgres.Translate.BoolExp
+import           Hasura.Backends.Postgres.Translate.Types
 import           Hasura.EncJSON
 import           Hasura.GraphQL.Schema.Common
 import           Hasura.RQL.DML.Internal
 import           Hasura.RQL.IR.OrderBy
 import           Hasura.RQL.IR.Select
-import           Hasura.RQL.Types
+import           Hasura.RQL.Types                           hiding (Identifier)
 import           Hasura.SQL.Types
 
 
@@ -229,7 +230,7 @@ mkArrayRelationAlias parentFieldName similarFieldsMap fieldName =
   HM.lookupDefault [fieldName] fieldName similarFieldsMap
 
 fromTableRowArgs
-  :: Identifier -> FunctionArgsExpTableRow S.SQLExp -> S.FunctionArgs
+  :: Identifier -> FunctionArgsExpTableRow 'Postgres S.SQLExp -> S.FunctionArgs
 fromTableRowArgs pfx = toFunctionArgs . fmap toSQLExp
   where
     toFunctionArgs (FunctionArgsExp positional named) =

--- a/server/src-lib/Hasura/Backends/Postgres/Translate/Types.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Translate/Types.hs
@@ -1,0 +1,135 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+module Hasura.Backends.Postgres.Translate.Types where
+
+import           Hasura.Prelude
+
+import qualified Data.HashMap.Strict                as HM
+
+import qualified Hasura.Backends.Postgres.SQL.DML   as PG
+import qualified Hasura.Backends.Postgres.SQL.Types as PG
+
+import           Hasura.RQL.IR.Select
+import           Hasura.RQL.Types.Common
+import           Hasura.SQL.Backend
+
+
+data SourcePrefixes
+  = SourcePrefixes
+  { _pfThis :: !PG.Identifier -- ^ Current source prefix
+  , _pfBase :: !PG.Identifier
+  -- ^ Base table source row identifier to generate
+  -- the table's column identifiers for computed field
+  -- function input parameters
+  } deriving (Show, Eq, Generic)
+instance Hashable SourcePrefixes
+
+data SelectSource (b :: BackendType)
+  = SelectSource
+  { _ssPrefix   :: !PG.Identifier
+  , _ssFrom     :: !PG.FromItem
+  , _ssDistinct :: !(Maybe PG.DistinctExpr)
+  , _ssWhere    :: !PG.BoolExp
+  , _ssOrderBy  :: !(Maybe PG.OrderByExp)
+  , _ssLimit    :: !(Maybe Int)
+  , _ssOffset   :: !(Maybe (SQLExpression b))
+  } deriving (Generic)
+instance Hashable (SelectSource 'Postgres)
+deriving instance Show (SelectSource 'Postgres)
+deriving instance Eq   (SelectSource 'Postgres)
+
+data SelectNode (b :: BackendType)
+  = SelectNode
+  { _snExtractors :: !(HM.HashMap (Alias b) (SQLExpression b))
+  , _snJoinTree   :: !(JoinTree b)
+  }
+
+instance Semigroup (SelectNode 'Postgres) where
+  SelectNode lExtrs lJoinTree <> SelectNode rExtrs rJoinTree =
+    SelectNode (lExtrs <> rExtrs) (lJoinTree <> rJoinTree)
+
+data ObjectSelectSource
+  = ObjectSelectSource
+  { _ossPrefix :: !PG.Identifier
+  , _ossFrom   :: !PG.FromItem
+  , _ossWhere  :: !PG.BoolExp
+  } deriving (Show, Eq, Generic)
+instance Hashable ObjectSelectSource
+
+objectSelectSourceToSelectSource :: ObjectSelectSource -> (SelectSource backend)
+objectSelectSourceToSelectSource ObjectSelectSource{..} =
+  SelectSource _ossPrefix _ossFrom Nothing _ossWhere Nothing Nothing Nothing
+
+data ObjectRelationSource (b :: BackendType)
+  = ObjectRelationSource
+  { _orsRelationshipName :: !RelName
+  , _orsRelationMapping  :: !(HM.HashMap (Column b) (Column b))
+  , _orsSelectSource     :: !ObjectSelectSource
+  } deriving (Generic)
+instance Hashable (ObjectRelationSource 'Postgres)
+deriving instance Eq (Column b) => Eq (ObjectRelationSource b)
+
+data ArrayRelationSource (b :: BackendType)
+  = ArrayRelationSource
+  { _arsAlias           :: !(Alias b)
+  , _arsRelationMapping :: !(HM.HashMap (Column b) (Column b))
+  , _arsSelectSource    :: !(SelectSource b)
+  } deriving (Generic)
+instance Hashable (ArrayRelationSource 'Postgres)
+deriving instance Eq (ArrayRelationSource 'Postgres)
+
+data ArraySelectNode (b :: BackendType)
+  = ArraySelectNode
+  { _asnTopExtractors :: ![PG.Extractor]
+  , _asnSelectNode    :: !(SelectNode b)
+  }
+
+instance Semigroup (ArraySelectNode 'Postgres) where
+  ArraySelectNode lTopExtrs lSelNode <> ArraySelectNode rTopExtrs rSelNode =
+    ArraySelectNode (lTopExtrs <> rTopExtrs) (lSelNode <> rSelNode)
+
+data ComputedFieldTableSetSource (b :: BackendType)
+  = ComputedFieldTableSetSource
+  { _cftssFieldName    :: !FieldName
+  , _cftssSelectType   :: !JsonAggSelect
+  , _cftssSelectSource :: !(SelectSource b)
+  } deriving (Generic)
+instance Hashable (ComputedFieldTableSetSource 'Postgres)
+deriving instance Show (ComputedFieldTableSetSource 'Postgres)
+deriving instance Eq   (ComputedFieldTableSetSource 'Postgres)
+
+data ArrayConnectionSource (b :: BackendType)
+  = ArrayConnectionSource
+  { _acsAlias           :: !(Alias b)
+  , _acsRelationMapping :: !(HM.HashMap (Column b) (Column b))
+  , _acsSplitFilter     :: !(Maybe PG.BoolExp)
+  , _acsSlice           :: !(Maybe ConnectionSlice)
+  , _acsSource          :: !(SelectSource b)
+  } deriving (Generic)
+deriving instance Eq (ArrayConnectionSource 'Postgres)
+
+instance Hashable (ArrayConnectionSource 'Postgres)
+
+data JoinTree (b :: BackendType)
+  = JoinTree
+  { _jtObjectRelations        :: !(HM.HashMap (ObjectRelationSource b) (SelectNode b))
+  , _jtArrayRelations         :: !(HM.HashMap (ArrayRelationSource b) (ArraySelectNode b))
+  , _jtArrayConnections       :: !(HM.HashMap (ArrayConnectionSource b) (ArraySelectNode b))
+  , _jtComputedFieldTableSets :: !(HM.HashMap (ComputedFieldTableSetSource b) (SelectNode b))
+  }
+
+instance Semigroup (JoinTree 'Postgres) where
+  JoinTree lObjs lArrs lArrConns lCfts <> JoinTree rObjs rArrs rArrConns rCfts =
+    JoinTree (HM.unionWith (<>) lObjs rObjs)
+             (HM.unionWith (<>) lArrs rArrs)
+             (HM.unionWith (<>) lArrConns rArrConns)
+             (HM.unionWith (<>) lCfts rCfts)
+
+instance Monoid (JoinTree 'Postgres) where
+  mempty = JoinTree mempty mempty mempty mempty
+
+
+data PermissionLimitSubQuery
+  = PLSQRequired !Int -- ^ Permission limit
+  | PLSQNotRequired
+  deriving (Show, Eq)

--- a/server/src-lib/Hasura/GraphQL/Execute/Action.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/Action.hs
@@ -519,12 +519,12 @@ mkJsonAggSelect =
   bool RS.JASSingleObject RS.JASMultipleRows . isListType
 
 processOutputSelectionSet
-  :: RS.ArgumentExp v
+  :: RS.ArgumentExp 'Postgres v
   -> GraphQLType
-  -> [(Column backend, ScalarType backend)]
-  -> RS.AnnFieldsG backend v
+  -> [(Column 'Postgres, ScalarType 'Postgres)]
+  -> RS.AnnFieldsG 'Postgres v
   -> Bool
-  -> RS.AnnSimpleSelG backend v
+  -> RS.AnnSimpleSelG 'Postgres v
 processOutputSelectionSet tableRowInput actionOutputType definitionList annotatedFields =
   RS.AnnSelectG annotatedFields selectFrom RS.noTablePermissions RS.noSelectArgs
   where

--- a/server/src-lib/Hasura/GraphQL/Execute/Action.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/Action.hs
@@ -205,7 +205,7 @@ resolveActionMutationAsync
   -> [HTTP.Header]
   -> SessionVariables
   -> m (tx EncJSON)
-resolveActionMutationAsync annAction reqHeaders sessionVariables = do
+resolveActionMutationAsync annAction reqHeaders sessionVariables =
   pure $ liftTx do
     actionId <- runIdentity . Q.getRow <$> Q.withQE defaultTxErrorHandler [Q.sql|
       INSERT INTO

--- a/server/src-lib/Hasura/GraphQL/Schema/Select.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema/Select.hs
@@ -1031,12 +1031,8 @@ remoteRelationshipField remoteFieldInfo = runMaybeT do
   remoteSchemasFieldDefns <- asks $ qcRemoteFields . getter
   let remoteSchemaName = _rfiRemoteSchemaName remoteFieldInfo
   fieldDefns <-
-    case Map.lookup remoteSchemaName remoteSchemasFieldDefns of
-      Nothing ->
-        throw500 $ "unexpected: remote schema "
-        <> remoteSchemaName
-        <<> " not found"
-      Just fieldDefns -> pure fieldDefns
+    Map.lookup remoteSchemaName remoteSchemasFieldDefns
+    `onNothing` throw500 ("unexpected: remote schema " <> remoteSchemaName <<> " not found")
 
   fieldName <- textToName $ remoteRelationshipNameToText $ _rfiName remoteFieldInfo
   remoteFieldsArgumentsParser <-

--- a/server/src-lib/Hasura/RQL/DDL/EventTrigger.hs
+++ b/server/src-lib/Hasura/RQL/DDL/EventTrigger.hs
@@ -132,7 +132,7 @@ addEventTriggerToCatalog
   :: QualifiedTable
   -> EventTriggerConf
   -> Q.TxE QErr ()
-addEventTriggerToCatalog qt etc = do
+addEventTriggerToCatalog qt etc =
   Q.unitQE defaultTxErrorHandler
          [Q.sql|
            INSERT into hdb_catalog.event_triggers
@@ -154,7 +154,7 @@ delEventTriggerFromCatalog trn = do
   archiveEvents trn
 
 archiveEvents :: TriggerName -> Q.TxE QErr ()
-archiveEvents trn = do
+archiveEvents trn =
   Q.unitQE defaultTxErrorHandler [Q.sql|
            UPDATE hdb_catalog.event_log
            SET archived = 't'

--- a/server/src-lib/Hasura/RQL/DDL/Metadata.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Metadata.hs
@@ -129,7 +129,7 @@ saveMetadata (Metadata tables functions
     indexedForM_ collections $ \c -> liftTx $ Collection.addCollectionToCatalog c systemDefined
 
   -- allow list
-  withPathK "allowlist" $ do
+  withPathK "allowlist" $
     indexedForM_ allowlist $ \(Collection.CollectionReq name) ->
       liftTx $ Collection.addCollectionToAllowlistCatalog name
 
@@ -143,7 +143,7 @@ saveMetadata (Metadata tables functions
 
   -- cron triggers
   withPathK "cron_triggers" $
-    indexedForM_ cronTriggers $ \ct -> liftTx $ do
+    indexedForM_ cronTriggers $ \ct -> liftTx $
     addCronTriggerToCatalog ct
 
   -- actions

--- a/server/src-lib/Hasura/RQL/DDL/Schema/Cache.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Cache.hs
@@ -452,11 +452,11 @@ withMetadataCheck cascade action = do
         SOFunction qf -> Just qf
         _             -> Nothing
 
-  forM_ (droppedFuncs \\ purgedFuncs) $ \qf -> do
+  forM_ (droppedFuncs \\ purgedFuncs) $ \qf ->
     liftTx $ delFunctionFromCatalog qf
 
   -- Process altered functions
-  forM_ alteredFuncs $ \(qf, newTy) -> do
+  forM_ alteredFuncs $ \(qf, newTy) ->
     when (newTy == FTVOLATILE) $
       throw400 NotSupported $
       "type of function " <> qf <<> " is altered to \"VOLATILE\" which is not supported now"

--- a/server/src-lib/Hasura/RQL/DML/Internal.hs
+++ b/server/src-lib/Hasura/RQL/DML/Internal.hs
@@ -77,15 +77,13 @@ askPermInfo
   -> TableInfo 'Postgres
   -> m c
 askPermInfo pa tableInfo = do
-  roleName <- askCurRole
+  roleName  <- askCurRole
   mPermInfo <- askPermInfo' pa tableInfo
-  case mPermInfo of
-    Just c  -> return c
-    Nothing -> throw400 PermissionDenied $ mconcat
-      [ pt <> " on " <>> _tciName (_tiCoreInfo tableInfo)
-      , " for role " <>> roleName
-      , " is not allowed. "
-      ]
+  onNothing mPermInfo $ throw400 PermissionDenied $ mconcat
+    [ pt <> " on " <>> _tciName (_tiCoreInfo tableInfo)
+    , " for role " <>> roleName
+    , " is not allowed. "
+    ]
   where
     pt = permTypeToCode $ permAccToType pa
 

--- a/server/src-lib/Hasura/RQL/DML/Internal.hs
+++ b/server/src-lib/Hasura/RQL/DML/Internal.hs
@@ -158,7 +158,7 @@ fetchRelTabInfo refTabName =
   -- Internal error
   modifyErrAndSet500 ("foreign " <> ) $ askTabInfo refTabName
 
-type SessVarBldr b m = PGType (ScalarType b) -> SessionVariable -> m (SQLExp b)
+type SessVarBldr b m = PGType (ScalarType b) -> SessionVariable -> m (SQLExpression b)
 
 fetchRelDet
   :: (UserInfoM m, QErrM m, CacheRM m)
@@ -211,7 +211,7 @@ convPartialSQLExp
   :: (Applicative f)
   => SessVarBldr backend f
   -> PartialSQLExp backend
-  -> f (SQLExp backend)
+  -> f (SQLExpression backend)
 convPartialSQLExp f = \case
   PSESQLExp sqlExp                 -> pure sqlExp
   PSESessVar colTy sessionVariable -> f colTy sessionVariable

--- a/server/src-lib/Hasura/RQL/IR/BoolExp.hs
+++ b/server/src-lib/Hasura/RQL/IR/BoolExp.hs
@@ -238,8 +238,8 @@ data OpExpG (b :: BackendType) a
   | ALIKE !a -- LIKE
   | ANLIKE !a -- NOT LIKE
 
-  | AILIKE () !a -- ILIKE, case insensitive
-  | ANILIKE () !a-- NOT ILIKE, case insensitive
+  | AILIKE (XAILIKE b) !a -- ILIKE, case insensitive
+  | ANILIKE (XANILIKE b) !a-- NOT ILIKE, case insensitive
 
   | ASIMILAR !a -- similar, regex
   | ANSIMILAR !a-- not similar, regex
@@ -278,13 +278,6 @@ deriving instance (Backend b, Eq a) => Eq (OpExpG b a)
 instance (Backend b, NFData a) => NFData (OpExpG b a)
 instance (Backend b, Cacheable a) => Cacheable (OpExpG b a)
 instance (Backend b, Hashable a) => Hashable (OpExpG b a)
--- FIXME: this should be moved to Backend
--- type family XAILIKE (b :: Backend) where
---   XAILIKE 'Postgres = ()
---   XAILIKE 'MySQL = Void
--- type family XANILIKE (b :: Backend) where
---   XANILIKE 'Postgres = ()
---   XANILIKE 'MySQL = Void
 
 
 opExpDepCol :: OpExpG backend a -> Maybe (Column backend)

--- a/server/src-lib/Hasura/RQL/IR/Delete.hs
+++ b/server/src-lib/Hasura/RQL/IR/Delete.hs
@@ -17,7 +17,7 @@ data AnnDelG (b :: BackendType) v
   , dqp1AllCols :: ![ColumnInfo b]
   }
 
-type AnnDel b = AnnDelG b (SQLExp b)
+type AnnDel b = AnnDelG b (SQLExpression b)
 
 traverseAnnDel
   :: (Applicative f)

--- a/server/src-lib/Hasura/RQL/IR/Insert.hs
+++ b/server/src-lib/Hasura/RQL/IR/Insert.hs
@@ -74,8 +74,8 @@ data InsertQueryP1 (b :: BackendType)
   = InsertQueryP1
   { iqp1Table     :: !(TableName b)
   , iqp1Cols      :: ![Column b]
-  , iqp1Tuples    :: ![[SQLExp b]]
-  , iqp1Conflict  :: !(Maybe (ConflictClauseP1 b (SQLExp b)))
+  , iqp1Tuples    :: ![[SQLExpression b]]
+  , iqp1Conflict  :: !(Maybe (ConflictClauseP1 b (SQLExpression b)))
   , iqp1CheckCond :: !(AnnBoolExpSQL b, Maybe (AnnBoolExpSQL b))
   , iqp1Output    :: !(MutationOutput b)
   , iqp1AllCols   :: ![ColumnInfo b]

--- a/server/src-lib/Hasura/RQL/IR/Returning.hs
+++ b/server/src-lib/Hasura/RQL/IR/Returning.hs
@@ -16,7 +16,7 @@ data MutFldG (b :: BackendType) v
   | MExp !Text
   | MRet !(AnnFieldsG b v)
 
-type MutFld b = MutFldG b (SQLExp b)
+type MutFld b = MutFldG b (SQLExpression b)
 
 type MutFldsG b v = Fields (MutFldG b v)
 
@@ -24,9 +24,9 @@ data MutationOutputG (b :: BackendType) v
   = MOutMultirowFields !(MutFldsG b v)
   | MOutSinglerowObject !(AnnFieldsG b v)
 
-type MutationOutput b = MutationOutputG b (SQLExp b)
+type MutationOutput b = MutationOutputG b (SQLExpression b)
 
-type MutFlds b = MutFldsG b (SQLExp b)
+type MutFlds b = MutFldsG b (SQLExpression b)
 
 buildEmptyMutResp :: MutationOutput backend -> EncJSON
 buildEmptyMutResp = \case

--- a/server/src-lib/Hasura/RQL/IR/Select.hs
+++ b/server/src-lib/Hasura/RQL/IR/Select.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveLift           #-}
-{-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Hasura.RQL.IR.Select where
@@ -12,9 +10,6 @@ import qualified Data.Sequence                       as Seq
 import qualified Language.GraphQL.Draft.Syntax       as G
 
 import           Control.Lens.TH                     (makeLenses, makePrisms)
-
-import qualified Hasura.Backends.Postgres.SQL.DML    as PG
-import qualified Hasura.Backends.Postgres.SQL.Types  as PG
 
 import           Hasura.GraphQL.Parser.Schema
 import           Hasura.RQL.IR.BoolExp
@@ -37,16 +32,16 @@ data AnnAggregateOrderBy (b :: BackendType)
   = AAOCount
   | AAOOp !Text !(ColumnInfo b)
   deriving (Generic)
-deriving instance Eq (AnnAggregateOrderBy 'Postgres)
-instance Hashable (AnnAggregateOrderBy 'Postgres)
+deriving instance (Backend b, Eq (ColumnInfo b)) => Eq (AnnAggregateOrderBy b)
+instance (Backend b, Hashable (ColumnInfo b)) => Hashable (AnnAggregateOrderBy b)
 
 data AnnOrderByElementG (b :: BackendType) v
   = AOCColumn !(ColumnInfo b)
   | AOCObjectRelation !RelInfo !v !(AnnOrderByElementG b v)
   | AOCArrayAggregation !RelInfo !v !(AnnAggregateOrderBy b)
   deriving (Generic, Functor)
-deriving instance Eq v => Eq (AnnOrderByElementG 'Postgres v)
-instance (Hashable v) => Hashable (AnnOrderByElementG 'Postgres v)
+deriving instance (Backend b, Eq (ColumnInfo b), Eq v) => Eq (AnnOrderByElementG b v)
+instance (Backend b, Hashable (ColumnInfo b), Hashable v) => Hashable (AnnOrderByElementG b v)
 
 type AnnOrderByElement b v = AnnOrderByElementG b (AnnBoolExp b v)
 
@@ -72,10 +67,10 @@ traverseAnnOrderByItem
 traverseAnnOrderByItem f =
   traverse (traverseAnnOrderByElement f)
 
-type AnnOrderByItem b = AnnOrderByItemG b (SQLExp b)
+type AnnOrderByItem b = AnnOrderByItemG b (SQLExpression b)
 
 type OrderByItemExp b =
-  OrderByItemG b (AnnOrderByElement b (SQLExp b), (Alias b, (SQLExp b)))
+  OrderByItemG b (AnnOrderByElement b (SQLExpression b), (Alias b, (SQLExpression b)))
 
 data AnnRelationSelectG (b :: BackendType) a
   = AnnRelationSelectG
@@ -87,7 +82,7 @@ data AnnRelationSelectG (b :: BackendType) a
 type ArrayRelationSelectG b v = AnnRelationSelectG b (AnnSimpleSelG b v)
 type ArrayAggregateSelectG b v = AnnRelationSelectG b (AnnAggregateSelectG b v)
 type ArrayConnectionSelect b v = AnnRelationSelectG b (ConnectionSelect b v)
-type ArrayAggregateSelect b = ArrayAggregateSelectG b (SQLExp b)
+type ArrayAggregateSelect b = ArrayAggregateSelectG b (SQLExpression b)
 
 data AnnObjectSelectG (b :: BackendType) v
   = AnnObjectSelectG
@@ -96,7 +91,7 @@ data AnnObjectSelectG (b :: BackendType) v
   , _aosTableFilter :: !(AnnBoolExp b v)
   }
 
-type AnnObjectSelect b = AnnObjectSelectG b (SQLExp b)
+type AnnObjectSelect b = AnnObjectSelectG b (SQLExpression b)
 
 traverseAnnObjectSelect
   :: (Applicative f)
@@ -109,17 +104,17 @@ traverseAnnObjectSelect f (AnnObjectSelectG fields fromTable permissionFilter) =
   <*> traverseAnnBoolExp f permissionFilter
 
 type ObjectRelationSelectG b v = AnnRelationSelectG b (AnnObjectSelectG b v)
-type ObjectRelationSelect b = ObjectRelationSelectG b (SQLExp b)
+type ObjectRelationSelect b = ObjectRelationSelectG b (SQLExpression b)
 
 data ComputedFieldScalarSelect (b :: BackendType) v
   = ComputedFieldScalarSelect
-  { _cfssFunction  :: !PG.QualifiedFunction
-  , _cfssArguments :: !(FunctionArgsExpTableRow v)
-  , _cfssType      :: !PG.PGScalarType
+  { _cfssFunction  :: !(FunctionName b)
+  , _cfssArguments :: !(FunctionArgsExpTableRow b v)
+  , _cfssType      :: !(ScalarType b)
   , _cfssColumnOp  :: !(Maybe (ColumnOp b))
   } deriving (Functor, Foldable, Traversable)
-deriving instance Show v => Show (ComputedFieldScalarSelect 'Postgres v)
-deriving instance Eq   v => Eq   (ComputedFieldScalarSelect 'Postgres v)
+deriving instance (Backend b, Show v) => Show (ComputedFieldScalarSelect b v)
+deriving instance (Backend b, Eq   v) => Eq   (ComputedFieldScalarSelect b v)
 
 data ComputedFieldSelect (b :: BackendType) v
   = CFSScalar !(ComputedFieldScalarSelect b v)
@@ -153,17 +148,17 @@ traverseArraySelect f = \case
   ASConnection relConnection ->
     ASConnection <$> traverse (traverseConnectionSelect f) relConnection
 
-type ArraySelect b = ArraySelectG b (SQLExp b)
+type ArraySelect b = ArraySelectG b (SQLExpression b)
 
 type ArraySelectFieldsG b v = Fields (ArraySelectG b v)
 
 data ColumnOp (b :: BackendType)
   = ColumnOp
-  { _colOp  :: PG.SQLOp
-  , _colExp :: (SQLExp b)
+  { _colOp  :: (SQLOperator b)
+  , _colExp :: (SQLExpression b)
   }
-deriving instance Show (ColumnOp 'Postgres)
-deriving instance Eq   (ColumnOp 'Postgres)
+deriving instance Backend b => Show (ColumnOp b)
+deriving instance Backend b => Eq   (ColumnOp b)
 
 data AnnColumnField (b :: BackendType)
   = AnnColumnField
@@ -219,18 +214,18 @@ traverseAnnField f = \case
   AFNodeId qt pKeys    -> pure $ AFNodeId qt pKeys
   AFExpression t       -> AFExpression <$> pure t
 
-type AnnField b = AnnFieldG b (SQLExp b)
+type AnnField b = AnnFieldG b (SQLExpression b)
 
 data SelectArgsG (b :: BackendType) v
   = SelectArgs
   { _saWhere    :: !(Maybe (AnnBoolExp b v))
   , _saOrderBy  :: !(Maybe (NE.NonEmpty (AnnOrderByItemG b v)))
   , _saLimit    :: !(Maybe Int)
-  , _saOffset   :: !(Maybe (SQLExp b))
+  , _saOffset   :: !(Maybe (SQLExpression b))
   , _saDistinct :: !(Maybe (NE.NonEmpty (Column b)))
   } deriving (Generic)
-deriving instance Eq v => Eq (SelectArgsG 'Postgres v)
-instance (Hashable v) => Hashable (SelectArgsG 'Postgres v)
+deriving instance (Backend b, Eq (ColumnInfo b), Eq v) => Eq (SelectArgsG b v)
+instance (Backend b, Hashable (ColumnInfo b), Hashable v) => Hashable (SelectArgsG b v)
 
 traverseSelectArgs
   :: (Applicative f)
@@ -244,7 +239,7 @@ traverseSelectArgs f (SelectArgs wh ordBy lmt ofst distCols) =
   <*> pure ofst
   <*> pure distCols
 
-type SelectArgs b = SelectArgsG b (SQLExp b)
+type SelectArgs b = SelectArgsG b (SQLExpression b)
 
 noSelectArgs :: SelectArgsG backend v
 noSelectArgs = SelectArgs Nothing Nothing Nothing Nothing Nothing
@@ -266,7 +261,7 @@ data AggregateOp (b :: BackendType)
   }
 
 data AggregateField (b :: BackendType)
-  = AFCount !PG.CountType
+  = AFCount !(CountType b)
   | AFOp !(AggregateOp b)
   | AFExp !Text
 
@@ -278,7 +273,7 @@ traverseAnnFields
   => (a -> f b) -> AnnFieldsG backend a -> f (AnnFieldsG backend b)
 traverseAnnFields f = traverse (traverse (traverseAnnField f))
 
-type AnnFields b = AnnFieldsG b (SQLExp b)
+type AnnFields b = AnnFieldsG b (SQLExpression b)
 
 data TableAggregateFieldG (b :: BackendType) v
   = TAFAgg !(AggregateFields b)
@@ -331,37 +326,39 @@ traverseTableAggregateField f = \case
   TAFNodes annFlds -> TAFNodes <$> traverseAnnFields f annFlds
   TAFExp t         -> pure $ TAFExp t
 
-type TableAggregateField b = TableAggregateFieldG b (SQLExp b)
+type TableAggregateField b = TableAggregateFieldG b (SQLExpression b)
 type TableAggregateFieldsG b v = Fields (TableAggregateFieldG b v)
-type TableAggregateFields b = TableAggregateFieldsG b (SQLExp b)
+type TableAggregateFields b = TableAggregateFieldsG b (SQLExpression b)
 
-data ArgumentExp a
-  = AETableRow !(Maybe PG.Identifier) -- ^ table row accessor
+data ArgumentExp (b :: BackendType) a
+  = AETableRow !(Maybe (Identifier b)) -- ^ table row accessor
   | AESession !a -- ^ JSON/JSONB hasura session variable object
   | AEInput !a
-  deriving (Show, Eq, Functor, Foldable, Traversable, Generic)
-instance (Hashable v) => Hashable (ArgumentExp v)
+  deriving (Functor, Foldable, Traversable, Generic)
+deriving instance (Backend b, Show a) => Show (ArgumentExp b a)
+deriving instance (Backend b, Eq   a) => Eq   (ArgumentExp b a)
+instance (Backend b, Hashable v) => Hashable (ArgumentExp b v)
 
-type FunctionArgsExpTableRow v = FunctionArgsExpG (ArgumentExp v)
+type FunctionArgsExpTableRow b v = FunctionArgsExpG (ArgumentExp b v)
 
 data SelectFromG (b :: BackendType) v
   = FromTable !(TableName b)
-  | FromIdentifier !PG.Identifier
-  | FromFunction !PG.QualifiedFunction
-                 !(FunctionArgsExpTableRow v)
+  | FromIdentifier !(Identifier b)
+  | FromFunction !(FunctionName b)
+                 !(FunctionArgsExpTableRow b v)
                  -- a definition list
                  !(Maybe [(Column b, ScalarType b)])
   deriving (Functor, Foldable, Traversable, Generic)
-instance (Hashable v) => Hashable (SelectFromG 'Postgres v)
+instance (Backend b, Hashable v) => Hashable (SelectFromG b v)
 
-type SelectFrom b = SelectFromG b (SQLExp b)
+type SelectFrom b = SelectFromG b (SQLExpression b)
 
 data TablePermG (b :: BackendType) v
   = TablePerm
   { _tpFilter :: !(AnnBoolExp b v)
   , _tpLimit  :: !(Maybe Int)
   } deriving (Generic)
-instance (Hashable v) => Hashable (TablePermG 'Postgres v)
+instance (Backend b, Hashable (ColumnInfo b), Hashable v) => Hashable (TablePermG b v)
 
 traverseTablePerm
   :: (Applicative f)
@@ -377,7 +374,7 @@ noTablePermissions :: TablePermG backend v
 noTablePermissions =
   TablePerm annBoolExpTrue Nothing
 
-type TablePerm b = TablePermG b (SQLExp b)
+type TablePerm b = TablePermG b (SQLExpression b)
 
 data AnnSelectG (b :: BackendType) a v
   = AnnSelectG
@@ -414,10 +411,10 @@ traverseAnnSelect f1 f2 (AnnSelectG flds tabFrom perm args strfyNum) =
   <*> pure strfyNum
 
 type AnnSimpleSelG b v = AnnSelectG    b (AnnFieldsG b v) v
-type AnnSimpleSel  b   = AnnSimpleSelG b (SQLExp b)
+type AnnSimpleSel  b   = AnnSimpleSelG b (SQLExpression b)
 
 type AnnAggregateSelectG b v = AnnSelectG b (TableAggregateFieldsG b v) v
-type AnnAggregateSelect b = AnnAggregateSelectG b (SQLExp b)
+type AnnAggregateSelect b = AnnAggregateSelectG b (SQLExpression b)
 
 data ConnectionSlice
   = SliceFirst !Int
@@ -437,7 +434,7 @@ data ConnectionSplit (b :: BackendType) v
   , _csValue   :: !v
   , _csOrderBy :: !(OrderByItemG b (AnnOrderByElementG b ()))
   } deriving (Functor, Generic, Foldable, Traversable)
-instance (Hashable v) => Hashable (ConnectionSplit 'Postgres v)
+instance (Backend b, Hashable (ColumnInfo b), Hashable v) => Hashable (ConnectionSplit b v)
 
 traverseConnectionSplit
   :: (Applicative f)
@@ -473,7 +470,7 @@ instance (Hashable a) => Hashable (FunctionArgsExpG a)
 emptyFunctionArgsExp :: FunctionArgsExpG a
 emptyFunctionArgsExp = FunctionArgsExp [] HM.empty
 
-type FunctionArgExp b = FunctionArgsExpG (SQLExp b)
+type FunctionArgExp b = FunctionArgsExpG (SQLExpression b)
 
 -- | If argument positional index is less than or equal to length of
 -- 'positional' arguments then insert the value in 'positional' arguments else
@@ -492,124 +489,6 @@ insertFunctionArg argName idx value (FunctionArgsExp positional named) =
   where
     insertAt i a = toList . Seq.insertAt i a . Seq.fromList
 
-data SourcePrefixes
-  = SourcePrefixes
-  { _pfThis :: !PG.Identifier -- ^ Current source prefix
-  , _pfBase :: !PG.Identifier
-  -- ^ Base table source row identifier to generate
-  -- the table's column identifiers for computed field
-  -- function input parameters
-  } deriving (Show, Eq, Generic)
-instance Hashable SourcePrefixes
-
-data SelectSource (b :: BackendType)
-  = SelectSource
-  { _ssPrefix   :: !PG.Identifier
-  , _ssFrom     :: !PG.FromItem
-  , _ssDistinct :: !(Maybe PG.DistinctExpr)
-  , _ssWhere    :: !PG.BoolExp
-  , _ssOrderBy  :: !(Maybe PG.OrderByExp)
-  , _ssLimit    :: !(Maybe Int)
-  , _ssOffset   :: !(Maybe (SQLExp b))
-  } deriving (Generic)
-instance Hashable (SelectSource 'Postgres)
-deriving instance Show (SelectSource 'Postgres)
-deriving instance Eq   (SelectSource 'Postgres)
-
-data SelectNode (b :: BackendType)
-  = SelectNode
-  { _snExtractors :: !(HM.HashMap (Alias b) (SQLExp b))
-  , _snJoinTree   :: !(JoinTree b)
-  }
-
-instance Semigroup (SelectNode 'Postgres) where
-  SelectNode lExtrs lJoinTree <> SelectNode rExtrs rJoinTree =
-    SelectNode (lExtrs <> rExtrs) (lJoinTree <> rJoinTree)
-
-data ObjectSelectSource
-  = ObjectSelectSource
-  { _ossPrefix :: !PG.Identifier
-  , _ossFrom   :: !PG.FromItem
-  , _ossWhere  :: !PG.BoolExp
-  } deriving (Show, Eq, Generic)
-instance Hashable ObjectSelectSource
-
-objectSelectSourceToSelectSource :: ObjectSelectSource -> (SelectSource backend)
-objectSelectSourceToSelectSource ObjectSelectSource{..} =
-  SelectSource _ossPrefix _ossFrom Nothing _ossWhere Nothing Nothing Nothing
-
-data ObjectRelationSource (b :: BackendType)
-  = ObjectRelationSource
-  { _orsRelationshipName :: !RelName
-  , _orsRelationMapping  :: !(HM.HashMap (Column b) (Column b))
-  , _orsSelectSource     :: !ObjectSelectSource
-  } deriving (Generic)
-instance Hashable (ObjectRelationSource 'Postgres)
-deriving instance Eq (Column b) => Eq (ObjectRelationSource b)
-
-data ArrayRelationSource (b :: BackendType)
-  = ArrayRelationSource
-  { _arsAlias           :: !(Alias b)
-  , _arsRelationMapping :: !(HM.HashMap (Column b) (Column b))
-  , _arsSelectSource    :: !(SelectSource b)
-  } deriving (Generic)
-instance Hashable (ArrayRelationSource 'Postgres)
-deriving instance Eq (ArrayRelationSource 'Postgres)
-
-data ArraySelectNode (b :: BackendType)
-  = ArraySelectNode
-  { _asnTopExtractors :: ![PG.Extractor]
-  , _asnSelectNode    :: !(SelectNode b)
-  }
-
-instance Semigroup (ArraySelectNode 'Postgres) where
-  ArraySelectNode lTopExtrs lSelNode <> ArraySelectNode rTopExtrs rSelNode =
-    ArraySelectNode (lTopExtrs <> rTopExtrs) (lSelNode <> rSelNode)
-
-data ComputedFieldTableSetSource (b :: BackendType)
-  = ComputedFieldTableSetSource
-  { _cftssFieldName    :: !FieldName
-  , _cftssSelectType   :: !JsonAggSelect
-  , _cftssSelectSource :: !(SelectSource b)
-  } deriving (Generic)
-instance Hashable (ComputedFieldTableSetSource 'Postgres)
-deriving instance Show (ComputedFieldTableSetSource 'Postgres)
-deriving instance Eq   (ComputedFieldTableSetSource 'Postgres)
-
-data ArrayConnectionSource (b :: BackendType)
-  = ArrayConnectionSource
-  { _acsAlias           :: !(Alias b)
-  , _acsRelationMapping :: !(HM.HashMap (Column b) (Column b))
-  , _acsSplitFilter     :: !(Maybe PG.BoolExp)
-  , _acsSlice           :: !(Maybe ConnectionSlice)
-  , _acsSource          :: !(SelectSource b)
-  } deriving (Generic)
-deriving instance Eq (ArrayConnectionSource 'Postgres)
-
-instance Hashable (ArrayConnectionSource 'Postgres)
-
-data JoinTree (b :: BackendType)
-  = JoinTree
-  { _jtObjectRelations        :: !(HM.HashMap (ObjectRelationSource b) (SelectNode b))
-  , _jtArrayRelations         :: !(HM.HashMap (ArrayRelationSource b) (ArraySelectNode b))
-  , _jtArrayConnections       :: !(HM.HashMap (ArrayConnectionSource b) (ArraySelectNode b))
-  , _jtComputedFieldTableSets :: !(HM.HashMap (ComputedFieldTableSetSource b) (SelectNode b))
-  }
-
-instance Semigroup (JoinTree 'Postgres) where
-  JoinTree lObjs lArrs lArrConns lCfts <> JoinTree rObjs rArrs rArrConns rCfts =
-    JoinTree (HM.unionWith (<>) lObjs rObjs)
-             (HM.unionWith (<>) lArrs rArrs)
-             (HM.unionWith (<>) lArrConns rArrConns)
-             (HM.unionWith (<>) lCfts rCfts)
-
-instance Monoid (JoinTree 'Postgres) where
-  mempty = JoinTree mempty mempty mempty mempty
-
-data PermissionLimitSubQuery
-  = PLSQRequired !Int -- ^ Permission limit
-  | PLSQNotRequired
-  deriving (Show, Eq)
 
 $(makeLenses ''AnnSelectG)
 $(makePrisms ''AnnFieldG)

--- a/server/src-lib/Hasura/RQL/IR/Select.hs
+++ b/server/src-lib/Hasura/RQL/IR/Select.hs
@@ -75,7 +75,7 @@ traverseAnnOrderByItem f =
 type AnnOrderByItem b = AnnOrderByItemG b (SQLExp b)
 
 type OrderByItemExp b =
-  OrderByItemG b (AnnOrderByElement b (SQLExp b), (PG.Alias, (SQLExp b)))
+  OrderByItemG b (AnnOrderByElement b (SQLExp b), (Alias b, (SQLExp b)))
 
 data AnnRelationSelectG (b :: BackendType) a
   = AnnRelationSelectG
@@ -518,7 +518,7 @@ deriving instance Eq   (SelectSource 'Postgres)
 
 data SelectNode (b :: BackendType)
   = SelectNode
-  { _snExtractors :: !(HM.HashMap PG.Alias (SQLExp b))
+  { _snExtractors :: !(HM.HashMap (Alias b) (SQLExp b))
   , _snJoinTree   :: !(JoinTree b)
   }
 
@@ -549,7 +549,7 @@ deriving instance Eq (Column b) => Eq (ObjectRelationSource b)
 
 data ArrayRelationSource (b :: BackendType)
   = ArrayRelationSource
-  { _arsAlias           :: !PG.Alias
+  { _arsAlias           :: !(Alias b)
   , _arsRelationMapping :: !(HM.HashMap (Column b) (Column b))
   , _arsSelectSource    :: !(SelectSource b)
   } deriving (Generic)
@@ -578,7 +578,7 @@ deriving instance Eq   (ComputedFieldTableSetSource 'Postgres)
 
 data ArrayConnectionSource (b :: BackendType)
   = ArrayConnectionSource
-  { _acsAlias           :: !PG.Alias
+  { _acsAlias           :: !(Alias b)
   , _acsRelationMapping :: !(HM.HashMap (Column b) (Column b))
   , _acsSplitFilter     :: !(Maybe PG.BoolExp)
   , _acsSlice           :: !(Maybe ConnectionSlice)

--- a/server/src-lib/Hasura/RQL/IR/Update.hs
+++ b/server/src-lib/Hasura/RQL/IR/Update.hs
@@ -23,7 +23,7 @@ data AnnUpdG (b :: BackendType) v
   , uqp1AllCols :: ![ColumnInfo b]
   }
 
-type AnnUpd b = AnnUpdG b (SQLExp b)
+type AnnUpd b = AnnUpdG b (SQLExpression b)
 
 data UpdOpExpG v = UpdSet !v
                  | UpdInc !v

--- a/server/src-lib/Hasura/RQL/Types.hs
+++ b/server/src-lib/Hasura/RQL/Types.hs
@@ -51,7 +51,7 @@ import           Hasura.Backends.Postgres.SQL.Types
 import           Hasura.RQL.IR.BoolExp               as R
 import           Hasura.RQL.Types.Action             as R
 import           Hasura.RQL.Types.Column             as R
-import           Hasura.RQL.Types.Common             as R
+import           Hasura.RQL.Types.Common             as R hiding (FunctionName)
 import           Hasura.RQL.Types.ComputedField      as R
 import           Hasura.RQL.Types.CustomTypes        as R
 import           Hasura.RQL.Types.Error              as R
@@ -67,8 +67,8 @@ import           Hasura.RQL.Types.ScheduledTrigger   as R
 import           Hasura.RQL.Types.SchemaCache        as R
 import           Hasura.RQL.Types.SchemaCache.Build  as R
 import           Hasura.RQL.Types.Table              as R
-import           Hasura.Session
 import           Hasura.SQL.Backend                  as R
+import           Hasura.Session
 import           Hasura.Tracing                      (TraceT)
 
 data QCtx

--- a/server/src-lib/Hasura/RQL/Types.hs
+++ b/server/src-lib/Hasura/RQL/Types.hs
@@ -293,12 +293,7 @@ askFieldInfo :: (MonadError QErr m)
              -> FieldName
              -> m fieldInfo
 askFieldInfo m f =
-  case M.lookup f m of
-  Just colInfo -> return colInfo
-  Nothing ->
-    throw400 NotExists $ mconcat
-    [ f <<> " does not exist"
-    ]
+  M.lookup f m `onNothing` throw400 NotExists (f <<> " does not exist")
 
 askRemoteRel :: (MonadError QErr m)
            => FieldInfoMap (FieldInfo backend)

--- a/server/src-lib/Hasura/RQL/Types/Common.hs
+++ b/server/src-lib/Hasura/RQL/Types/Common.hs
@@ -111,6 +111,8 @@ class
   , Representable (ScalarType b)
   , Representable (SQLExpression b)
   , Representable (SQLOperator b)
+  , Representable (XAILIKE b)
+  , Representable (XANILIKE b)
   , Lift (TableName b)
   , Lift (BasicOrderType b)
   , Lift (NullsOrderType b)
@@ -135,6 +137,8 @@ class
   type ScalarType     b :: Type
   type SQLExpression  b :: Type
   type SQLOperator    b :: Type
+  type XAILIKE        b :: Type
+  type XANILIKE       b :: Type
 
 instance Backend 'Postgres where
   type Identifier     'Postgres = PG.Identifier
@@ -149,6 +153,12 @@ instance Backend 'Postgres where
   type ScalarType     'Postgres = PG.PGScalarType
   type SQLExpression  'Postgres = PG.SQLExp
   type SQLOperator    'Postgres = PG.SQLOp
+  type XAILIKE        'Postgres = ()
+  type XANILIKE       'Postgres = ()
+
+-- instance Backend 'Mysql where
+--   type XAILIKE 'MySQL = Void
+--   type XANILIKE 'MySQL = Void
 
 
 adminText :: NonEmptyText

--- a/server/src-lib/Hasura/RQL/Types/Common.hs
+++ b/server/src-lib/Hasura/RQL/Types/Common.hs
@@ -136,6 +136,7 @@ class
   , ToJSON (NullsOrderType b)
   , Typeable b
   ) => Backend (b :: BackendType) where
+  type Alias          b :: Type
   type TableName      b :: Type
   type ConstraintName b :: Type
   type BasicOrderType b :: Type
@@ -143,6 +144,7 @@ class
   type Column         b :: Type
 
 instance Backend 'Postgres where
+  type Alias          'Postgres = PG.Alias
   type TableName      'Postgres = PG.QualifiedTable
   type ConstraintName 'Postgres = PG.ConstraintName
   type BasicOrderType 'Postgres = PG.OrderType

--- a/server/src-lib/Hasura/RQL/Types/Common.hs
+++ b/server/src-lib/Hasura/RQL/Types/Common.hs
@@ -6,8 +6,6 @@ module Hasura.RQL.Types.Common
        , relTypeToTxt
        , RelInfo(..)
 
-       , ScalarType
-       , SQLExp
        , Backend (..)
 
        , FieldName(..)
@@ -90,15 +88,7 @@ import           Hasura.RQL.Types.Error
 import           Hasura.SQL.Backend
 
 
-type family ScalarType (b :: BackendType) where
-  ScalarType 'Postgres = PG.PGScalarType
-
-type family ColumnType (b :: BackendType) where
-  ColumnType 'Postgres = PG.PGType
-
-type family SQLExp (b :: BackendType) where
-  SQLExp 'Postgres = PG.SQLExp
-
+type Representable a = (Show a, Eq a, Hashable a, Cacheable a, NFData a)
 
 -- | Mapping from abstract types to concrete backend representation
 --
@@ -111,45 +101,54 @@ type family SQLExp (b :: BackendType) where
 -- dedicated type families allows to explicitly list all typeclass requirements,
 -- which simplifies the instance declarations of all IR types.
 class
-  ( Show (TableName b)
-  , Show (ConstraintName b)
-  , Show (Column b)
-  , Show (BasicOrderType b)
-  , Show (NullsOrderType b)
-  , Eq (TableName b)
-  , Eq (ConstraintName b)
-  , Eq (Column b)
-  , Eq (BasicOrderType b)
-  , Eq (NullsOrderType b)
+  ( Representable (Identifier b)
+  , Representable (TableName b)
+  , Representable (FunctionName b)
+  , Representable (ConstraintName b)
+  , Representable (BasicOrderType b)
+  , Representable (NullsOrderType b)
+  , Representable (Column b)
+  , Representable (ScalarType b)
+  , Representable (SQLExpression b)
+  , Representable (SQLOperator b)
   , Lift (TableName b)
   , Lift (BasicOrderType b)
   , Lift (NullsOrderType b)
-  , Cacheable (TableName b)
   , Data (TableName b)
-  , Hashable (BasicOrderType b)
-  , Hashable (NullsOrderType b)
-  , Hashable (TableName b)
-  , NFData (TableName b)
+  , Data (ScalarType b)
+  , Data (SQLExpression b)
   , FromJSON (BasicOrderType b)
   , FromJSON (NullsOrderType b)
   , ToJSON (BasicOrderType b)
   , ToJSON (NullsOrderType b)
   , Typeable b
   ) => Backend (b :: BackendType) where
+  type Identifier     b :: Type
   type Alias          b :: Type
   type TableName      b :: Type
+  type FunctionName   b :: Type
   type ConstraintName b :: Type
   type BasicOrderType b :: Type
   type NullsOrderType b :: Type
+  type CountType      b :: Type
   type Column         b :: Type
+  type ScalarType     b :: Type
+  type SQLExpression  b :: Type
+  type SQLOperator    b :: Type
 
 instance Backend 'Postgres where
+  type Identifier     'Postgres = PG.Identifier
   type Alias          'Postgres = PG.Alias
   type TableName      'Postgres = PG.QualifiedTable
+  type FunctionName   'Postgres = PG.QualifiedFunction
   type ConstraintName 'Postgres = PG.ConstraintName
   type BasicOrderType 'Postgres = PG.OrderType
   type NullsOrderType 'Postgres = PG.NullsOrder
+  type CountType      'Postgres = PG.CountType
   type Column         'Postgres = PG.PGCol
+  type ScalarType     'Postgres = PG.PGScalarType
+  type SQLExpression  'Postgres = PG.SQLExp
+  type SQLOperator    'Postgres = PG.SQLOp
 
 
 adminText :: NonEmptyText

--- a/server/src-lib/Hasura/RQL/Types/SchemaCache.hs
+++ b/server/src-lib/Hasura/RQL/Types/SchemaCache.hs
@@ -136,7 +136,7 @@ import           Hasura.GraphQL.Context              (GQLContext, RemoteField, R
 import           Hasura.Incremental                  (Dependency, MonadDepend (..), selectKeyD)
 import           Hasura.RQL.IR.BoolExp
 import           Hasura.RQL.Types.Action
-import           Hasura.RQL.Types.Common
+import           Hasura.RQL.Types.Common             hiding (FunctionName)
 import           Hasura.RQL.Types.ComputedField
 import           Hasura.RQL.Types.CustomTypes
 import           Hasura.RQL.Types.Error


### PR DESCRIPTION
_(Note: this PR is on top of #6150.)_

### Description
This PR is one further step in our work to make the IR backend-agnostic; this time, tackling the representation of `Select`. 

This PR does a few big changes:
- it introduces `Backends.Postgres.Translate.Types` for types that are only used as intermediary representation steps during the translation to Postgres
- it adds more type to the `Representation` class and cleans up constraints
- it generalizes several instance declarations for which we still had an explicit `'Postgres`
- it makes a few names more explicit

None of those changes result in a change of behaviour, and they therefore do not need a changelog entry.