### PR TITLE
ci: add hlint escape hatch

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,5 +1,7 @@
-on: pull_request
-name: changelog 
+on:
+  label
+  pull_request
+name: changelog
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,6 +1,4 @@
-on:
-  label
-  pull_request
+on: [label, pull_request]
 name: changelog
 jobs:
   check:

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -1,9 +1,9 @@
 name: server lint
 on:
-  label
-  pull_request:
-    paths:
-      - 'server/**'
+  - label
+  - pull_request:
+      paths:
+        - 'server/**'
 
 jobs:
   hlint:

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -1,5 +1,6 @@
 name: server lint
 on:
+  label:
   pull_request:
     paths:
       - 'server/**'
@@ -7,6 +8,7 @@ on:
 jobs:
   hlint:
     runs-on: ubuntu-20.04
+    if: !contains(github.event.pull_request.labels.*.name, 'ignore-lint-checks')
     env:
       working-directory: ./server
       HLINT_BASE_URL: https://dl.haskellworks.io/binaries/hlint
@@ -14,7 +16,6 @@ jobs:
       HLINT_ARCH: x86_64
       HLINT_OS: linux
       HLINT_URL: $HLINT_BASE_URL/hlint-${HLINT_VERSION}-${HLINT_ARCH}-${HLINT_OS}.tar.gz
-
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -1,6 +1,6 @@
 name: server lint
 on:
-  label:
+  label
   pull_request:
     paths:
       - 'server/**'

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   hlint:
     runs-on: ubuntu-20.04
-    if: "!contains(github.event.pull_request.labels.*.name, 'ignore-server-lint-checks') && github.event.label.name != 'ignore-server-lint-checks'"
+    if: "!contains(github.event.pull_request.labels.*.name, 'ignore-server-hlint-checks') && github.event.label.name != 'ignore-server-hlint-checks'"
     env:
       working-directory: ./server
       HLINT_BASE_URL: https://dl.haskellworks.io/binaries/hlint

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -1,14 +1,14 @@
 name: server lint
 on:
-  - label
-  - pull_request:
-      paths:
-        - 'server/**'
+  label:
+  pull_request:
+    paths:
+      - 'server/**'
 
 jobs:
   hlint:
     runs-on: ubuntu-20.04
-    if: !contains(github.event.pull_request.labels.*.name, 'ignore-lint-checks')
+    if: "!contains(github.event.pull_request.labels.*.name, 'ignore-server-lint-checks') && github.event.label.name != 'ignore-server-lint-checks'"
     env:
       working-directory: ./server
       HLINT_BASE_URL: https://dl.haskellworks.io/binaries/hlint

--- a/server/.hlint.yaml
+++ b/server/.hlint.yaml
@@ -109,6 +109,7 @@
     - warn: {lhs: "case x of {Just b -> pure b; Nothing -> a}", rhs: "onNothing x a"}
     - warn: {lhs: "case x of {Nothing -> a; Just b -> return b}", rhs: "onNothing x a"}
     - warn: {lhs: "case x of {Just b -> return b; Nothing -> a}", rhs: "onNothing x a"}
+    - warn: {lhs: "fromMaybe [] x", rhs: "maybeToList x"}
 
 - group:
     name: data-text-extended


### PR DESCRIPTION
### Description
This PR changes our check configuration:
- the changelog check will be re-run whenever a label changes
- the hlint check will be skipped if a label named `ignore-server-lint-checks` is present
- (it also adds one new hlint check)

This is hard to test, given that `label` events are only fired using the configuration as it is on main, according to the documentation. At the very least this runs, which means that even if it does not work as expected it won't break our workflows.

If someone has any experience with actions and can check this, that'd be great!