### PR TITLE
console: misc fixes 

### DIFF
--- a/console/src/Endpoints.ts
+++ b/console/src/Endpoints.ts
@@ -20,8 +20,9 @@ const Endpoints = {
   hasuractlMetadata: `${hasuractlUrl}/apis/metadata`,
   hasuractlMigrateSettings: `${hasuractlUrl}/apis/migrate/settings`,
   telemetryServer: 'wss://telemetry.hasura.io/v1/ws',
-  consoleNotificationsStg: 'https://data.hasura-stg.hasura-app.io/v1/query',
-  consoleNotificationsProd: 'https://data.hasura.io/v1/query',
+  consoleNotificationsStg:
+    'https://notifications.hasura-stg.hasura-app.io/v1/graphql',
+  consoleNotificationsProd: 'https://notifications.hasura.io/v1/graphql',
 };
 
 const globalCookiePolicy = 'same-origin';

--- a/console/src/components/App/Actions.js
+++ b/console/src/components/App/Actions.js
@@ -16,7 +16,7 @@ const CONNECTION_FAILED = 'App/CONNECTION_FAILED';
  * title: string null
  * message: string null
  * autoDismiss: integer 5, set to 0 to not auto-dismiss
- * dismissible: bool true, set if user can dismiss notification
+ * dismissible: 'button', set if the user can dismiss the notification, false otherwise
  * action: object null, action button with label string and callback function
  * children: element/string, null, add custom element, over-rides action
  * onAdd: function, null, called when notification is successfully created, 1st argument is the notification

--- a/console/src/components/Common/utils/v1QueryUtils.ts
+++ b/console/src/components/Common/utils/v1QueryUtils.ts
@@ -700,47 +700,34 @@ export const getConsoleNotificationQuery = (
   time: Date | string | number,
   userType?: Nullable<ConsoleScope>
 ) => {
-  let consoleUserScope = {
-    $ilike: `%${userType}%`,
-  };
+  let consoleUserScopeVar = `%${userType}%`;
   if (!userType) {
-    consoleUserScope = {
-      $ilike: '%OSS%',
-    };
+    consoleUserScopeVar = '%OSS%';
   }
 
-  return {
-    args: {
-      table: 'console_notification',
-      columns: ['*'],
-      where: {
-        $or: [
-          {
-            expiry_date: {
-              $gte: time,
-            },
-          },
-          {
-            expiry_date: {
-              $eq: null,
-            },
-          },
-        ],
-        scope: consoleUserScope,
-        start_date: { $lte: time },
-      },
-      order_by: [
-        {
-          type: 'asc',
-          nulls: 'last',
-          column: 'priority',
-        },
-        {
-          type: 'desc',
-          column: 'start_date',
-        },
-      ],
-    },
-    type: 'select',
+  const query = `query fetchNotifications($currentTime: timestamptz, $userScope: String) {
+    console_notifications(
+      where: {start_date: {_lte: $currentTime}, scope: {_ilike: $userScope}, _or: [{expiry_date: {_gte: $currentTime}}, {expiry_date: {_eq: null}}]},
+      order_by: {priority: asc_nulls_last, start_date: desc}
+    ) {
+      content
+      created_at
+      external_link
+      expiry_date
+      id
+      is_active
+      priority
+      scope
+      start_date
+      subject
+      type
+    }
+  }`;
+
+  const variables = {
+    userScope: consoleUserScopeVar,
+    currentTime: time,
   };
+
+  return { query, variables };
 };

--- a/console/src/components/Main/ConsoleNotification.ts
+++ b/console/src/components/Main/ConsoleNotification.ts
@@ -31,7 +31,6 @@ export type ConsoleNotification = {
   scope?: NotificationScope;
 };
 
-// FIXME? : we may have to remove this
 export const defaultNotification: ConsoleNotification = {
   subject: 'No updates available at the moment',
   created_at: Date.now(),

--- a/console/src/components/Main/Main.js
+++ b/console/src/components/Main/Main.js
@@ -36,6 +36,7 @@ import {
   setProClickState,
   getLoveConsentState,
   setLoveConsentState,
+  getUserType,
 } from './utils';
 import { getSchemaBaseRoute } from '../Common/utils/routesUtils';
 import {
@@ -45,6 +46,35 @@ import {
 } from '../Common/utils/localStorageUtils';
 import { ProPopup } from './components/ProPopup';
 import LoveSection from './LoveSection';
+import { HASURA_COLLABORATOR_TOKEN } from '../../constants';
+import { UPDATE_CONSOLE_NOTIFICATIONS } from '../../telemetry/Actions';
+
+const updateRequestHeaders = props => {
+  const { requestHeaders, dispatch } = props;
+
+  const collabTokenKey = Object.keys(requestHeaders).find(
+    hdr => hdr.toLowerCase() === HASURA_COLLABORATOR_TOKEN
+  );
+
+  if (collabTokenKey) {
+    const userID = getUserType(requestHeaders[collabTokenKey]);
+    if (props.console_opts && props.console_opts.console_notifications) {
+      if (!props.console_opts.console_notifications[userID]) {
+        dispatch({
+          type: UPDATE_CONSOLE_NOTIFICATIONS,
+          data: {
+            ...props.console_opts.console_notifications,
+            [userID]: {
+              read: [],
+              date: null,
+              showBadge: true,
+            },
+          },
+        });
+      }
+    }
+  }
+};
 
 class Main extends React.Component {
   constructor(props) {
@@ -63,6 +93,7 @@ class Main extends React.Component {
   componentDidMount() {
     const { dispatch } = this.props;
 
+    updateRequestHeaders(this.props);
     dispatch(loadServerVersion()).then(() => {
       dispatch(featureCompatibilityInit());
 
@@ -77,6 +108,18 @@ class Main extends React.Component {
     });
 
     dispatch(fetchServerConfig());
+  }
+
+  componentDidUpdate(prevProps) {
+    const prevHeaders = Object.keys(prevProps.requestHeaders);
+    const currHeaders = Object.keys(this.props.requestHeaders);
+
+    if (
+      prevHeaders.length !== currHeaders.length ||
+      prevHeaders.filter(hdr => !currHeaders.includes(hdr)).length
+    ) {
+      updateRequestHeaders(this.props);
+    }
   }
 
   toggleProPopup = () => {
@@ -448,6 +491,7 @@ const mapStateToProps = (state, ownProps) => {
     currentSchema: state.tables.currentSchema,
     metadata: state.metadata,
     console_opts: state.telemetry.console_opts,
+    requestHeaders: state.tables.dataHeaders,
   };
 };
 

--- a/console/src/components/Main/Main.scss
+++ b/console/src/components/Main/Main.scss
@@ -1323,7 +1323,7 @@
   font-size: 16px;
   top: 52px;
   right: 8px;
-  &:hover{
+  &:hover {
     cursor: pointer;
   }
 }
@@ -1334,9 +1334,9 @@
   left: auto;
   border: none;
   user-select: none;
-  -webkit-box-shadow: -3px 4px 10px 0px rgba(0,0,0,0.1);
-  -moz-box-shadow: -3px 4px 10px 0px rgba(0,0,0,0.1);
-  box-shadow: -3px 4px 10px 0px rgba(0,0,0,0.1);
+  -webkit-box-shadow: -3px 4px 10px 0px rgba(0, 0, 0, 0.1);
+  -moz-box-shadow: -3px 4px 10px 0px rgba(0, 0, 0, 0.1);
+  box-shadow: -3px 4px 10px 0px rgba(0, 0, 0, 0.1);
 }
 
 .notificationsContainer {
@@ -1366,7 +1366,7 @@
   position: absolute;
   width: 17px;
   top: 16px;
-  right: 8px;
+  right: 0.8rem;
   border-radius: 50%;
   user-select: none;
   visibility: visible;

--- a/console/src/components/Main/NotificationSection.tsx
+++ b/console/src/components/Main/NotificationSection.tsx
@@ -511,15 +511,19 @@ const HasuraNotifications: React.FC<
 
   let userType = 'admin';
 
-  if (dataHeaders?.[HASURA_COLLABORATOR_TOKEN]) {
-    const collabToken = dataHeaders[HASURA_COLLABORATOR_TOKEN];
+  const headerHasCollabToken = Object.keys(dataHeaders).find(
+    header => header.toLowerCase() === HASURA_COLLABORATOR_TOKEN
+  );
+
+  if (headerHasCollabToken) {
+    const collabToken = dataHeaders[headerHasCollabToken];
     userType = getUserType(collabToken);
   }
 
   const previouslyReadState = React.useMemo(
     () =>
       console_opts?.console_notifications &&
-      console_opts?.console_notifications[userType].read,
+      console_opts?.console_notifications[userType]?.read,
     [console_opts?.console_notifications, userType]
   );
   const showBadge = React.useMemo(
@@ -639,7 +643,7 @@ const HasuraNotifications: React.FC<
 
   useOnClickOutside([dropDownRef, wrapperRef], onClickOutside);
 
-  const onClickShareSection = () => {
+  const onClickNotificationButton = () => {
     if (showBadge) {
       if (console_opts?.console_notifications) {
         let updatedState = {};
@@ -718,11 +722,11 @@ const HasuraNotifications: React.FC<
   return (
     <>
       <div
-        className={`${styles.shareSection} ${
+        className={`${styles.shareSection} ${styles.headerRightNavbarBtn} ${
           isDropDownOpen ? styles.opened : ''
         } dropdown-toggle`}
         aria-expanded="false"
-        onClick={onClickShareSection}
+        onClick={onClickNotificationButton}
         ref={wrapperRef}
       >
         <i className={`fa fa-bell ${styles.bellIcon}`} />
@@ -750,7 +754,7 @@ const HasuraNotifications: React.FC<
           <Button
             title="Mark all as read"
             onClick={onClickMarkAllAsRead}
-            disabled={!numberNotifications}
+            disabled={!numberNotifications || !consoleNotifications.length}
             className={styles.markAllAsReadBtn}
           >
             mark all as read

--- a/console/src/components/Services/Common/Notification.tsx
+++ b/console/src/components/Services/Common/Notification.tsx
@@ -20,7 +20,7 @@ export interface Notification {
   level?: 'error' | 'warning' | 'info' | 'success';
   position?: 'tr' | 'tl' | 'tc' | 'br' | 'bl' | 'bc';
   autoDismiss?: number;
-  dismissible?: boolean;
+  dismissible?: 'both' | 'button' | 'click' | 'hide' | 'none' | boolean;
   children?: React.ReactNode;
   uid?: number | string;
   action?: {
@@ -43,7 +43,9 @@ export const showNotification = (
         {
           position: options.position || 'tr',
           autoDismiss: ['error', 'warning'].includes(level) ? 0 : 5,
-          dismissible: ['error', 'warning'].includes(level),
+          dismissible: ['error', 'warning'].includes(level)
+            ? ('button' as any) // bug in @types/react-notification-system-redux types
+            : ('click' as any),
           ...options,
         },
         level

--- a/console/src/components/Services/Data/Common/Components/TableRow.tsx
+++ b/console/src/components/Services/Data/Common/Components/TableRow.tsx
@@ -7,7 +7,11 @@ import {
 import styles from '../../../../Common/TableCommon/Table.scss';
 import { TypedInput } from './TypedInput';
 
-const getColumnInfo = (col: TableColumn, prevValue?: unknown) => {
+const getColumnInfo = (
+  col: TableColumn,
+  prevValue?: unknown,
+  clone?: Record<string, unknown>
+) => {
   const isEditing = prevValue !== undefined;
 
   const hasDefault = col.column_default
@@ -24,7 +28,8 @@ const getColumnInfo = (col: TableColumn, prevValue?: unknown) => {
 
   let columnValueType;
   switch (true) {
-    case !isEditing && (isIdentity || hasDefault || isGenerated):
+    case !isEditing && !clone && (isIdentity || hasDefault || isGenerated):
+    case clone && isDisabled:
     case identityGeneration === 'ALWAYS':
       columnValueType = 'default';
       break;
@@ -56,9 +61,9 @@ export interface TableRowProps {
     refName: 'valueNode' | 'nullNode' | 'defaultNode' | 'insertRadioNode',
     node: HTMLInputElement | null
   ) => void;
-  enumOptions: object;
+  enumOptions: Record<string, any>;
   index: number;
-  clone?: object;
+  clone?: Record<string, any>;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>, val: unknown) => void;
   onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void;
   prevValue?: unknown;
@@ -80,7 +85,7 @@ export const TableRow: React.FC<TableRowProps> = ({
     isNullable,
     hasDefault,
     columnValueType,
-  } = getColumnInfo(column, prevValue);
+  } = getColumnInfo(column, prevValue, clone);
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement>,

--- a/console/src/components/Services/Data/DataActions.js
+++ b/console/src/components/Services/Data/DataActions.js
@@ -689,6 +689,7 @@ const makeMigrationCall = (
                 successMsg,
                 errorMsg,
                 shouldSkipSchemaReload,
+                false,
                 true // prevent further retry
               ),
           },

--- a/console/src/components/Services/Data/TablePermissions/Actions.js
+++ b/console/src/components/Services/Data/TablePermissions/Actions.js
@@ -723,7 +723,7 @@ const permChangePermissions = changeType => {
     const limitEnabled = permissionsState.limitEnabled;
 
     const table = permissionsState.table;
-    const role = permissionsState.role;
+    const role = permissionsState.role.trim();
     const query = permissionsState.query;
 
     const tableSchema = allSchemas.find(

--- a/console/src/components/Services/Data/TablePermissions/Permissions.js
+++ b/console/src/components/Services/Data/TablePermissions/Permissions.js
@@ -482,9 +482,9 @@ class Permissions extends Component {
         });
 
         const dispatchRoleNameChange = e => {
-          const newRole = e.target.value.trim();
+          const role = e.target.value;
 
-          dispatch(permSetRoleName(newRole));
+          dispatch(permSetRoleName(role));
         };
 
         return (

--- a/console/src/components/Services/Data/TableRelationships/RemoteRelationships/components/EditorCollapsed.tsx
+++ b/console/src/components/Services/Data/TableRelationships/RemoteRelationships/components/EditorCollapsed.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RemoteRelationshipServer } from '../utils';
+import { RemoteRelationshipServer, parseRemoteRelationship } from '../utils';
 import styles from '../SchemaExplorer.scss';
 
 type Props = {
@@ -10,6 +10,11 @@ const Collapsed: React.FC<Props> = ({ relationship }) => {
   if (!relationship) {
     return null;
   }
+  const parseRelationship = parseRemoteRelationship(relationship);
+  const relationMap = () => {
+    const fields = parseRelationship.remoteFields.map(field => field.name);
+    return ['', ...fields].join(' . ');
+  };
   return (
     <div className={styles.display_flex}>
       <div>
@@ -19,7 +24,7 @@ const Collapsed: React.FC<Props> = ({ relationship }) => {
         <i>
           {`- ${relationship.table_name} → ${
             relationship.definition.remote_schema
-          } . ${Object.keys(relationship.definition.remote_field)}`}
+          }  ${relationMap()}`}
         </i>
       </div>
     </div>

--- a/console/src/types.ts
+++ b/console/src/types.ts
@@ -27,6 +27,40 @@ export type ConsoleState = {
   hasura_uuid: string;
 };
 
+export type ApiExplorer = {
+  authApiExpanded: string;
+  currentTab: number;
+  headerFocus: boolean;
+  loading: boolean;
+  mode: string;
+  modalState: Record<string, string>;
+  explorerData: Record<string, string>;
+  displayedApi: DisplayedApiState;
+};
+
+export type DisplayedApiState = {
+  details: Record<string, string>;
+  id: string;
+  request: ApiExplorerRequest;
+};
+
+export type ApiExplorerRequest = {
+  bodyType: string;
+  headers: ApiExplorerHeader[];
+  headersInitialised: boolean;
+  method: string;
+  params: string;
+  url: string;
+};
+
+export type ApiExplorerHeader = {
+  key: string;
+  value: string;
+  isActive: boolean;
+  isNewHeader: boolean;
+  isDisabled: boolean;
+};
+
 // Redux Utils
 export type ReduxState = {
   tables: {
@@ -43,6 +77,7 @@ export type ReduxState = {
     consoleNotifications: ConsoleNotification[];
   };
   telemetry: ConsoleState;
+  apiexplorer: ApiExplorer;
 };
 
 export type ReduxAction = RAEvents | RouterAction;


### PR DESCRIPTION
### Description

This PR includes fixes to notifications and a few small improvements:

* notifications bug fixes (#6067)
* trim role names when submitting the form (close #5553) (#5748)
* make error notifications dismissible only after clicking on the close button (close #5533) (#5780)
* fix default option selected when cloning row in data browser (close #5340) (#5364)
* fix makeMigrationCall arguments order (it was fixed in https://github.com/hasura/graphql-engine/pull/5248/files#r498117139. As https://github.com/hasura/graphql-engine/pull/5248 is not included in 1.3.x, but the issue was reported multiple times and it was a one-line change, I included it in this PR) — commit: https://github.com/hasura/graphql-engine/commit/f378538e33ea8d8777f16a6af47aa5e6a0946f8d
* improve UI for nested remote relationships (close #4973) (#5612)

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components

- [x] Console
