### PR TITLE
v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ The corresponding JWT config can be:
 **NOTE:** If you have event triggers with names greater than 42 chars, then you should update their names to avoid running into Postgres identifier limit bug (#5786)
 - server: fix issue with tracking custom functions that return `SETOF` materialized view (close #5294) (#5945)
 - server: allow remote relationships with union, interface and enum type fields as well (fixes #5875) (#6080)
+- server: Fix fine-grained incremental cache invalidation (fix #3759)
+
+  This issue could cause enum table values to sometimes not be properly reloaded without restarting `graphql-engine`. Now a `reload_metadata` API call (or clicking “Reload enum values” in the console) should consistently force a reload of all enum table values.
 - server: fix event trigger cleanup on deletion via replace_metadata (fix #5461) (#6137)
 - cli: fix bug in metadata apply which made the server aquire some redundant and unnecessary locks (close #6115)
 - cli: fix cli-migrations-v2 image failing to run as a non root user (close #4651, close #5333)

--- a/server/src-test/Hasura/IncrementalSpec.hs
+++ b/server/src-test/Hasura/IncrementalSpec.hs
@@ -31,6 +31,29 @@ spec = do
       (_, state3) <- runStateT (Inc.rebuild result2 (True, True)) 0
       state3 `shouldBe` 2
 
+    it "tracks dependencies within nested uses of cache across multiple executions" do
+      let rule :: (MonadWriter String m, MonadUnique m)
+               => Inc.Rule m (Inc.InvalidationKey, Inc.InvalidationKey) ()
+          rule = proc (key1, key2) -> do
+            dep1 <- Inc.newDependency -< key2
+            (key1, dep1) >- Inc.cache (proc (_, dep2) ->
+              dep2 >- Inc.cache (proc dep3 -> do
+                Inc.dependOn -< dep3
+                arrM tell -< "executed"))
+            returnA -< ()
+
+      let key1 = Inc.initialInvalidationKey
+          key2 = Inc.invalidate key1
+
+      (result1, log1) <- runWriterT $ Inc.build rule (key1, key1)
+      log1 `shouldBe` "executed"
+
+      (result2, log2) <- runWriterT $ Inc.rebuild result1 (key2, key1)
+      log2 `shouldBe` ""
+
+      (_, log3) <- runWriterT $ Inc.rebuild result2 (key2, key2)
+      log3 `shouldBe` "executed"
+
   describe "keyed" $ do
     it "preserves incrementalization when entries don’t change" $ do
       let rule :: (MonadWriter (S.HashSet (String, Integer)) m, MonadUnique m)

--- a/server/tests-py/queries/v1/set_table_is_enum/set_and_delayed_reload/introspect_enum_values.yaml
+++ b/server/tests-py/queries/v1/set_table_is_enum/set_and_delayed_reload/introspect_enum_values.yaml
@@ -1,0 +1,44 @@
+- description: Insert a new enum value without reloading
+  url: /v1/query
+  status: 200
+  query:
+    type: run_sql
+    args:
+      sql: |
+        INSERT INTO crust VALUES ('thick');
+
+- description: Check that the previous enum values are cached
+  url: /v1/graphql
+  status: 200
+  response:
+    data:
+      crust:
+        enumValues:
+        - name: thin
+  query: &crust_query
+    query: |
+      {
+        crust: __type(name: "crust_enum") {
+          enumValues {
+            name
+          }
+        }
+      }
+
+- description: Reload the metadata
+  url: /v1/query
+  status: 200
+  query:
+    type: reload_metadata
+    args: {}
+
+- description: Check that the enum values are updated
+  url: /v1/graphql
+  status: 200
+  response:
+    data:
+      crust:
+        enumValues:
+        - name: thick
+        - name: thin
+  query: *crust_query

--- a/server/tests-py/queries/v1/set_table_is_enum/set_and_delayed_reload/setup.yaml
+++ b/server/tests-py/queries/v1/set_table_is_enum/set_and_delayed_reload/setup.yaml
@@ -1,0 +1,24 @@
+type: bulk
+args:
+- type: run_sql
+  args:
+    sql: |
+      CREATE TABLE crust (name text NOT NULL PRIMARY KEY);
+      INSERT INTO crust VALUES ('thin');
+- type: add_existing_table_or_view
+  args: crust
+- type: set_table_is_enum
+  args:
+    table: crust
+    is_enum: true
+- type: run_sql
+  args:
+    sql: |
+      CREATE TABLE pizza
+        ( id serial NOT NULL PRIMARY KEY
+        , name text NOT NULL
+        , crust text NOT NULL REFERENCES crust );
+
+      INSERT INTO pizza (name, crust) VALUES ('margarita', 'thin');
+- type: add_existing_table_or_view
+  args: pizza

--- a/server/tests-py/queries/v1/set_table_is_enum/set_and_delayed_reload/teardown.yaml
+++ b/server/tests-py/queries/v1/set_table_is_enum/set_and_delayed_reload/teardown.yaml
@@ -1,0 +1,8 @@
+type: bulk
+args:
+- type: run_sql
+  args:
+    sql: |
+      DROP TABLE pizza;
+      DROP TABLE crust;
+    cascade: true

--- a/server/tests-py/test_v1_queries.py
+++ b/server/tests-py/test_v1_queries.py
@@ -729,6 +729,16 @@ class TestSetTableIsEnum:
     def test_relationship_with_inconsistent_enum_table(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + '/relationship_with_inconsistent_enum_table.yaml')
 
+# regression test for issue #3759
+@usefixtures('per_method_tests_db_state')
+class TestSetTableIsEnumSetAndDelayedReload:
+    @classmethod
+    def dir(cls):
+        return 'queries/v1/set_table_is_enum/set_and_delayed_reload'
+
+    def test_introspect_enum_values(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + '/introspect_enum_values.yaml')
+
 @usefixtures('per_method_tests_db_state')
 class TestSetTableCustomFields:
 


### PR DESCRIPTION
This PR contains cherry-picking of the https://github.com/hasura/graphql-engine/pull/6027 PR which was not included in the v1.3.3 branch.

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [ ] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [ ] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [ ] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [ ] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
