### PR TITLE
server: query remote server in a remote join query iff all arguments are not null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,13 +122,14 @@ This release contains the [PDV refactor (#4111)](https://github.com/hasura/graph
 - server: fix bug which arised when renaming a table which had a manual relationship defined (close #4158)
 - server: limit the length of event trigger names (close #5786)
 - server: Configurable websocket keep-alive interval. Add `--websocket-keepalive` command-line flag
-          and handle `HASURA_GRAPHQL_WEBSOCKET_KEEPALIVE` env variable (fix #3539) 
+          and handle `HASURA_GRAPHQL_WEBSOCKET_KEEPALIVE` env variable (fix #3539)
 **NOTE:** If you have event triggers with names greater than 42 chars, then you should update their names to avoid running into Postgres identifier limit bug (#5786)
 - server: validate remote schema queries (fixes #4143)
 - server: fix issue with tracking custom functions that return `SETOF` materialized view (close #5294) (#5945)
 - server: introduce optional custom table name in table configuration to track the table according to the custom name. The `set_table_custom_fields` API has been deprecated, A new API `set_table_customization` has been added to set the configuration. (#3811)
 - server: allow remote relationships with union, interface and enum type fields as well (fixes #5875) (#6080)
 - server: fix event trigger cleanup on deletion via replace_metadata (fix #5461) (#6137)
+- server: in a remote relationship query, query the remote server only when all of the joining arguments are **not** null (fixes #5448)
 - console: allow user to cascade Postgres dependencies when dropping Postgres objects (close #5109) (#5248)
 - console: mark inconsistent remote schemas in the UI (close #5093) (#5181)
 - console: remove ONLY as default for ALTER TABLE in column alter operations (close #5512) #5706

--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -224,6 +224,7 @@ library
 
                      -- pretty printer
                      , ansi-wl-pprint
+                     , pretty-simple
 
                      -- for capturing various metrics
                      , ekg-core

--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -224,7 +224,6 @@ library
 
                      -- pretty printer
                      , ansi-wl-pprint
-                     , pretty-simple
 
                      -- for capturing various metrics
                      , ekg-core

--- a/server/src-lib/Hasura/Backends/Postgres/Execute/RemoteJoin.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Execute/RemoteJoin.hs
@@ -48,8 +48,6 @@ import           Hasura.RQL.IR.Select
 import           Hasura.RQL.Types
 import           Hasura.Server.Version                  (HasVersion)
 import           Hasura.Session
-import Debug.Pretty.Simple (pTrace, pTraceM)
-
 
 -- | Executes given query and fetch response JSON from Postgres. Substitutes remote relationship fields.
 executeQueryWithRemoteJoins
@@ -385,7 +383,6 @@ traverseQueryResponseJSON rjm =
                          case find ((== fieldName) . _rjName) remoteJoins of
                            Just rj -> Just . CVFromRemote <$> mkRemoteSchemaField fields rj
                            Nothing -> Just <$> traverseValue fieldPath value
-          pTraceM ("processedFields are " <> (show processedFields))
           pure $ CVObject $ OMap.fromList processedFields
 
 convertFieldWithVariablesToName :: G.Field G.NoFragments Variable -> G.Field G.NoFragments G.Name

--- a/server/src-lib/Hasura/Backends/Postgres/Execute/RemoteJoin.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Execute/RemoteJoin.hs
@@ -516,13 +516,12 @@ replaceRemoteFields
 replaceRemoteFields compositeJson remoteServerResponse =
   compositeValueToJSON <$> traverse replaceValue compositeJson
   where
-    -- `Nothing` below signfies that at-least one of the
-    -- joining fields was NULL, when that happens we
-    -- have to manually insert the `NULL` value for the
+    -- `Nothing` below signfies that at-least one of the joining fields was NULL
+    -- , when that happens we have to manually insert the `NULL` value for the
     -- remoteField value in the response.
     replaceValue Nothing = pure $ AO.Null
-    replaceValue (Just (RemoteJoinField _ alias _ fieldCall)) =
-      extractAtPath (alias:fieldCall) $ AO.Object remoteServerResponse
+    replaceValue (Just RemoteJoinField {_rjfAlias, _rjfFieldCall}) =
+      extractAtPath (_rjfAlias:_rjfFieldCall) $ AO.Object remoteServerResponse
 
     -- | 'FieldCall' is path to remote relationship value in remote server response.
     -- 'extractAtPath' traverse through the path and extracts the json value

--- a/server/src-lib/Hasura/Backends/Postgres/Execute/RemoteJoin.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Execute/RemoteJoin.hs
@@ -624,9 +624,8 @@ substituteVariables values = traverse go
   where
     go = \case
       G.VVariable variableName ->
-        case Map.lookup variableName values of
-          Nothing    -> Failure ["Value for variable " <> variableName <<> " not provided"]
-          Just value -> pure value
+        onNothing (Map.lookup variableName values) $
+          Failure ["Value for variable " <> variableName <<> " not provided"]
       G.VList listValue ->
         fmap G.VList (traverse go listValue)
       G.VObject objectValue ->

--- a/server/src-lib/Hasura/Prelude.hs
+++ b/server/src-lib/Hasura/Prelude.hs
@@ -15,6 +15,7 @@ module Hasura.Prelude
   , base64Decode
   , spanMaybeM
   , liftEitherM
+  , hoistMaybe
   -- * Efficient coercions
   , coerce
   , findWithIndex
@@ -179,3 +180,7 @@ startTimer = do
   return $ do
     aft <- liftIO Clock.getMonotonicTimeNSec
     return $ nanoseconds $ fromIntegral (aft - bef)
+
+-- copied from http://hackage.haskell.org/package/errors-2.3.0/docs/src/Control.Error.Util.html#hoistMaybe
+hoistMaybe :: (Monad m) => Maybe b -> MaybeT m b
+hoistMaybe = MaybeT . return

--- a/server/tests-py/queries/remote_schemas/remote_relationships/remote_rel_with_null_joining_fields.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/remote_rel_with_null_joining_fields.yaml
@@ -1,0 +1,31 @@
+description: Remote join with null joining fields
+url: /v1/graphql
+status: 200
+response:
+  data:
+    employees:
+      - id: 1
+        name: alice
+        employeeMessages:
+          - id: 1
+            name: alice
+            msg: You win!
+      - id: 2
+        name: null
+        employeeMessages: null
+      - id: 3
+        name: bob
+        employeeMessages: []
+query:
+  query: |
+    query {
+      employees {
+        id
+        name
+        employeeMessages {
+          id
+          name
+          msg
+        }
+      }
+    }

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup.yaml
@@ -52,3 +52,17 @@ args:
   args:
     schema: public
     name: authors
+
+- type: run_sql
+  args:
+    sql: |
+      create table employees (
+         id serial primary key,
+         name text
+      );
+      insert into employees (name) values ('alice'),(NULL),('bob');
+
+- type: track_table
+  args:
+    schema: public
+    name: employees

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup_remote_rel_null_joining_fields.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup_remote_rel_null_joining_fields.yaml
@@ -1,0 +1,16 @@
+type: create_remote_relationship
+args:
+  name: employeeMessages
+  table: employees
+  hasura_fields:
+    - id
+    - name
+  remote_schema: my-remote-schema
+  remote_field:
+    messages:
+      arguments:
+        where:
+          name:
+            eq: "$name"
+        includes:
+          id: ["$id"]

--- a/server/tests-py/queries/remote_schemas/remote_relationships/teardown.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/teardown.yaml
@@ -15,6 +15,11 @@ args:
     sql: |
       drop table if exists authors
 
+- type: run_sql
+  args:
+    sql: |
+      drop table if exists employees
+
 # also drops remote relationship as direct dep
 - type: remove_remote_schema
   args:

--- a/server/tests-py/test_remote_relationships.py
+++ b/server/tests-py/test_remote_relationships.py
@@ -186,6 +186,11 @@ class TestExecution:
         assert st_code == 200, resp
         check_query_f(hge_ctx, self.dir() + 'basic_multiple_fields.yaml')
 
+    def test_remote_join_fields_with_null_joining_fields(self, hge_ctx):
+        st_code, resp = hge_ctx.v1q_f(self.dir() + 'setup_remote_rel_null_joining_fields.yaml')
+        assert st_code == 200, resp
+        check_query_f(hge_ctx, self.dir() + 'remote_rel_with_null_joining_fields.yaml')
+
     def test_nested_fields(self, hge_ctx):
         st_code, resp = hge_ctx.v1q_f(self.dir() + 'setup_remote_rel_nested_fields.yaml')
         assert st_code == 200, resp


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

fixes #5448 

This PR modifies the way data is joined in remote joins. Earlier, we used to query the remote schema irrespective of the value of the arguments. This PR modifies that behaviour, the remote schema will only be queried when all of the arguments are not null, in case any of the arguments is NULL, then the response of the remote join field will be NULL.

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [x] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [ ] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [ ] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [ ] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [ ] No Breaking changes
- [x] There are breaking changes:
Earlier a remote join query would query the remote schema irrespective of the argument values. Now, when we have any of the joining values as NULL, we output the result as NULL for the remote relationship. 

 <!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
