### PR TITLE
cli: use gitHub API as fallback to get version information in installation script (close #6141)

### DIFF
--- a/cli/get.sh
+++ b/cli/get.sh
@@ -27,12 +27,6 @@ function maybe_sudo() {
     fi
 }
 
-get_latest_release() {
-  curl --silent "https://api.github.com/repos/$1/releases/latest" | 
-    grep '"tag_name":' |                                            
-    sed -E 's/.*"([^"]+)".*/\1/'                                   
-}
-
 # check for curl
 hasCurl=$(which curl)
 if [ "$?" = "1" ]; then


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
Use GitHub API as fallback to get information about latest version when hasura release server is unavialable.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Related Issues
https://github.com/hasura/graphql-engine/issues/6141
