### PR TITLE
cli: force update local plugin index (close #6219)

### DIFF
--- a/cli/util/git.go
+++ b/cli/util/git.go
@@ -107,6 +107,7 @@ func (g *GitUtil) updateAndCleanUntracked() error {
 	}
 	err = wt.Pull(&git.PullOptions{
 		ReferenceName: g.ReferenceName,
+		Force:         true,
 	})
 	if err != nil && err != git.NoErrAlreadyUpToDate {
 		return err


### PR DESCRIPTION
### Description

Fixes https://github.com/hasura/graphql-engine/issues/6219

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] CLI
