### PR TITLE
server: consistently log request_id at the same level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ and be accessible according to the permissions that were configured for the role
 - server: fix issue with non-optional fields of the remote schema being added as optional in the graphql-engine (fix #6401)
 - server: accept new config `allowed_skew` in JWT config to provide leeway for JWT expiry (fixes #2109)
 - server: fix issue with query actions with relationship with permissions configured on the remote table (fix #6385)
+- server: always log the `request_id` at the `detail.request_id` path for both `query-log` and `http-log` (#6244)
 - console: allow user to cascade Postgres dependencies when dropping Postgres objects (close #5109) (#5248)
 - console: mark inconsistent remote schemas in the UI (close #5093) (#5181)
 - console: remove ONLY as default for ALTER TABLE in column alter operations (close #5512) #5706

--- a/docs/graphql/core/deployment/logging.rst
+++ b/docs/graphql/core/deployment/logging.rst
@@ -198,6 +198,7 @@ This is how the HTTP access logs look like:
       "level": "info",
       "type": "http-log",
       "detail": {
+        "request_id": "072b3617-6653-4fd5-b5ee-580e9d098c3d",
         "operation": {
           "query_execution_time": 0.009240042,
           "user_vars": {

--- a/server/src-lib/Hasura/Server/Logging.hs
+++ b/server/src-lib/Hasura/Server/Logging.hs
@@ -203,6 +203,7 @@ data HttpLogContext
   = HttpLogContext
   { hlcHttpInfo  :: !HttpInfoLog
   , hlcOperation :: !OperationLog
+  , hlcRequestId :: !RequestId
   } deriving (Show, Eq)
 $(deriveToJSON (aesonDrop 3 snakeCase) ''HttpLogContext)
 
@@ -236,7 +237,7 @@ mkHttpAccessLogContext userInfoM reqId req res mTiming compressTypeM headers =
            , olRawQuery = Nothing
            , olError = Nothing
            }
-  in HttpLogContext http op
+  in HttpLogContext http op reqId
   where
     status = HTTP.status200
     respSize = Just $ BL.length res
@@ -272,7 +273,7 @@ mkHttpErrorLogContext userInfoM reqId waiReq (reqBody, parsedReq) err mTiming co
            , olRawQuery           = maybe (Just $ bsToTxt $ BL.toStrict reqBody) (const Nothing) parsedReq
            , olError              = Just err
            }
-  in HttpLogContext http op
+  in HttpLogContext http op reqId
 
 data HttpLogLine
   = HttpLogLine


### PR DESCRIPTION
### Description

Before this change, the server is logging requests with a different
shape.

- HTTPLog

```json
{
  "type": "http-log",
  "timestamp": "2020-11-23T17:30:41.782+0100",
  "level": "info",
  "detail": {
    "operation": {
      "query_execution_time": 8.6201e-05,
      "user_vars": {
        "x-hasura-role": "admin"
      },
      "request_id": "f579069a-23fc-4119-b2d8-4bab1a4e29e6",
      "response_size": 347,
      "request_read_time": 3.884e-06
    },
    "http_info": {
      "status": 200,
      "http_version": "HTTP/1.1",
      "url": "/foo",
      "ip": "127.0.0.1",
      "method": "GET",
      "content_encoding": "gzip"
    }
  }
}
```

- QueryLog

```json

{
"detail":  {
  "query": {...}
  "request_id": "90b07309-38c1-483c-800e-9d51bd457797"
...
}
```

Notice that the `request_id` is nested in different levels in both
examples. This makes correlating the requests a bit more difficult than
it should be.

For instance, services like DataDog allow you to extract a json path as
a facet that can be used in searches. Since the `request_id` is at a
different level, it is not possible to correlate using the `request_id`.

After this change, the `HttpLog` will look like

```json
{
"detail":  {
  "http_info" {...}
  "operation" {
    "query_execution_time": 0.001201056,
    "request_id": "e9bd9dd2-f5b3-4e26-9d88-9a39cff5acbb"
    ...
  },
  "request_id": "e9bd9dd2-f5b3-4e26-9d88-9a39cff5acbb"
},
"level": "info",
"timestamp": "2020-11-23T16:48:07.173+0000",
"type":	"http-log"
}
```

The `request_id` is still present in the `operation` key for backward
compatibility.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [ ] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
- [ ] New types and typenames are correlated

#### Breaking changes

- [] No Breaking changes
- [x] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [x] Log `JSON` schema has changed
     - [ ] Log `type` names have changed