### PR TITLE
Fix: GraphiQL clears request after page refresh (close #6521)

### DIFF
--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -3280,6 +3280,7 @@
       "version": "4.6.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.6.tgz",
       "integrity": "sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==",
+      "dev": true,
       "requires": {
         "@types/lodash": "*"
       }

--- a/console/src/components/Services/ApiExplorer/ApiExplorer.js
+++ b/console/src/components/Services/ApiExplorer/ApiExplorer.js
@@ -5,6 +5,7 @@ import Helmet from 'react-helmet';
 import ApiRequestWrapper from './ApiRequestWrapper';
 
 import globals from '../../../Globals';
+import { flatten } from 'lodash';
 
 /*
 import ApiCollectionPanel from './ApiCollectionPanel';
@@ -120,7 +121,9 @@ const generatedApiExplorer = connect => {
       credentials: {},
       dataApiExplorerData: { ...state.dataApiExplorer },
       dataHeaders: state.tables.dataHeaders,
-      tables: state.tables.allSchemas,
+      tables: flatten(
+        state.metadata.metadataObject?.sources.map(s => s.tables)
+      ),
       serverConfig: state.main.serverConfig ? state.main.serverConfig.data : {},
     };
   };


### PR DESCRIPTION
This fixes the issue with graphlQl queries not persisting after refresh. (close #6521)
### Description
This fix ensures that the queries are persisted in LocalStorage and also displayed on refresh/reload.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the`no-changelog-required` label.

### Affected components

- [ ] Server
- [x] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
#6521 

### Steps to test and verify
 - Type and run a graphQl query in the console
 - Refresh the page
 - If the query is persisted, then it works.

### Limitations, known bugs & workarounds
I'm not sure this is a limitation, but this PR used `flatten` from `lodash`. Array.prototype.flatMap might have been better but out typescript lib typedefs doesn't include it yet.

Does this PR add a new Metadata feature?
- [X] No

#### GraphQL
- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No Breaking changes

