### PR TITLE
install manifests: persist caddy certificates

### DIFF
--- a/install-manifests/docker-compose-https/docker-compose.yaml
+++ b/install-manifests/docker-compose-https/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
     - "443:443"
     volumes:
     - ./Caddyfile:/etc/caddy/Caddyfile
-    - caddy_certs:/root/.caddy
+    - caddy_certs:/data
 volumes:
   db_data:
   caddy_certs:


### PR DESCRIPTION
Caddy v2 uses the `/data` directory. 

I was restarting my containers a few times while testing and I noticed that https randomly stopped working. Caddy did not persist the certificate and I was being rate limited by let's encrypt. 