### PR TITLE
docs: fix typo

### DIFF
--- a/docs/graphql/core/auth/authorization/inherited-roles.rst
+++ b/docs/graphql/core/auth/authorization/inherited-roles.rst
@@ -154,7 +154,7 @@ Let's take the example of an ``users`` table with the following columns:
 
 There are two roles defined namely ``employee`` and ``manager``.
 
-1. User role - The user role will be able to able to access all columns of their row  when the session variable ``X-Hasura-User-Id`` is equal to the ``id``.
+1. User role - The user role will be able to access all columns of their row  when the session variable ``X-Hasura-User-Id`` is equal to the ``id``.
 
 2. Anonymous role - The anonymous role will be able to access only the ``id`` and ``name`` columns of all the users.
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
There's a typo in inherited role document. "The user role will **be able to able to** access"

### Changelog

### Affected components

- [x] Docs

#### Metadata

Does this PR add a new Metadata feature?
- [x] No


#### GraphQL
- [x] No new GraphQL schema is generated
#### Breaking changes

- [x] No Breaking changes
