### PR TITLE
Update Auth0 Docs if using SPA's and regular web app

### DIFF
--- a/docs/graphql/core/guides/integrations/auth0-jwt.rst
+++ b/docs/graphql/core/guides/integrations/auth0-jwt.rst
@@ -75,6 +75,28 @@ For auth0-spa-js:
       callback(null, user, context);
     }
 
+If you use both SDKs:
+
+.. code-block:: javascript
+
+    function (user, context, callback) {
+      const namespace = "https://hasura.io/jwt/claims";
+      const tokenConfig = {
+          'x-hasura-default-role': 'user',
+          // do some custom logic to decide allowed roles
+          'x-hasura-allowed-roles': ['user'],
+          'x-hasura-user-id': user.user_id
+        };
+
+      if (context.auth0_client.name === 'auth0-react') {
+         context.accessToken[namespace] = tokenConfig;
+      } else {
+         context.idToken[namespace] = tokenConfig;
+      }
+
+      callback(null, user, context);
+    }
+
 .. _test-auth0:
 
 Create an Auth0 API

--- a/docs/graphql/core/guides/integrations/auth0-jwt.rst
+++ b/docs/graphql/core/guides/integrations/auth0-jwt.rst
@@ -88,6 +88,7 @@ If you use both SDKs:
           'x-hasura-user-id': user.user_id
         };
 
+      // Replace with library client name
       if (context.auth0_client.name === 'auth0-react') {
          context.accessToken[namespace] = tokenConfig;
       } else {


### PR DESCRIPTION
### Description
There are separate instructions on creating a rule for the SPA flow and the Regular Web Application flow. 
This adds documentation if a user has both types of applications.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

^ Would this be required for this PR?

### Affected components

- [x] Docs

### Solution and Design

I switch on the client type. It would be better if I could switch on the app type (e.g. if SPA) but I didn't see a way to do that.

I've include auth0-react as an example instructing the user to replace with the library client name.

Alternatively, we could instruct the user to switch on the client name `context.clientName`.

### Steps to test and verify

Follow the documentation and create both types of applications.
