### PR TITLE
Basic ARM64 support

### DIFF
--- a/cli-ext/package.json
+++ b/cli-ext/package.json
@@ -4,7 +4,7 @@
   "description": "A service to generate Hasura action scaffolds",
   "main": "src/server.js",
   "scripts": {
-    "get-shared-modules": "rm -rf src/shared && cp ../console/src/shared ./src/shared -r",
+    "get-shared-modules": "rm -rf src/shared && cp -R ../console/src/shared ./src/shared",
     "pretranspile": "npm run get-shared-modules",
     "transpile": "rm -rf build/* && babel --extensions '.ts,.js' ./src ./tests --out-dir build",
     "prebuild": "npm run transpile",

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -3,6 +3,7 @@ PARENT_DIR := $(shell dirname $(PWD))
 VERSION ?= $(shell ../scripts/get-version.sh)
 PLUGINS_BRANCH ?= master
 OS ?= linux darwin windows
+ARCH ?= amd64
 OUTPUT_DIR := _output
 
 HAS_GOX := $(shell command -v gox;)
@@ -39,7 +40,7 @@ endif
 	gox -ldflags '-X github.com/hasura/graphql-engine/cli/version.BuildVersion=$(VERSION) -X github.com/hasura/graphql-engine/cli/plugins.IndexBranchRef=$(PLUGINS_BRANCH) -s -w -extldflags "-static"' \
 	-rebuild \
 	-os="$(OS)" \
-	-arch="amd64" \
+	-arch="$(ARCH)" \
 	-output="$(OUTPUT_DIR)/$(VERSION)/cli-hasura-{{.OS}}-{{.Arch}}" \
 	./cmd/hasura/
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -26,6 +26,7 @@ go get github.com/hasura/graphql-engine/cli/cmd/hasura
 git clone https://github.com/hasura/graphql-engine
 cd graphql-engine/cli
 make deps
+make build-cli-ext
 make build
 # binaries will be in _output directory
 ```


### PR DESCRIPTION
### Description

Attempt to add early support for linux-arm64 and macos-arm64 (Apple Silicon).

Compilation steps for compiling on Apple Silicon:
```sh
cd cli

# Work around for `make build-cli-ext`
npm install -g pkg@5
cd ../cli-ext
npm run prebuild
pkg ./build/command.js --output ./bin/cli-ext-hasura-macos -t node14-macos-arm64

cd -
make deps
OS=$(go env GOHOSTOS) ARCH=$(go env GOHOSTARCH) make build
_output/*/cli-hasura-$(go env GOHOSTOS)-$(go env GOHOSTARCH) version
```

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [x] CLI
- [ ] Docs
- [ ] Community Content
- [x] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues

- https://github.com/hasura/graphql-engine/issues/6680
- https://github.com/hasura/graphql-engine/issues/6433

### Solution and Design

Provides limited support for specifying the architecture when building the cli instead of just hardcoding "amd64"

### Steps to test and verify

I've only verified that the application compiles and runs. The contribution guide on running the tests appears out of date and I'm hoping the CI test are functional.

### Limitations, known bugs & workarounds

Currently `make build-cli-ext` isn't working on ARM64 platforms. Adding in the ARM targets to the cli-ext build results in `Failed to make bytecode node14-arm64` on AMD64 which is why I haven't made modifications there at the moment.

#### Breaking changes

- [x] No Breaking changes
