### PR TITLE
Update hasura_completion.rst

### DIFF
--- a/docs/graphql/core/hasura-cli/hasura_completion.rst
+++ b/docs/graphql/core/hasura-cli/hasura_completion.rst
@@ -49,8 +49,10 @@ Examples
         # restart git bash
 
     # Zsh (using oh-my-zsh)
-      $ mkdir -p $HOME/.oh-my-zsh/completions
-      $ hasura completion zsh --file=$HOME/.oh-my-zsh/completions/_hasura
+      $ mkdir -p $HOME/.oh-my-zsh/plugins/hasura
+      $ hasura completion zsh --file=$HOME/.oh-my-zsh/plugins/hasura/_hasura
+      # Add hasura to zsh plugins list e.g: 
+      plugins=(git yarn hasura)
 
     # Reload the shell for the changes to take effect!
 


### PR DESCRIPTION
.oh-my-zsh completions folder does not seems to work for autocompleting on the latest version.
Adding it into the plugin, then adding the plugin to zsh `plugins` does the trick.

I got inspired to try that from from this project: https://github.com/g-plane/zsh-yarn-autocompletions.

