### PR TITLE
fix: modifying action comment - allow whitespace, close #6897

### DIFF
--- a/console/src/components/Services/Actions/Modify/ActionEditor.js
+++ b/console/src/components/Services/Actions/Modify/ActionEditor.js
@@ -110,7 +110,7 @@ const ActionEditor = ({
   }
 
   const updateActionComment = e =>
-    dispatch(setActionComment(e.target.value?.trim()));
+    dispatch(setActionComment(e.target.value));
 
   return (
     <div>
@@ -140,7 +140,7 @@ const ActionEditor = ({
         <h2
           className={`${styles.subheading_text} ${styles.add_mar_bottom_small}`}
         >
-          Comment
+          Comment hehehe
         </h2>
         <input
           type="text"


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
Fix: when modifying action comment, allow whitespace

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Console

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
close #6897 

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Modify comment, should now be allowed to use spaces as you type.
