### PR TITLE
docs: fix migrate apply example

### DIFF
--- a/cli/commands/migrate_apply.go
+++ b/cli/commands/migrate_apply.go
@@ -57,7 +57,7 @@ func newMigrateApplyCmd(ec *cli.ExecutionContext) *cobra.Command {
   hasura migrate apply --goto 125
   
   # Apply all down migrations upto version 125, last applied is 150
-  hasura migrate apply --goto 125
+  hasura migrate apply --type down --goto 125
 
   # Rollback a particular version:
   hasura migrate apply --type down --version "<version>"

--- a/docs/graphql/core/hasura-cli/hasura_migrate_apply.rst
+++ b/docs/graphql/core/hasura-cli/hasura_migrate_apply.rst
@@ -52,7 +52,7 @@ Examples
     hasura migrate apply --goto 125
     
     # Apply all down migrations upto version 125, last applied is 150
-    hasura migrate apply --goto 125
+    hasura migrate apply --type-down --goto 125
 
     # Rollback a particular version:
     hasura migrate apply --type down --version "<version>"


### PR DESCRIPTION
### Description
The example for applying all down migrations up to a certain migration version is missing a `--type` flag

### Changelog

### Affected components

- [x] CLI
- [x] Docs


#### Metadata
Does this PR add a new Metadata feature?
- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No Breaking changes
