### PR TITLE
Clarify many-to-many foreign key section in documentation

### DIFF
--- a/docs/graphql/core/guides/data-modelling/many-to-many.rst
+++ b/docs/graphql/core/guides/data-modelling/many-to-many.rst
@@ -49,13 +49,13 @@ This ``many-to-many`` relationship can be established in the database by:
    .. code-block:: sql
 
       article_tag (
+        id SERIAL PRIMARY KEY
         article_id INT
         tag_id INT
-        PRIMARY KEY (article_id, tag_id)
         ...
       )
 
-2. Adding **foreign key constraints** from the ``article_tag`` table to:
+2. Adding **foreign key constraints** in the ``article_tag`` table for:
 
    - the ``articles`` table using the ``article_id`` and ``id`` columns of the tables respectively
    - the ``tags`` table using the ``tag_id`` and ``id`` columns of the tables respectively


### PR DESCRIPTION
### Description
I think clarification in the foreign key section is necessary. Foreign keys are meant to be added in the join table, not on each table to be joined. If you attempt to add foreign keys to the individual tables you get an error that is difficult to parse.

Also in some cases, a join table could join two objects more than once and therefore using a primary key might be best. This portion might not need changing, but in my application it would not work to have the primary key not be unique.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components

- [x] Docs


********************
This is my first time contributing here, or anywhere! I attempted to read through guidelines and do things correctly, but if I failed to do so, please help me along. Thanks! I wasn't able to add the label myself from what I can tell to say `no-changelog-required`. I can see them now on the reviewers column but unable to add anything.
