### PR TITLE
[Research] Add toxicity detection pipeline

### DIFF
--- a/.github/workflows/toxicity-check-job.yml
+++ b/.github/workflows/toxicity-check-job.yml
@@ -1,0 +1,48 @@
+name: 'Toxicity check'
+on: 
+  issue_comment:
+    types: ['created', 'edited', 'deleted']
+  pull_request_review:
+  pull_request_review_comment:
+  issues:
+    types: ['opened', 'edited', 'deleted', 'closed', 'reopened', 'locked', 'unlocked']
+  pull_request:
+    types: ['opened', 'edited', 'closed', 'reopened', 'locked', 'unlocked']
+
+# This job dispatches the Github event to the API that
+# performs the toxicity check. 
+# 
+# The silent variable in the JSON can be used to control
+# whether the bot should post a message if it detects 
+# toxicity. If silent is set to true, the github events
+# will only be logged such that we can use the data for our study.
+# 
+# The message is the message that is posted by the bot if 
+# it detects toxicity and silent is set to false. You can
+# for instance modify this to link the community code of 
+# conduct. 
+#
+# Lastly a log key unique to this project is sent in the 
+# header of the request. 
+#
+jobs:
+  toxic-check-job:
+    runs-on: ubuntu-latest
+    name: Toxicity check job
+    steps:
+      - name: Trigger API
+        run: |
+          # By using a here doc we can safely store the json 
+          # event body in a bash variable. 
+          event_body=$(cat <<-"EOFToxic"
+              {
+                "silent": true,
+                "message": "Please refrain from using toxic language in this repository.",
+                "pipeline_trigger": ${{ toJSON(github) }}
+              }
+          EOFToxic
+                )
+
+          curl -s -X POST https://toxic.research.cassee.dev/curl \
+            -d "$event_body" \
+            -H "Log-Key: d178e2f1-a426-4048-a2bb-43e58749be8b" \


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description

We’re Nathan Cassee and Alexander Serebrenik (Eindhoven University of Technology, The Netherlands), Nicole Novielli (University of Bari, Italy), Christian Kastner (Carnegie Mellon University, USA), and Bogdan Vasilescu (Carnegie Mellon University, USA). And we are conducting research to understand the effectiveness of toxicity detection bots on GitHub. As part of our research we want to understand the impact of a state of the art toxicity detection bot in your project. We hope that a better knowledge and understanding of how these toxicity bots operate can be used to further improve the health of open-source projects.

To participate in this experiment we ask you to adopt a toxicity bot in hasura/graphql-engine. You can adopt the bot by merging this pull-request. This bot will monitor issues and pull-requests for comments containing toxicity, and will post a comment if it detects toxicity using the GH account @ToxicityDetectionBot. Additionally, the bot will securely store comments and edits or deletions made to those comments. This will allow us to study the frequency of toxic comments, and whether and how toxic comments are edited or deleted.

We expect that the toxicity bot reduces toxicity in issues or in pull-requests. However, there might be cases where the bot responds in issues or pull-requests where there is no toxicity (a false positive) and this might distract on-topic discussions. 

Even if your project does not frequently see toxic activity (this is the case for most GH projects!) we are still interested in your participation! 


### Affected components

- [X] Build System

### Related Issues


**NB:** I did not open an issue, please let me know if that is required. 

### Practicalities

Your participation in this study is completely voluntary, at any point in time you can retract your project from this study. This can be done by disabling the toxicity bot, or by sending us an email. Additionally, if you don’t want us to use the results of your project in the analysis of the study, you can always email us to inform us that you want to retract your data from the study. 

The study itself will run for roughly three months, at the end of this time we will open a PR in your project to remove the toxicity bot from the project. If after the experiment you want to keep using the toxicity bot we can also provide you with a version of the toxicity bot that does not record telemetry. 

The data collected for this study will be stored securely on a private server, and the raw data will only be available to the researchers involved in this study. When we release or publicize results of the study the results will be released anonymously or in an aggregated way. Additionally, we will not list the projects that participated in this study, nor will will we release or report on any information that can be used to compare whether one project is more toxic than the other. 

This study has been approved by the Ethical Review Board of the Eindhoven University of Technology. 


#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [X] No
- [ ] Yes

Does this PR add a new Metadata feature?
- [X] No
- [ ] Yes


#### GraphQL
- [X] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated

#### Breaking changes

- [X] No Breaking changes
- [ ] There are breaking changes:

## Closing and Survey

If you have any questions about the bot feel free to ask them here, or mail them to n.w.cassee@tue.nl. 

If you are not interested in participating we would really appreciate it if you would let us know why you are not participating. 

Secondly, it would be really helpful if everyone involved in the project could respond to the following survey on your expectations of the bot, especially if you are not interested in adopting the bot (https://docs.google.com/forms/d/e/1FAIpQLSfI7oz6jbqy74wAllQaWP3HQMJvssGfN08Judv-mSlyOYxF4A/viewform)!

**Note**: We are not sure how best to approach projects to participate in this study, if you thought this PR was spammy, or unhelpful, please let us know so we can modify how we invite project!

