### PR TITLE
console: export metadata before tracking new table (fix #6805) (fix #7233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - server: fix inherited roles bug where mutations were not accessible when inherited roles was enabled
 - server: reintroduce the unique name constraint in allowed lists
 - server: subscriptions now validate that all session variables are properly set (#7111)
+- console: fix metadata out-of-date errors when creating tables with certain configurations (fix #6805) (fix #7233)
 - cli-migrations-v2: fix database url showing up in metadata (#7319)
 
 ## v2.0.4

--- a/console/src/components/Services/Data/Add/AddActions.js
+++ b/console/src/components/Services/Data/Add/AddActions.js
@@ -13,6 +13,7 @@ import {
   escapeTableName,
 } from '../../../../dataSources/common';
 import { getRunSqlQuery } from '../../../Common/utils/v1QueryUtils';
+import { exportMetadata } from '../../../../metadata/actions';
 import {
   getTrackTableQuery,
   getUntrackTableQuery,
@@ -267,7 +268,9 @@ const createTableSql = () => {
     const errorMsg = 'Create table failed';
 
     const customOnSuccess = () => {
-      dispatch(trackTable({ schema: currentSchema, name: tableName }));
+      dispatch(exportMetadata()).then(() => {
+        dispatch(trackTable({ schema: currentSchema, name: tableName }));
+      });
     };
     const customOnError = err => {
       dispatch({ type: REQUEST_ERROR, data: errorMsg });


### PR DESCRIPTION
### Description
Table creation actions that execute additional modifying statments trigger the server to bump the metadata `resource_version`, even if the metadata hasn't actually changed (bug #7324).

The current console table creation logic doesn't refetch the metadata before tracking a table that has been created, which can lead to metadata out-of-date errors and the newly created table not getting tracked in this scenario.

### Changelog

- [X] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [X] Console

### Related Issues
#6805, #7221, #7233, #7324

### Solution and Design
This change triggers the console to refetch the metadata before tracking a newly created table (thus updating the `resource_version`) and preventing metadata `resource_version` mismatches caused by server-side updates to the metadata table.

This change mimics the behavior of the Raw SQL action for table creation in the console, which triggers `export_metadata` before tracking any new items.

Even if #7324 is fixed, I think it's good practice to refetch the metadata immediately before trying to update it.

### Steps to test and verify
Verify the fix by creating a table in the console with either a comment or an `updated_at` field trigger set during creation; with the fix applied the table will be created and tracked without throwing a metadata out-of-date error.

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [X] No

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [X] No

#### GraphQL
- [X] No new GraphQL schema is generated

#### Breaking changes

- [X] No Breaking changes
