### PR TITLE
Initial cli --api-host arg changes

### DIFF
--- a/cli/commands/console.go
+++ b/cli/commands/console.go
@@ -58,6 +58,7 @@ func NewConsoleCmd(ec *cli.ExecutionContext) *cobra.Command {
 	f := consoleCmd.Flags()
 
 	f.StringVar(&opts.APIPort, "api-port", "9693", "port for serving migrate api")
+	f.StringVar(&opts.APIHost, "api-host", "http://localhost", "host serving migrate api")
 	f.StringVar(&opts.ConsolePort, "console-port", "9695", "port for serving console")
 	f.StringVar(&opts.Address, "address", "localhost", "address to serve console and migration API from")
 	f.BoolVar(&opts.DontOpenBrowser, "no-browser", false, "do not automatically open console in browser")
@@ -86,6 +87,7 @@ type ConsoleOptions struct {
 	EC *cli.ExecutionContext
 
 	APIPort     string
+	APIHost     string
 	ConsolePort string
 	Address     string
 
@@ -125,7 +127,7 @@ func (o *ConsoleOptions) Run() error {
 	}
 
 	consoleRouter, err := console.BuildConsoleRouter(templateProvider, consoleTemplateVersion, o.StaticDir, gin.H{
-		"apiHost":              "http://" + o.Address,
+		"apiHost":              o.APIHost,
 		"apiPort":              o.APIPort,
 		"cliVersion":           o.EC.Version.GetCLIVersion(),
 		"serverVersion":        o.EC.Version.GetServerVersion(),


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
This adds a `--api-host` argument to the cli to allow you to pass in a custom url.  Great for working with Codespaces.

### Changelog

(Pending)
- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components

- [x] CLI

### Related Issues
(pending)

### Solution and Design
Allows you to use Hasura with Github Codespaces, as currently you need make the url public which uses a url like `${CODESPACE_NAME}-9694.githubpreview.dev`

### Steps to test and verify
(pending)

### Limitations, known bugs & workarounds
Currently the Hasura console frontend code hard codes `:9693` onto the api host url https://github.com/hasura/graphql-engine/blob/fed7f71aa20ed9804b75f26dfe9d7d02852d9e51/console/src/Endpoints.ts#L7, this needs to be removed if a custom url is present as Codespaces does not allow you to append ports to their public urls.

### Server checklist
n/a

#### Catalog upgrade
Does this PR change Hasura Catalog version?
- [x] No

#### Metadata
Does this PR add a new Metadata feature?
- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes: