### PR TITLE
[Hasura CLI]: fix possible typo "depricated" to "deprecated"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - server: add support for `connection_parameters` on `pg_add_source` API
 - cli: add progress bar for `migrate apply` command (#4795)
 - cli: embed cli-ext for windows binaries (#7509)
+- cli: fix typo on deprecated warnings (#7527)
 
 ## v2.0.8
 

--- a/cli/commands/migrate_create.go
+++ b/cli/commands/migrate_create.go
@@ -49,10 +49,10 @@ func newMigrateCreateCmd(ec *cli.ExecutionContext) *cobra.Command {
 		Args:         cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if cmd.Flags().Changed("metadata-from-server") {
-				return fmt.Errorf("metadata-from-server flag is depricated")
+				return fmt.Errorf("metadata-from-server flag is deprecated")
 			}
 			if cmd.Flags().Changed("metadata-from-file") {
-				return fmt.Errorf("metadata-from-file flag is depricated")
+				return fmt.Errorf("metadata-from-file flag is deprecated")
 			}
 			if err := validateConfigV3Flags(cmd, ec); err != nil {
 				if errors.Is(err, errDatabaseNotFound) {


### PR DESCRIPTION
### Description
Small typo fix in the CLI on a deprecated warning.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components

- [x] CLI
