### PR TITLE
Install CLI v2.0.9 by default instead of v2.0.6

### DIFF
--- a/cli/get.sh
+++ b/cli/get.sh
@@ -44,7 +44,7 @@ log "Selecting version..."
 # version=${VERSION:-`echo $(curl -s -f -H 'Content-Type: application/json' \
     # https://releases.hasura.io/graphql-engine?agent=cli-get.sh) | sed -n -e "s/^.*\"$release\":\"\([^\",}]*\)\".*$/\1/p"`}
 
-version=${VERSION:-v2.0.6}
+version=${VERSION:-v2.0.9}
 
 if [ ! $version ]; then
     log "${YELLOW}"
@@ -62,7 +62,7 @@ log "Selected version: $version"
 
 log "${YELLOW}"
 log NOTE: Install a specific version of the CLI by using VERSION variable
-log 'curl -L https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh | VERSION=v2.0.6 bash'
+log 'curl -L https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh | VERSION=v2.0.8 bash'
 log "${NC}"
 
 # check for existing hasura installation


### PR DESCRIPTION
I noticed that if you don't specify a specific version, you get v2.0.6 by default. This changes it so that you get v2.0.9 by default

### Description
It looks like the tag-release script used to auto-update the default version in get.sh but that functionality was removed in 28c7a1d0d0283413d304ebae4aa476d39fbdab75 -- I'm not sure why.

### Affected components

- [ ] CLI (installation process)