### PR TITLE
Updated Relay dead link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -947,7 +947,7 @@ If you do have such headers configured, then you must update the header configur
 
 ### Relay
 
-The Hasura GraphQL Engine serves [Relay](https://relay.dev/en/) schema for Postgres tables which has a primary key defined.
+The Hasura GraphQL Engine serves [Relay](https://relay.dev/) schema for Postgres tables which has a primary key defined.
 
 The Relay schema can be accessed through `/v1beta1/relay` endpoint.
 


### PR DESCRIPTION
Updated Relay dead link in CHANGELOG.md
https://relay.dev/en/ ❌ 
https://relay.dev/ ✔️ 