### PR TITLE
server: recreate event triggers on startup only when the source catalog is migrated

### DIFF
--- a/server/CONTRIBUTING.md
+++ b/server/CONTRIBUTING.md
@@ -292,6 +292,15 @@ This naming convention enables easier test filtering with [pytest command line f
 
 The backend-specific and common test suites are disjoint; for example, run `pytest --integration -k "Common or MySQL" --backend mysql` to run all MySQL tests.
 
+#### Building with profiling
+
+To build with profiling support, you need to both enable profiling via `cabal`
+and set the `profiling` flag. E.g.
+
+```
+cabal build exe:graphql-engine -f profiling --enable-profiling
+```
+
 ### Create Pull Request
 
 - Make sure your commit messages meet the [guidelines](../CONTRIBUTING.md).

--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -118,7 +118,6 @@ library
                      , either
                      , exceptions
                      , fast-logger
-                     , ghc-heap-view
                      , hashable
                      , hashable-time
                      , http-client-tls
@@ -289,6 +288,10 @@ library
                      -- mysql
                      , mysql
                      , mysql-simple
+
+  if !flag(profiling)
+    -- ghc-heap-view can't be built with profiling
+    build-depends:     ghc-heap-view
 
   exposed-modules:     Control.Arrow.Extended
                      , Control.Arrow.Trans

--- a/server/src-lib/GHC/AssertNF/CPP.hs
+++ b/server/src-lib/GHC/AssertNF/CPP.hs
@@ -3,6 +3,29 @@
 -- | GHC.AssertNF.CPP localizes our use of CPP around calls
 -- to 'assertNFHere', primarily to give tooling (e.g. ormolu)
 -- an easier time.
+--
+-- We disable the 'assertNF'-related code because it is provided
+-- by the package ghc-heap-view, which can't be built using profiling.
+
+#ifdef PROFILING
+
+module GHC.AssertNF.CPP
+  ( assertNFHere,
+    disableAssertNF,
+  )
+where
+
+import Hasura.Prelude
+import Language.Haskell.TH
+
+assertNFHere :: Q Exp
+assertNFHere = [| const (return ()) |]
+
+disableAssertNF :: IO ()
+disableAssertNF = return ()
+
+#else
+
 module GHC.AssertNF.CPP
   ( assertNFHere,
     disableAssertNF,
@@ -13,14 +36,9 @@ where
 import GHC.AssertNF qualified
 import Hasura.Prelude
 import Language.Haskell.TH
-#ifndef PROFILING
-import           Text.Printf         (printf)
-#endif
+import Text.Printf (printf)
 
 assertNFHere :: Q Exp
-#ifdef PROFILING
-assertNFHere = [| const (return ()) |]
-#else
 -- This is a copy of 'GHC.AssertNF.assertNFHere'. We can't easily
 -- use the original because that relies on an import of "GHC.AssertNF".
 -- Instead, we rewrite it to use the re-exported 'assertNFNamed'.
@@ -32,11 +50,8 @@ assertNFHere = do
         formatLoc loc = let file = loc_filename loc
                             (line, col) = loc_start loc
                         in  printf "parameter at %s:%d:%d" file line col
-#endif
 
 disableAssertNF :: IO ()
-#ifdef PROFILING
-disableAssertNF = return ()
-#else
 disableAssertNF = GHC.AssertNF.disableAssertNF
+
 #endif


### PR DESCRIPTION
<!--
Template usage:
  * "✍️" and "✅❎" are writing prompt markers.
  * "✍️" indicates that a section should be expanded on or _elided_.
  * "✅❎" indicates that a choice between ✅ and ❎ should be made or _elided_.
  * When you are done editing, please ensure all writing prompt markers have been acted on.
-->

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^ -->

### Description ✍️
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

Currently, when the graphql-engine starts up, if any event triggers exist in the source then its recreated on startup, even though it's not needed. The expected behaviour is to recreate the event triggers only when there are any catalog migrations otherwise to do nothing. Since, we introduced per source catalog migration, this bug was introduced. This PR now fixes this behaviour to recreate event triggers on startup only when there are source catalog migrations to be done.

### Changelog ✍️

- ✅ `CHANGELOG.md` is updated with user-facing content relevant to this PR.
  If no changelog is required, then add the `no-changelog-required` label.

### Affected components ✍️
<!-- Remove non-affected components from the list -->

- ✅ Server

### Related Issues ✍
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design ✍
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify ✍
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

1. Run postgres which logs all the queries run.

```yaml
version: '3.6'
services:
  postgres:
    image: postgres:12
    restart: always
    ports:
      - "7432:5432"
    volumes:
    - db_data:/var/lib/postgresql/data
    command:
      - "-clog_statement=all"
    environment:
      POSTGRES_PASSWORD: postgrespassword
volumes:
  db_data:
```

Sample docker-compose file to setup postgres with logging.

2. Create an event trigger and then restart the graphql-engine.
3. Expected: There will be no event trigger DDLs logged.

### Limitations, known bugs & workarounds ✍
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist ✍
<!-- A checklist for server code -->

#### Catalog upgrade ✍
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- ✅❎ No
- ✅❎ Yes
  - ✅❎ Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/latest/graphql/core/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata ✍
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- ✅❎ No
- ✅❎ Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - ✅❎ Yes
    - ✅❎ Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - ✅❎ Yes
    - ✅❎ Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - ✅❎ Yes
    - ✅❎ Not required


#### GraphQL ✍
- ✅❎ No new GraphQL schema is generated
- ✅❎ New GraphQL schema is being generated:
   - ✅❎ New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes ✍

- ✅❎ No Breaking changes
- ✅❎ There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - ✅❎ Modify `args` payload which is not backward compatible
     - ✅❎ Behavioural change of the API
     - ✅❎ Change in response `JSON` schema
     - ✅❎ Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - ✅❎ Change in any `NamedType`
     - ✅❎ Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - ✅❎ Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - ✅❎ Log `JSON` schema has changed
     - ✅❎ Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->



---

### Kodiak commit message
Information used by [Kodiak bot](https://kodiakhq.com/) while merging this PR.

#### Commit title
Same as the title of this pull request

#### Commit body
(Append below if you want to add something to the commit body)
<!-- kodiak-commit-message-body-start: do not remove/edit this line -->
