### PR TITLE
make pg_table_metadata CockroachDB compatible

### DIFF
--- a/server/src-rsr/pg_table_metadata.sql
+++ b/server/src-rsr/pg_table_metadata.sql
@@ -59,28 +59,28 @@ LEFT JOIN LATERAL
       'constraint', jsonb_build_object('name', class.relname, 'oid', class.oid :: integer),
       'columns', coalesce(columns.info, '[]')
     ) AS info
-    FROM pg_catalog.pg_index index
+    FROM pg_catalog.pg_index idx
     JOIN pg_catalog.pg_class class
-      ON class.oid = index.indexrelid
+      ON class.oid = idx.indexrelid
     LEFT JOIN LATERAL
       ( SELECT jsonb_agg("column".attname) AS info
         FROM pg_catalog.pg_attribute "column"
         WHERE "column".attrelid = "table".oid
-          AND "column".attnum = ANY (index.indkey)
+          AND "column".attnum = ANY (idx.indkey)
       ) AS columns ON true
-    WHERE index.indrelid = "table".oid
-      AND index.indisprimary
+    WHERE idx.indrelid = "table".oid
+      AND idx.indisprimary
   ) primary_key ON true
 
 -- unique constraints
 LEFT JOIN LATERAL
   ( SELECT jsonb_agg(jsonb_build_object('name', class.relname, 'oid', class.oid :: integer)) AS info
-    FROM pg_catalog.pg_index index
+    FROM pg_catalog.pg_index idx
     JOIN pg_catalog.pg_class class
-      ON class.oid = index.indexrelid
-    WHERE index.indrelid = "table".oid
-      AND index.indisunique
-      AND NOT index.indisprimary
+      ON class.oid = idx.indexrelid
+    WHERE idx.indrelid = "table".oid
+      AND idx.indisunique
+      AND NOT idx.indisprimary
   ) unique_constraints ON true
 
 -- foreign keys


### PR DESCRIPTION
### Description

CockroachDB doesn't support `index` as a table alias, but PostgreSQL
does. Since `idx` is supported by both, change the metadata query
accordingly.


<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Changelog

No changelog required, but can't set a label.

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
- [x] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues

Refs https://github.com/cockroachdb/cockroach/issues/72407

### Solution and Design

See description.

### Steps to test and verify
Existing tests should pass.
