### PR TITLE
Use proxy if env vars set (close #7781)

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -325,11 +325,34 @@ func (s *ServerConfig) SetTLSConfig() error {
 	return nil
 }
 
+// isProxyEnvSet - returns true if any of the Proxy env variables are set.  If they are set, then the http client will
+// use the proxy in the transport.
+func isProxyEnvSet() bool {
+	if isEnvSet("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy") {
+		return true
+	}
+
+	return false
+}
+
+// isEnvSet - returns true if ANY of the environment variables passed in are set
+func isEnvSet(names ...string) bool {
+	for _, n := range names {
+		if val := os.Getenv(n); val != "" {
+			return true
+		}
+	}
+	return false
+}
+
 // SetHTTPClient - sets the http client
 func (s *ServerConfig) SetHTTPClient() error {
 	s.HTTPClient = &http.Client{Transport: http.DefaultTransport}
 	if s.TLSConfig != nil {
 		tr := &http.Transport{TLSClientConfig: s.TLSConfig}
+		if isProxyEnvSet() {
+			tr.Proxy = http.ProxyFromEnvironment
+		}
 		s.HTTPClient.Transport = tr
 	}
 	return nil
@@ -758,11 +781,14 @@ func (ec *ExecutionContext) Validate() error {
 		ec.SetHGEHeaders(headers)
 	}
 
+	tr := &http.Transport{TLSClientConfig: ec.Config.TLSConfig}
+	if isProxyEnvSet() {
+		tr.Proxy = http.ProxyFromEnvironment
+	}
+
 	httpClient, err := httpc.New(
 		&http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: ec.Config.TLSConfig,
-			},
+			Transport: tr,
 		},
 		ec.Config.Endpoint,
 		headers,

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -325,34 +325,12 @@ func (s *ServerConfig) SetTLSConfig() error {
 	return nil
 }
 
-// isProxyEnvSet - returns true if any of the Proxy env variables are set.  If they are set, then the http client will
-// use the proxy in the transport.
-func isProxyEnvSet() bool {
-	if isEnvSet("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy") {
-		return true
-	}
-
-	return false
-}
-
-// isEnvSet - returns true if ANY of the environment variables passed in are set
-func isEnvSet(names ...string) bool {
-	for _, n := range names {
-		if val := os.Getenv(n); val != "" {
-			return true
-		}
-	}
-	return false
-}
-
 // SetHTTPClient - sets the http client
 func (s *ServerConfig) SetHTTPClient() error {
 	s.HTTPClient = &http.Client{Transport: http.DefaultTransport}
 	if s.TLSConfig != nil {
 		tr := &http.Transport{TLSClientConfig: s.TLSConfig}
-		if isProxyEnvSet() {
-			tr.Proxy = http.ProxyFromEnvironment
-		}
+		tr.Proxy = http.ProxyFromEnvironment
 		s.HTTPClient.Transport = tr
 	}
 	return nil
@@ -781,14 +759,12 @@ func (ec *ExecutionContext) Validate() error {
 		ec.SetHGEHeaders(headers)
 	}
 
-	tr := &http.Transport{TLSClientConfig: ec.Config.TLSConfig}
-	if isProxyEnvSet() {
-		tr.Proxy = http.ProxyFromEnvironment
-	}
-
 	httpClient, err := httpc.New(
 		&http.Client{
-			Transport: tr,
+			Transport: &http.Transport{
+				TLSClientConfig: ec.Config.TLSConfig,
+				Proxy:           http.ProxyFromEnvironment,
+			},
 		},
 		ec.Config.Endpoint,
 		headers,


### PR DESCRIPTION
### Description
If there is a proxy set using the well known proxy environment variables (HTTPS_PROXY, https_proxy, HTTP_PROXY, http_proxy, NO_PROXY) use the proxy when connecting to a TLS protected endpoint.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components

- [x] CLI

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#7781

### Solution and Design
In the default transport used in the SetHTTPClient function, it contains the use setting of the proxy.

```go
var DefaultTransport RoundTripper = &Transport{
	Proxy: ProxyFromEnvironment,
```

But when setting the transport for TLS connections this Proxy setting is missing.  

Additionally, in the Validate function, when setting up the new httpClient, the transport is missing the Proxy setting.

Solution is to add the Proxy to both transports.

### Steps to test and verify
To test this a proxy will need to be setup with an Hasura instance only available via the proxy.  Another instance should be available via https without going through the proxy.

I tested this by having one Hasura instance running in our corporate cloud solution that is available only from our network (i.e. via the proxy).  I also setup an instance running in the Hasura Cloud, so that I could test against an instance available without the proxy.

I then metadata export against the corporate solution with the proxy set and it was successful as expected.  

```shell
~/code/hasura/jproxy-test 7:35:04
$ set-proxy

~/code/hasura/proxy-test 7:35:17
$ ../../open-source/graphql-engine/cli/_output/corp-proxy-check-19033fcd4-dirty/cli-hasura-darwin-amd64 --cli-ext-path ~/code/open-source/graphql-engine/cli-ext/bin/cli-ext-hasura metadata export
INFO Metadata exported
```
I also removed the proxy env variables and tested against the corporate solution and the call failed as expected.

```shell
~/code/hasura/proxy-test 7:33:25
$ remove-proxy

~/code/hasura/proxy-test 7:34:29
$ ../../open-source/graphql-engine/cli/_output/corp-proxy-check-19033fcd4-dirty/cli-hasura-darwin-amd64 --cli-ext-path ~/code/open-source/graphql-engine/cli-ext/bin/cli-ext-hasura metadata export
ERRO connecting to graphql-engine server failed
INFO possible reasons:
INFO 1) Provided root endpoint of graphql-engine server is wrong. Verify endpoint key in config.yaml or/and value of --endpoint flag
INFO 2) Endpoint should NOT be your GraphQL API, ie endpoint is NOT https://hasura-cloud-app.io/v1/graphql it should be: https://hasura-cloud-app.io
INFO 3) Server might be unhealthy and is not running/accepting API requests
INFO 4) Admin secret is not correct/set
INFO
FATA[0000] making http request failed: Get "https://removed-endpoint/healthz": dial tcp: lookup remvoed-endpoint on 10.XX.XX.XX:53: no such host
```

I ran the same metadata export against the Hasura Cloud with the proxy set and it failed as expected (as via our proxy the cloud is not resolvable).  

```shell
~/code/hasura/personal 7:43:55
$ ../../open-source/graphql-engine/cli/_output/corp-proxy-check-19033fcd4-dirty/cli-hasura-darwin-amd64 --cli-ext-path ~/code/open-source/graphql-engine/cli-ext/bin/cli-ext-hasura metadata export
ERRO connecting to graphql-engine server failed
INFO possible reasons:
INFO 1) Provided root endpoint of graphql-engine server is wrong. Verify endpoint key in config.yaml or/and value of --endpoint flag
INFO 2) Endpoint should NOT be your GraphQL API, ie endpoint is NOT https://hasura-cloud-app.io/v1/graphql it should be: https://hasura-cloud-app.io
INFO 3) Server might be unhealthy and is not running/accepting API requests
INFO 4) Admin secret is not correct/set
INFO
FATA[0001] making http request failed: Get "https://removed.hasura.app/healthz": proxyconnect tcp: dial tcp: lookup web.prod.proxy.my-company.com on [XXXX:XXX:xxxx::X]:53: no such host
```

When I removed the proxy env variables and disconnected from VPN, the Hasura Cloud calls succeeded as expected.

```shell
~/code/hasura/personal 7:44:21
$ remove-proxy

~/code/hasura/personal 7:44:27
$ ../../open-source/graphql-engine/cli/_output/corp-proxy-check-19033fcd4-dirty/cli-hasura-darwin-amd64 --cli-ext-path ~/code/open-source/graphql-engine/cli-ext/bin/cli-ext-hasura metadata export
INFO Metadata exported
```

### Limitations, known bugs & workarounds

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/latest/graphql/core/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
