### PR TITLE
Update README.md

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -38,6 +38,7 @@ go get github.com/hasura/graphql-engine/cli/cmd/hasura
 git clone https://github.com/hasura/graphql-engine
 cd graphql-engine/cli
 make deps
+make build-cli-ext copy-cli-ext
 make build
 # binaries will be in _output directory
 ```


### PR DESCRIPTION
Add `make build-cli-ext copy-cli-ext` command, which is necessary to build CLI after clone.

### Description
If you want to build the CLI, the README.md contains useful instructions. It doesn't contain all commands yet though, only the CONTRIBUTING.md hints to the required command. Adding the command to README.md might reduce some friction.

### Affected components
- [x] CLI
