### PR TITLE
console: fix custom field names sort (fix #7974, #8021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - server: fix parsing FLOAT64s in scientific notation and non-finite ones in BigQuery
 - server: extend support for the `min`/`max` aggregates to all comparable types in BigQuery
 - server: fix support for joins in aggregates nodes in BigQuery
+- console: fix custom field names breaking browse table sorting and the pre-populating of the edit form
 - cli: migrate and seed subcommands has an option in prompt to choose and apply operation on all available databases
 - cli: fix `metadata diff --type json | unified-json` behaving incorrectly and showing diff in YAML format.
 - cli: fix regression in `migrate create` command (#7971)

--- a/console/src/components/Services/Data/TableBrowseRows/ViewActions.js
+++ b/console/src/components/Services/Data/TableBrowseRows/ViewActions.js
@@ -94,25 +94,12 @@ const vMakeRowsRequest = () => {
           originalTable,
           tableConfiguration,
         });
-        const updatedRows = rows.map(row => {
-          for (const key in row) {
-            if (row.hasOwnProperty(key)) {
-              const customColumnName =
-                tableConfiguration?.custom_column_names?.[key];
-              if (customColumnName) {
-                row[customColumnName] = row[key];
-                delete row[key];
-              }
-            }
-          }
-          return row;
-        });
         const currentTable = getState().tables.currentTable;
         if (currentTable === originalTable) {
           Promise.all([
             dispatch({
               type: V_REQUEST_SUCCESS,
-              data: updatedRows,
+              data: rows,
               estimatedCount,
             }),
             dispatch({ type: V_REQUEST_PROGRESS, data: false }),

--- a/console/src/components/Services/Data/TableBrowseRows/ViewRows.js
+++ b/console/src/components/Services/Data/TableBrowseRows/ViewRows.js
@@ -173,7 +173,7 @@ const ViewRows = props => {
       let sortIcon = 'fa-sort';
       if (curQuery.order_by && curQuery.order_by.length) {
         curQuery.order_by.forEach(orderBy => {
-          if (orderBy.column === columnName) {
+          if (orderBy.column === col.id) {
             sortIcon = orderBy.type === 'asc' ? 'fa-caret-up' : 'fa-caret-down';
           }
         });
@@ -188,9 +188,9 @@ const ViewRows = props => {
           </div>
         ),
         accessor: columnName,
-        id: columnName,
+        id: col.id,
         foldable: true,
-        width: getColWidth(columnName, curRows),
+        width: getColWidth(col.id, curRows),
       });
     });
 
@@ -517,9 +517,10 @@ const ViewRows = props => {
               ...col,
               column_name:
                 _tableSchema.configuration.custom_column_names[col.column_name],
+              id: col.column_name,
             };
           }
-          return col;
+          return { ...col, id: col.column_name };
         })
         .forEach(col => {
           const columnName = col.column_name;
@@ -539,7 +540,7 @@ const ViewRows = props => {
            * */
 
           const getColCellContent = () => {
-            const rowColumnValue = row[columnName];
+            const rowColumnValue = row[col.id];
 
             let cellValue = '';
             let cellTitle = '';
@@ -659,12 +660,13 @@ const ViewRows = props => {
           ...col,
           column_name:
             tableSchema.configuration.custom_column_names[col.column_name],
+          id: col.column_name,
         };
       }
-      return col;
+      return { ...col, id: col.column_name };
     })
     .sort(ordinalColSort);
-  // const tableColumnsSorted = tableSchema.columns.sort(ordinalColSort)
+
   const tableRelationships = tableSchema.relationships;
 
   const hasPrimaryKey = isTableWithPK(tableSchema);
@@ -858,7 +860,7 @@ const ViewRows = props => {
     let disableSortColumn = false;
 
     const sortByColumn = (col, clearExisting = true) => {
-      const columnNames = tableColumnsSorted.map(column => column.column_name);
+      const columnNames = tableColumnsSorted.map(column => column.id);
       if (!columnNames.includes(col)) {
         return;
       }


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

Fix some UI issues with custom field names such as being able to sort the browse table and pre-populating the edit row form.

### Changelog

- [X] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [X] Console

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

#7974 #8021

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

In the UI now we pass the real column ID while keeping the custom field name for display. This is my first console PR so please double check.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

Add a column with a custom field name, you are now able to sort it when browsing a table by clicking on the table header. Also when you edit a row with a custom field name it will correctly prepopulate.

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [X] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/latest/graphql/core/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [X] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [X] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [X] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
