### PR TITLE
cli: fix --address option (close #8005)

### DIFF
--- a/cli/commands/console.go
+++ b/cli/commands/console.go
@@ -126,7 +126,7 @@ func (o *ConsoleOptions) Run() error {
 	}
 
 	consoleRouter, err := console.BuildConsoleRouter(templateProvider, consoleTemplateVersion, o.StaticDir, gin.H{
-		"apiHost":              o.addressOrAPIHost(),
+		"apiHost":              o.handleAPIHost(),
 		"apiPort":              o.APIPort,
 		"cliVersion":           o.EC.Version.GetCLIVersion(),
 		"serverVersion":        o.EC.Version.GetServerVersion(),
@@ -176,10 +176,10 @@ func (o *ConsoleOptions) Run() error {
 	return console.Serve(serveOpts)
 }
 
-func (o *ConsoleOptions) addressOrAPIHost() string {
-	if o.Address != "localhost" {
-		return "http://" + o.Address
+func (o *ConsoleOptions) handleAPIHost() string {
+	if o.APIHost != "http://localhost" {
+		return o.APIHost
 	}
 
-	return o.APIHost
+	return "http://" + o.Address
 }

--- a/cli/commands/console.go
+++ b/cli/commands/console.go
@@ -126,7 +126,7 @@ func (o *ConsoleOptions) Run() error {
 	}
 
 	consoleRouter, err := console.BuildConsoleRouter(templateProvider, consoleTemplateVersion, o.StaticDir, gin.H{
-		"apiHost":              o.APIHost,
+		"apiHost":              o.addressOrAPIHost(),
 		"apiPort":              o.APIPort,
 		"cliVersion":           o.EC.Version.GetCLIVersion(),
 		"serverVersion":        o.EC.Version.GetServerVersion(),
@@ -174,4 +174,12 @@ func (o *ConsoleOptions) Run() error {
 	}
 
 	return console.Serve(serveOpts)
+}
+
+func (o *ConsoleOptions) addressOrAPIHost() string {
+	if o.Address != "localhost" {
+		return "http://" + o.Address
+	}
+
+	return o.APIHost
 }


### PR DESCRIPTION
### Description
Closes #8005
Resolved the problem where the `--address` option would not work if the `--api-host` option was the default value.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [x] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
#8005

### Solution and Design
If the value of the `--api-host` option is the default value, the value specified by the `--address` option is now used for the console and migrate API.
If both `--apihost` and `--address` options are specified, `--address` has priority.

### Steps to test and verify
Make sure it passes all the e2e tests to show that the changes are OK.


### Server checklist

#### Catalog upgrade
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/latest/graphql/core/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
