### PR TITLE
docs: add v1 version warning banner

### DIFF
--- a/docs/_static/styles/main.css
+++ b/docs/_static/styles/main.css
@@ -79,6 +79,19 @@ p {
   line-height: 1.7;
 }
 
+#v1-maintenance-warning {
+  background-color: #FFEFD8;
+  padding: 1rem;
+  margin: 1rem 0;
+  color: black;
+  border-left: 4px solid #F2B14F;
+  border-radius: 4px;
+}
+
+#v1-maintenance-warning a {
+  font-weight: bold;
+}
+
 .inline-block {
   display: inline-block;
   vertical-align: middle;

--- a/docs/_static/styles/main.css
+++ b/docs/_static/styles/main.css
@@ -81,11 +81,15 @@ p {
 
 #v1-maintenance-warning {
   background-color: #FFEFD8;
-  padding: 1rem;
+  padding: 1.5rem;
   margin: 1rem 0;
   color: black;
   border-left: 4px solid #F2B14F;
   border-radius: 4px;
+}
+
+#v1-maintenance-warning .latest-version {
+  margin-top: 1rem;
 }
 
 #v1-maintenance-warning a {

--- a/docs/_theme/djangodocs/layout.html
+++ b/docs/_theme/djangodocs/layout.html
@@ -257,8 +257,8 @@
 
               <div id="docs-content">
                 <div id="v1-maintenance-warning">
-                  <p>This is documentation for Hasura Core <b>v1.x</b>, which is no longer actively maintained.</p>
-                  <p>For up-to-date documentation, see the <a href="https://hasura.io/docs/latest/graphql/core/index.html">latest version</a>.</p>
+                  <div>This is documentation for Hasura Core <b>v1.x</b>.</div>
+                  <div class="latest-version">For up-to-date documentation, see the <a href="https://hasura.io/docs/latest/graphql/core/index.html">latest version</a>.</div>
                 </div>
                 <div id="{{ pagename|replace('/', '-') }}">
                   {% block body %}{% endblock %}

--- a/docs/_theme/djangodocs/layout.html
+++ b/docs/_theme/djangodocs/layout.html
@@ -257,7 +257,7 @@
 
               <div id="docs-content">
                 <div id="v1-maintenance-warning">
-                  <div>This is documentation for Hasura Core <b>v1.x</b>.</div>
+                  <div>This is documentation for Hasura GraphQL engine <b>v1.x</b>.</div>
                   <div class="latest-version">For up-to-date documentation, see the <a href="https://hasura.io/docs/latest/graphql/core/index.html">latest version</a>.</div>
                 </div>
                 <div id="{{ pagename|replace('/', '-') }}">

--- a/docs/_theme/djangodocs/layout.html
+++ b/docs/_theme/djangodocs/layout.html
@@ -256,6 +256,10 @@
               </div>
 
               <div id="docs-content">
+                <div id="v1-maintenance-warning">
+                  <p>This is documentation for Hasura Core <b>v1.x</b>, which is no longer actively maintained.</p>
+                  <p>For up-to-date documentation, see the <a href="https://hasura.io/docs/latest/graphql/core/index.html">latest version</a>.</p>
+                </div>
                 <div id="{{ pagename|replace('/', '-') }}">
                   {% block body %}{% endblock %}
                 </div>


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
Add version v1 warning banner for v1 docs and link to latest
<img width="996" alt="Screenshot 2022-02-25 at 7 54 41 PM" src="https://user-images.githubusercontent.com/22497932/155731503-0b1e1cab-8c77-4cd9-a38e-620a1b0d8f40.png">




### Affected components
- [x] Docs
