### PR TITLE
migrate realtime poll sample app to graphql-ws

### DIFF
--- a/community/sample-apps/realtime-poll/package.json
+++ b/community/sample-apps/realtime-poll/package.json
@@ -5,12 +5,12 @@
   "dependencies": {
     "@apollo/client": "^3.4.16",
     "graphql": "^15.6.0",
+    "graphql-ws": "^5.6.2",
     "react": "^17.0.2",
     "react-bootstrap": "^1.0.0",
     "react-dom": "^16.4.2",
     "react-google-charts": "^3.0.5",
-    "react-scripts": "^3.4.1",
-    "subscriptions-transport-ws": "^0.9.19"
+    "react-scripts": "^3.4.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/community/sample-apps/realtime-poll/src/apollo.js
+++ b/community/sample-apps/realtime-poll/src/apollo.js
@@ -1,5 +1,6 @@
 import { ApolloClient, HttpLink, InMemoryCache, split } from "@apollo/client";
-import { WebSocketLink } from "@apollo/client/link/ws";
+import { GraphQLWsLink } from '@apollo/client/link/subscriptions';
+import { createClient } from "graphql-ws";
 import { getMainDefinition } from "@apollo/client/utilities";
 
 const scheme = (proto) =>
@@ -19,7 +20,7 @@ const options = { reconnect: true };
 const wsURI = `${scheme("ws")}://${GRAPHQL_ENDPOINT}/v1/graphql`;
 const httpurl = `${scheme("https")}://${GRAPHQL_ENDPOINT}/v1/graphql`;
 
-const wsLink = new WebSocketLink({ uri: wsURI, options });
+const wsLink = new GraphQLWsLink(createClient({ url: wsURI, connectionParams: { options } }));
 const httpLink = new HttpLink({ uri: httpurl });
 const link = split(splitter, wsLink, httpLink);
 const client = new ApolloClient({ link, cache });


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
The application moves away from `subscriptions-transport-ws` because it's no longer maintained.

The application uses `graphql-ws` now, which is a newer implementation of a similar protocol that's actively maintained.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [x] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [ ] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/latest/graphql/core/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
