### PR TITLE
Clarify computed fields documentation

### DIFF
--- a/docs/docs/graphql/core/databases/postgres/schema/computed-fields.mdx
+++ b/docs/docs/graphql/core/databases/postgres/schema/computed-fields.mdx
@@ -21,7 +21,8 @@ import TabItem from '@theme/TabItem';
 
 Computed fields are virtual values or objects that are dynamically
 computed and can be queried along with a table/view's columns. Computed
-fields are computed when requested for via [custom SQL functions](https://www.postgresql.org/docs/current/sql-createfunction.html)
+fields are computed upon request. They are computed by 
+[custom SQL functions](https://www.postgresql.org/docs/current/sql-createfunction.html)
 (a.k.a. stored procedures) using other columns of the table/view and
 other custom inputs if needed.
 


### PR DESCRIPTION
Computed fields docs - intro paragraph: the existing phrasing combined two ideas into one sentence, in this case resulting in some ambiguity. 

### Description

The existing phrasing said "Computed fields are computed when requested for" (that's the first idea) "via custom SQL functions ..." (that's the second idea). When put together, "Computed fields are computed when requested for via custom SQL functions," it can be interpreted as "Computed fields are computed when [requested-by] custom SQL functions," for example. There should be no ambiguity about when computed fields actually get run/computed, i.e. upon each request. So hopefully this small change would make that clearer, without having to reread the sentence a couple of times to make sure.

### Changelog

- [ ] ~`CHANGELOG.md` is updated with user-facing content relevant to this PR.~ If no changelog is required, then add the `no-changelog-required` label.

### Affected components

- [x] Docs
