### PR TITLE
[gh-pages] Remove broken haddock links from hasura.github.io

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -10,12 +10,9 @@ You can also get started with a list of [tips and tricks](tips.md).
 
 ## Haddock documentation
 
-You can browse the generated haddock documentation for the engine's code; we
-automatically update it on every push to a branch of interest:
+You can browse the engine's generated haddock documentation for the following branches:
 
 * [stable branch](haddock/stable)
-* [alpha branch](haddock/alpha)
-* [beta branch](haddock/beta)
 * [main branch](haddock/main)
 
 

--- a/server/README.md
+++ b/server/README.md
@@ -10,8 +10,8 @@ You can also get started with a list of [tips and tricks](tips.md).
 
 ## Haddock documentation
 
-You can browse the generated [haddock documentation](haddock/) for the engine's
-code; we automatically update it on every push to a branch of interest:
+You can browse the generated haddock documentation for the engine's code; we
+automatically update it on every push to a branch of interest:
 
 * [stable branch](haddock/stable)
 * [alpha branch](haddock/alpha)


### PR DESCRIPTION
Hello!

I noticed that on [the deployed docs](https://hasura.github.io/graphql-engine/server/), [the first Haddock link](https://hasura.github.io/graphql-engine/server/haddock) and alpha/beta links were broken. I've removed the broken links and checked the other two.

Thanks!