### PR TITLE
Fix branch path and filter out index file.

### DIFF
--- a/server/haddock/index.html
+++ b/server/haddock/index.html
@@ -18,9 +18,10 @@
       .then(function (res) { return res.json() })
       .then(function (branches) {
         var list = document.getElementById('haddocks')
-
         branches.forEach(function (branch) {
-          list.innerHTML += '<li><a href="/' + branch.path + '">' + branch.name + '</a></li>'
+          if (branch.name != "index.html") {
+            list.innerHTML += '<li><a href="' + branch.name + '">' + branch.name + '</a></li>'
+          }
         })
       })
     </script>


### PR DESCRIPTION
### Description
This PR does two small fixes to the haddock indexing pages:
- it makes the link relative to the index; the absolute link was wrong, as it was missing the `graphql-engine` root; making it relative is probably a most robust fix than making it absolute?
- it filters out the "index.html" page out of the list of branches ^^