### PR TITLE
Add default privileges to pg user permissions example (close #3671)

### DIFF
--- a/docs/docs/graphql/core/deployment/postgres-requirements.mdx
+++ b/docs/docs/graphql/core/deployment/postgres-requirements.mdx
@@ -107,6 +107,17 @@ GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO hasurauser;
 -- GRANT ALL ON ALL TABLES IN SCHEMA <schema-name> TO hasurauser;
 -- GRANT ALL ON ALL SEQUENCES IN SCHEMA <schema-name> TO hasurauser;
 -- GRANT ALL ON ALL FUNCTIONS IN SCHEMA <schema-name> TO hasurauser;
+
+-- By defaults users won't have access to tables they have not created (and thus do not own).
+-- You can change these default prvileges to grant access to any object created in the future.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS;
+
+-- Alternatively, you may restrict this to objects created by a specific user
+-- ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT ALL ON TABLES TO hasurauser;
+-- ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT ALL ON SEQUENCES TO hasurauser;
+-- ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT ALL ON FUNCTIONS TO hasurauser;
 ```
 
 ### 2. A single role to manage metadata and user objects in the **same database**
@@ -155,6 +166,17 @@ GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO hasurauser;
 -- GRANT ALL ON ALL TABLES IN SCHEMA <schema-name> TO hasurauser;
 -- GRANT ALL ON ALL SEQUENCES IN SCHEMA <schema-name> TO hasurauser;
 -- GRANT ALL ON ALL FUNCTIONS IN SCHEMA <schema-name> TO hasurauser;
+
+-- By defaults users won't have access to tables they have not created (and thus do not own).
+-- You can change these default prvileges to grant access to any object created in the future.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS;
+
+-- Alternatively, you may restrict this to objects created by a specific user
+-- ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT ALL ON TABLES TO hasurauser;
+-- ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT ALL ON SEQUENCES TO hasurauser;
+-- ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT ALL ON FUNCTIONS TO hasurauser;
 ```
 
 ### Notes for managed databases (AWS RDS, GCP Cloud SQL, etc.)


### PR DESCRIPTION

### Description
Adds an example of `ALTER DEFAULT PRIVILEGES` to grant permissions to newly created database objects by default.

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Docs

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#3671

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
Reference: postgres documentation on [GRANT](https://www.postgresql.org/docs/current/sql-grant.html), [REVOKE](https://www.postgresql.org/docs/current/sql-revoke.html), and [ALTER DEFAULT PRIVILEGES](https://www.postgresql.org/docs/current/sql-alterdefaultprivileges.html).

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Follow edited example, check if hasura user defaults to having permissions to tables newly created by other users

