### PR TITLE
Cosnole: Set width for action handler input to w-8/12 (66%) close #8710

### DIFF
--- a/console/src/components/Services/Actions/Common/components/HandlerEditor.tsx
+++ b/console/src/components/Services/Actions/Common/components/HandlerEditor.tsx
@@ -30,7 +30,7 @@ const HandlerEditor: React.FC<HandlerEditorProps> = ({
   );
 
   return (
-    <div className="mb-lg w-4/12">
+    <div className="mb-lg w-8/12">
       <h2 className="text-lg font-semibold mb-xs flex items-center">
         {editorLabel}
         <span className="text-red-700 ml-xs mr-sm">*</span>
@@ -42,7 +42,7 @@ const HandlerEditor: React.FC<HandlerEditorProps> = ({
         value={localValue}
         onChange={e => setLocalValue(e.target.value)}
         placeholder="http://custom-logic.com/api"
-        className={inputStyles}
+        className={`${inputStyles} w-full`}
         data-test="action-create-handler-input"
       />
       <p className="text-sm text-gray-600">


### PR DESCRIPTION
### Description
The current size of the input for the action handler is too small.
<img width="369" alt="image" src="https://user-images.githubusercontent.com/9244507/180337445-a753e54e-cf18-42bb-8a89-647e104bfcd7.png">

This updates it to a larger size
<img width="722" alt="image" src="https://user-images.githubusercontent.com/9244507/180337477-70392a72-0900-4871-bf66-8c90148dcd8c.png">


I choose to size it to `w-8/12` (66.6%) as that is what the Action Handler Name width is currently set to.
However, it could also be set to `w-1/2` so it matches with the input boxes above (although for me this was still a bit short).

This is only a change to CSS styling in the console.

### Changelog

- [ ] `CHANGELOG.md` is updated with user-facing content relevant to this PR. If no changelog is required, then add the `no-changelog-required` label.

### Affected components
- [x] Console

### Related Issues
N/A

### Solution and Design
N/A

### Steps to test and verify
N/A

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
N/A

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated
#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:


<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
