### PR TITLE
[security] Update Debian base image to debian:buster-20220711-slim

### DIFF
--- a/packaging/graphql-engine-base/debian.dockerfile
+++ b/packaging/graphql-engine-base/debian.dockerfile
@@ -1,6 +1,6 @@
-# DATE VERSION: 2022-04-12
+# DATE VERSION: 2022-08-02
 # Modify the above date version (YYYY-MM-DD) if you want to rebuild the image for security updates
-FROM debian:buster-20210511-slim
+FROM debian:buster-20220711-slim
 
 # TARGETPLATFORM is automatically set up by docker buildx based on the platform we are targetting for
 ARG TARGETPLATFORM


### PR DESCRIPTION
### Description

Fixes some security issues marked as High & Critical by container security scanning tooling. Dumping a list of the critical security issues flagged here:

```
✗ Critical severity vulnerability found in openssl/libssl1.1
  Description: OS Command Injection
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-OPENSSL-2807585
  Introduced through: cyrus-sasl2/libsasl2-modules@2.1.27+dfsg-1+deb10u2, postgresql-14/libpq5@14.2-1.pgdg100+1, postgresql-14/postgresql-client-14@14.2-1.pgdg100+1, ca-certificates@20200601~deb10u2, curl@7.64.0-4+deb10u2, msodbcsql17@17.9.1.1-1
  From: cyrus-sasl2/libsasl2-modules@2.1.27+dfsg-1+deb10u2 > openssl/libssl1.1@1.1.1n-0+deb10u1
  From: postgresql-14/libpq5@14.2-1.pgdg100+1 > openssl/libssl1.1@1.1.1n-0+deb10u1
  From: postgresql-14/postgresql-client-14@14.2-1.pgdg100+1 > openssl/libssl1.1@1.1.1n-0+deb10u1
  and 5 more...
  Image layer: 'apt-get install -y curl'
  Fixed in: 1.1.1n-0+deb10u2

✗ Critical severity vulnerability found in openssl/libssl1.1
  Description: OS Command Injection
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-OPENSSL-2933515
  Introduced through: cyrus-sasl2/libsasl2-modules@2.1.27+dfsg-1+deb10u2, postgresql-14/libpq5@14.2-1.pgdg100+1, postgresql-14/postgresql-client-14@14.2-1.pgdg100+1, ca-certificates@20200601~deb10u2, curl@7.64.0-4+deb10u2, msodbcsql17@17.9.1.1-1
  From: cyrus-sasl2/libsasl2-modules@2.1.27+dfsg-1+deb10u2 > openssl/libssl1.1@1.1.1n-0+deb10u1
  From: postgresql-14/libpq5@14.2-1.pgdg100+1 > openssl/libssl1.1@1.1.1n-0+deb10u1
  From: postgresql-14/postgresql-client-14@14.2-1.pgdg100+1 > openssl/libssl1.1@1.1.1n-0+deb10u1
  and 5 more...
  Image layer: 'apt-get install -y curl'
  Fixed in: 1.1.1n-0+deb10u3

✗ Critical severity vulnerability found in openldap/libldap-common
  Description: SQL Injection
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-OPENLDAP-2808412
  Introduced through: curl@7.64.0-4+deb10u2, gnupg2/dirmngr@2.2.12-1+deb10u1, postgresql-14/libpq5@14.2-1.pgdg100+1
  From: curl@7.64.0-4+deb10u2 > curl/libcurl4@7.64.0-4+deb10u2 > openldap/libldap-2.4-2@2.4.47+dfsg-3+deb10u6 > openldap/libldap-common@2.4.47+dfsg-3+deb10u6
  From: gnupg2/dirmngr@2.2.12-1+deb10u1 > openldap/libldap-2.4-2@2.4.47+dfsg-3+deb10u6
  From: postgresql-14/libpq5@14.2-1.pgdg100+1 > openldap/libldap-2.4-2@2.4.47+dfsg-3+deb10u6
  and 1 more...
  Image layer: 'apt-get install -y curl'
  Fixed in: 2.4.47+dfsg-3+deb10u7

✗ Critical severity vulnerability found in mariadb-10.3/libmariadb3
  Description: Out-of-Bounds
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-MARIADB103-2940554
  Introduced through: libdbd-mysql-perl@4.050-2, mysql-defaults/default-libmysqlclient-dev@1.0.5, mysql-defaults/default-mysql-client@1.0.5
  From: libdbd-mysql-perl@4.050-2 > mariadb-10.3/libmariadb3@1:10.3.34-0+deb10u1
  From: mysql-defaults/default-libmysqlclient-dev@1.0.5 > mariadb-10.3/libmariadb-dev-compat@1:10.3.34-0+deb10u1 > mariadb-10.3/libmariadb-dev@1:10.3.34-0+deb10u1 > mariadb-10.3/libmariadb3@1:10.3.34-0+deb10u1
  From: mysql-defaults/default-mysql-client@1.0.5 > mariadb-10.3/mariadb-client-10.3@1:10.3.34-0+deb10u1 > mariadb-10.3/mariadb-client-core-10.3@1:10.3.34-0+deb10u1 > mariadb-10.3/mariadb-common@1:10.3.34-0+deb10u1
  and 5 more...
  Image layer: Introduced by your base image (debian:10.9-slim)

✗ Critical severity vulnerability found in mariadb-10.3/libmariadb3
  Description: Out-of-Bounds
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-MARIADB103-2940555
  Introduced through: libdbd-mysql-perl@4.050-2, mysql-defaults/default-libmysqlclient-dev@1.0.5, mysql-defaults/default-mysql-client@1.0.5
  From: libdbd-mysql-perl@4.050-2 > mariadb-10.3/libmariadb3@1:10.3.34-0+deb10u1
  From: mysql-defaults/default-libmysqlclient-dev@1.0.5 > mariadb-10.3/libmariadb-dev-compat@1:10.3.34-0+deb10u1 > mariadb-10.3/libmariadb-dev@1:10.3.34-0+deb10u1 > mariadb-10.3/libmariadb3@1:10.3.34-0+deb10u1
  From: mysql-defaults/default-mysql-client@1.0.5 > mariadb-10.3/mariadb-client-10.3@1:10.3.34-0+deb10u1 > mariadb-10.3/mariadb-client-core-10.3@1:10.3.34-0+deb10u1 > mariadb-10.3/mariadb-common@1:10.3.34-0+deb10u1
  and 5 more...
  Image layer: Introduced by your base image (debian:10.9-slim)

✗ Critical severity vulnerability found in lz4/liblz4-1
  Description: Out-of-bounds Write
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-LZ4-1277601
  Introduced through: apt/apt-transport-https@1.8.2.3, mysql-defaults/default-mysql-client@1.0.5
  From: apt/apt-transport-https@1.8.2.3 > apt@1.8.2.3 > apt/libapt-pkg5.0@1.8.2.3 > lz4/liblz4-1@1.8.3-1
  From: mysql-defaults/default-mysql-client@1.0.5 > mariadb-10.3/mariadb-client-10.3@1:10.3.34-0+deb10u1 > mariadb-10.3/mariadb-client-core-10.3@1:10.3.34-0+deb10u1 > lz4/liblz4-1@1.8.3-1
  From: apt/apt-transport-https@1.8.2.3 > apt@1.8.2.3 > apt/libapt-pkg5.0@1.8.2.3 > systemd/libsystemd0@241-7~deb10u7 > lz4/liblz4-1@1.8.3-1
  Image layer: Introduced by your base image (debian:10.9-slim)
  Fixed in: 1.8.3-1+deb10u1

✗ Critical severity vulnerability found in dpkg
  Description: Directory Traversal
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-DPKG-2847944
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > dpkg@1.19.7
  Image layer: Introduced by your base image (debian:10.9-slim)
  Fixed in: 1.19.8
  ```

### Affected components
<!-- Remove non-affected components from the list -->

- [x] Server
- [ ] Console
- [x] CLI
- [ ] Docs
- [ ] Community Content
- [] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design

```
Recommendations for base image upgrade:

Minor upgrades
Base Image                   Vulnerabilities  Severity
debian:buster-20220711-slim  71               0 critical, 1 high, 0 medium, 70 low
```

### Steps to test and verify

* Running against any container-sec tool - ECR Enhanced Scanning / Snyk etc.

#### Catalog upgrade

Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/latest/graphql/core/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

