### PR TITLE
Update `docker-entrypoint.sh` to stop overwriting the $PORT env var (fix #8770)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes and improvements
 
+- cli-migrations: fix issue with overwriting the $PORT env var (fix #8770)
 
 ## v2.11.0-beta.1
 

--- a/packaging/cli-migrations/v2/docker-entrypoint.sh
+++ b/packaging/cli-migrations/v2/docker-entrypoint.sh
@@ -38,7 +38,7 @@ fi
 
 # wait for a port to be ready
 wait_for_port() {
-    PORT=$1
+    local PORT=$1
     log "migrations-startup" "waiting $HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT for $PORT to be ready"
     for _ in $(seq 1 $HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT);
     do

--- a/packaging/cli-migrations/v3/docker-entrypoint.sh
+++ b/packaging/cli-migrations/v3/docker-entrypoint.sh
@@ -34,7 +34,7 @@ fi
 
 # wait for a port to be ready
 wait_for_port() {
-    PORT=$1
+    local PORT=$1
     log "migrations-startup" "waiting $HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT for $PORT to be ready"
     for _ in $(seq 1 $HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT);
     do


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

This PR fixes an issue that prevents the user needs from binding Hasura to the $PORT env var.

### Changelog

- [x] `CHANGELOG.md` is updated with user-facing content relevant to this PR. 

### Affected components

I'm not sure where the `packaging` dir fits in here, but it kind of feels somewhere between the Server and Build System.

- [x] Server
- [x] Build System

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

#8770

### Solution and Design

This PR reverts a line change made in https://github.com/hasura/graphql-engine/commit/cde3ab7612a07fe97c8e7888a1b1a19e3aa388ca# where the `local` keyword was removed when assigning to the PORT env var.

### Steps to test and verify

I'm not sure how to compile Hasura into a docker image, so instead I tested this fix by manually patching the `docker-entrypoint.sh` script in the Dockerfile.

1. Create a Dockerfile with these instructions:

```Dockerfile
FROM `hasura/graphql-engine:v2.9.0.cli-migrations-v3`

# patch docker-entrypoint.sh
# replace "PORT=" with "local PORT="
RUN sed -i 's/\(^\s\+\)PORT=/\1local PORT=/m'  /bin/docker-entrypoint.sh

CMD graphql-engine serve --server-port $PORT
```

2. Build the image

```bash
docker build -t local/graphql-engine:v2.9.0-patch-entrypoint .
```

3. Start the container, expecting to start Hasura on port 8080

```bash
docker run \
  -p 8080:8080 \
  -e PORT=8080 \
  -e HASURA_GRAPHQL_DATABASE_URL='<your_database_url>' \
  -e HASURA_GRAPHQL_ENABLE_CONSOLE=true \
  local/graphql-engine:v2.9.0-patch-entrypoint
```

4. Open http://localhost:8080. The Hasura Console will load as expected.

### Limitations, known bugs & workarounds

- N/A

### Server checklist

#### Catalog upgrade

Does this PR change Hasura Catalog version?

- [x] No

#### Metadata

Does this PR add a new Metadata feature?

- [x] No

#### GraphQL

- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No Breaking changes