### PR TITLE
Clarifies Cloud project time limit note

### DIFF
--- a/docs/docs/security/api-limits.mdx
+++ b/docs/docs/security/api-limits.mdx
@@ -142,7 +142,7 @@ sources.
 
 :::info Time limits on Hasura Cloud projects
 
-All Hasura Cloud projects get a default time limit of 60 seconds. When the cloud limit is hit, the error contains the
+All Free tier and Standard tier Hasura Cloud projects get a time limit of 60 seconds. When the cloud limit is hit, the error contains the
 code `tenant-time-limit-exceeded` in the error message.
 
 :::


### PR DESCRIPTION
The word default in this docs note is wrong. It's not a default value that can be changed by a user.

### Description
Changes a Hasura Cloud specific note to clarify how time limits work in Cloud.

### Changelog
Clarifies Hasura Cloud usage of time limits configuration.
#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [X] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/latest/graphql/core/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [X] No
- [ ] Yes

#### GraphQL
- [X] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:

#### Breaking changes

- [X] No Breaking changes
- [ ] There are breaking changes