### PR TITLE
isolate-git isolate git in nix-shell

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -72,6 +72,8 @@ let
   devInputs = [
     pkgs.nixpkgs-fmt
     pkgs.shellcheck
+    pkgs.git
+    pkgs.openssh
   ];
 
   ciInputs = [


### PR DESCRIPTION
 git is not isolated inside nix-shell environment. 
It is one of issues preventing cabal building the project and pushing PRs on Debian 10 (old glibc)