### PR TITLE
server: deduplicate Postgres function names with HashSet (close #8888)

### DIFF
--- a/server/src-lib/Hasura/Backends/Postgres/DDL/RunSQL.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/DDL/RunSQL.hs
@@ -22,7 +22,6 @@ import Control.Monad.Trans.Control (MonadBaseControl)
 import Data.Aeson
 import Data.HashMap.Strict qualified as M
 import Data.HashSet qualified as HS
-import Data.HashSet.InsOrd qualified as OHS
 import Data.Text.Extended
 import Database.PG.Query qualified as PG
 import Hasura.Backends.Postgres.Connection.MonadTx
@@ -152,7 +151,7 @@ fetchTablesFunctionsMetadata ::
   ) =>
   TableCache ('Postgres pgKind) ->
   [TableName ('Postgres pgKind)] ->
-  OHS.InsOrdHashSet (FunctionName ('Postgres pgKind)) ->
+  HS.HashSet (FunctionName ('Postgres pgKind)) ->
   m ([TableMeta ('Postgres pgKind)], [FunctionMeta ('Postgres pgKind)])
 fetchTablesFunctionsMetadata tableCache tables functions = do
   tableMetaInfos <- fetchTableMetadata tables
@@ -299,8 +298,8 @@ runTxWithMetadataCheck source sourceConfig txAccess tableCache functionCache cas
 
         -- Before running the @'tx', fetch metadata of existing tables and functions from Postgres.
         let tableNames = M.keys tableCache
-            computedFieldFunctions = concatMap getComputedFieldFunctions (M.elems tableCache)
-            functionNames = OHS.fromList $ M.keys functionCache <> computedFieldFunctions
+            computedFieldFunctions = HS.fromList $ concatMap getComputedFieldFunctions (M.elems tableCache)
+            functionNames = M.keysSet functionCache <> computedFieldFunctions
         (preTxTablesMeta, preTxFunctionsMeta) <- fetchTablesFunctionsMetadata tableCache tableNames functionNames
 
         -- Since the @'tx' may alter table/function names we use the OIDs of underlying tables
@@ -400,7 +399,7 @@ fetchTablesFunctionsFromOids ::
   (MonadIO m) =>
   [OID] ->
   [OID] ->
-  PG.TxET QErr m ([TableName ('Postgres pgKind)], OHS.InsOrdHashSet (FunctionName ('Postgres pgKind)))
+  PG.TxET QErr m ([TableName ('Postgres pgKind)], HS.HashSet (FunctionName ('Postgres pgKind)))
 fetchTablesFunctionsFromOids tableOids functionOids =
   ((PG.getViaJSON *** PG.getViaJSON) . PG.getRow)
     <$> PG.withQE

--- a/server/src-lib/Hasura/Backends/Postgres/DDL/RunSQL.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/DDL/RunSQL.hs
@@ -22,7 +22,7 @@ import Control.Monad.Trans.Control (MonadBaseControl)
 import Data.Aeson
 import Data.HashMap.Strict qualified as M
 import Data.HashSet qualified as HS
-import Data.List (nub)
+import Data.HashSet.InsOrd qualified as OHS
 import Data.Text.Extended
 import Database.PG.Query qualified as PG
 import Hasura.Backends.Postgres.Connection.MonadTx
@@ -152,7 +152,7 @@ fetchTablesFunctionsMetadata ::
   ) =>
   TableCache ('Postgres pgKind) ->
   [TableName ('Postgres pgKind)] ->
-  [FunctionName ('Postgres pgKind)] ->
+  OHS.InsOrdHashSet (FunctionName ('Postgres pgKind)) ->
   m ([TableMeta ('Postgres pgKind)], [FunctionMeta ('Postgres pgKind)])
 fetchTablesFunctionsMetadata tableCache tables functions = do
   tableMetaInfos <- fetchTableMetadata tables
@@ -300,7 +300,7 @@ runTxWithMetadataCheck source sourceConfig txAccess tableCache functionCache cas
         -- Before running the @'tx', fetch metadata of existing tables and functions from Postgres.
         let tableNames = M.keys tableCache
             computedFieldFunctions = concatMap getComputedFieldFunctions (M.elems tableCache)
-            functionNames = nub $ M.keys functionCache <> computedFieldFunctions
+            functionNames = OHS.fromList $ M.keys functionCache <> computedFieldFunctions
         (preTxTablesMeta, preTxFunctionsMeta) <- fetchTablesFunctionsMetadata tableCache tableNames functionNames
 
         -- Since the @'tx' may alter table/function names we use the OIDs of underlying tables
@@ -400,7 +400,7 @@ fetchTablesFunctionsFromOids ::
   (MonadIO m) =>
   [OID] ->
   [OID] ->
-  PG.TxET QErr m ([TableName ('Postgres pgKind)], [FunctionName ('Postgres pgKind)])
+  PG.TxET QErr m ([TableName ('Postgres pgKind)], OHS.InsOrdHashSet (FunctionName ('Postgres pgKind)))
 fetchTablesFunctionsFromOids tableOids functionOids =
   ((PG.getViaJSON *** PG.getViaJSON) . PG.getRow)
     <$> PG.withQE


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

#### Long Changelog

<!--
  Detailed description of this change. This might contain links to documentation, blogposts, images. Use markdown for formatting.
  (optional if you choose to fill the Short Changelog section instead)
-->
There was a bug (#8643) where if a function is added as both a root field and computed field at the same time, the migrations would fail.

This was temporarily resolved in b0d2262 by using [Data.List#nub](https://hackage.haskell.org/package/base-4.16.3.0/docs/Data-List.html#v:nub) in `runTxWithMetadataCheck` to remove duplicates, however [Data.List#nub](https://hackage.haskell.org/package/base-4.16.3.0/docs/Data-List.html#v:nub) is really inefficient (`O(n^2)` time-complexity).

This PR refactors `runTxWithMetadataCheck` to use a `Set` instead of [Data.List#nub](https://hackage.haskell.org/package/base-4.16.3.0/docs/Data-List.html#v:nub) to deduplicate the Postgres function names.

<!-- Changelog Section End -->

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#8888

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
I used [Data.HashSet.InsOrd](https://hackage.haskell.org/package/insert-ordered-containers-0.2.5.1/docs/Data-HashSet-InsOrd.html) instead of [Data.HashSet](https://hackage.haskell.org/package/unordered-containers-0.2.19.1/docs/Data-HashSet.html) to maintain insertion order, so that the sorting is the same as now (using `List`), is that desired?

Alternately, should I use [Data.Set](https://hackage.haskell.org/package/containers-0.6.5.1/docs/Data-Set.html) to sort by alphabetical order instead?

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/latest/graphql/core/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
