### PR TITLE
Added depends_on to hasura container config

### DIFF
--- a/install-manifests/enterprise/snowflake/docker-compose.yaml
+++ b/install-manifests/enterprise/snowflake/docker-compose.yaml
@@ -40,6 +40,8 @@ services:
       HASURA_GRAPHQL_REDIS_URL: 'redis://redis:6379'
       HASURA_GRAPHQL_RATE_LIMIT_REDIS_URL: 'redis://redis:6379'
       HASURA_GRAPHQL_MAX_CACHE_SIZE: '200'
+    depends_on:
+      - gdw_server
   gdw_server:
     image: hasura/graphql-data-connector:v2.16.0-beta.1
     restart: always


### PR DESCRIPTION
Adding depends_on gdw_server to hasura container config will avoid start up race conditions when the agent is being queried by Hasura GraphQL Engine prior to being available which results in inconsistent metadata errors.

### Description
The current docker-compose does not have dependencies between containers.  This can result in Hasura GraphQL Engine starting up with inconsistent metadata errors as it attempts to reach the agent prior to the agent being available.  This adds a dependency that requires the agent to be started prior to Hasura GraphQL Engine starting.  This resolves the race condition resulting in inconsistent metadata.

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [ ] No

Does this PR add a new Metadata feature?
- [ ] No


#### GraphQL
- [ ] No new GraphQL schema is generated

#### Breaking changes

- [ ] No Breaking changes

