### PR TITLE
docs: fix typo in operations tab

### DIFF
--- a/docs/docs/observability/operations.mdx
+++ b/docs/docs/observability/operations.mdx
@@ -26,7 +26,7 @@ can also inspect individual operations.
 
 <Thumbnail src="/img/observability/pro-tab-operations-inspect.png" alt="Hasura Cloud Console inspect operation" />
 
-## Enable response body analysis and capture query variables
+## Capture query variables
 
 At the top of the `Monitoring > Operations` page in the Console, you can select whether to turn on "Capture query
 variables" which is disabled by default.


### PR DESCRIPTION
fix typo in operations docs page