### PR TITLE
add liveness and readiness kubernetes probes

### DIFF
--- a/install-manifests/kubernetes/deployment.yaml
+++ b/install-manifests/kubernetes/deployment.yaml
@@ -31,6 +31,15 @@ spec:
         - name: HASURA_GRAPHQL_DEV_MODE
           value: "true"
         ports:
-        - containerPort: 8080
+        - name: http
+          containerPort: 8080
           protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: http
         resources: {}


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
[Kubernetes liveness and readiness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) can be used to know when a kubernetes deployment is ready, and when it is healthy.

[It uses the Hasura `GET` `/healthz` endpoint.](https://hasura.io/docs/latest/api-reference/health/)



### Changelog


__Component__ : server

__Type__: enhancement

__Product__: community-edition

#### Short Changelog

add liveness and readiness kubernetes probes

<!-- Changelog Section End -->

### Related Issues
NA. I can create an issue if you really need it.

### Solution and Design
I copy pasted standard liveness and readiness magic yaml.

### Steps to test and verify
Deploy hasura on a kubernetes cluster.

### Limitations, known bugs & workarounds
Hasura may be slow to start on extremely slow hardware, and kubernetes may kill hasura before it manages to completely start.

In such case, an `initialDelaySeconds` may be added in the probe. To give Hasura more time to start. I would guess that owner of such bad hardware are already aware of `initialDelaySeconds`, as they probably have to add it to most of their kubernetes deployments. I don't think changing the default value is necessary.

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/latest/graphql/core/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
