### PR TITLE
update graphql-engine version to

### DIFF
--- a/community/sample-apps/streaming-subscriptions-chat/docker-compose.yml
+++ b/community/sample-apps/streaming-subscriptions-chat/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       POSTGRES_PASSWORD: postgrespassword
   graphql-engine:
-    image: hasura/graphql-engine:v2.12.0.cli-migrations-v3
+    image: hasura/graphql-engine:v2.12.1.cli-migrations-v3
     ports:
       - "8080:8080"
     depends_on:


### PR DESCRIPTION
### Description
Fixes #9390 

### Changelog
Updates graphql engine depenendency from `hasura/graphql-engine:v2.12.0.cli-migrations-v3` to `hasura/graphql-engine:v2.12.1.cli-migrations-v3`