### PR TITLE
fix: big number issue, lost precision when editing or inserting numeric records using console (close #9386)

### DIFF
--- a/console/src/components/Services/Data/TableEditItem/EditActions.js
+++ b/console/src/components/Services/Data/TableEditItem/EditActions.js
@@ -51,17 +51,6 @@ const editItem = (tableName, colValues) => {
       errorMessage = 'No fields modified';
     }
 
-    const findContentBetweenQuotes = (str) => {
-      const checkForQuotesWrap = str.match(/^\"(.*)\"$/);
-      const checkForSingleQuotesWrap = str.match(/^\'(.*)\'$/);
-      if (checkForQuotesWrap) {
-        return checkForQuotesWrap[1];
-      } else if (checkForSingleQuotesWrap) {
-        return checkForSingleQuotesWrap[1];
-      }
-      return null;
-    }
-
     Object.keys(colValues).map(colName => {
       const colValue = colValues[colName];
 
@@ -72,29 +61,33 @@ const editItem = (tableName, colValues) => {
         _defaultArray.push(colName);
       } else {
         if (Integers.indexOf(colType) > 0) {
-          // For now this solution is suggested way of enforcing the system to send string value to the server.
-          // Better solution would be to check if the server flag(HASURA_GRAPHQL_STRINGIFY_NUMERIC_TYPES) is turned on through example: "/v1alpha1/config" 
-          const checkForQuotesOrSingleQuotesWrap = findContentBetweenQuotes(colValue);
-          if(checkForQuotesOrSingleQuotesWrap){
-            // The string should be used instead of JS Float if the env flag is used.
-            _setObject[colName] = checkForQuotesOrSingleQuotesWrap;
-          } else {
-            _setObject[colName] = parseInt(colValue, 10) || colValue;;// To not introduce breaking change.
-          }
+          /*
+            Hasura GraphQL Engine server will accept integers sent as string, and will interpret them correctly.
+            Better solution would probably be to check if the server flag(HASURA_GRAPHQL_STRINGIFY_NUMERIC_TYPES) is turned on through example: "/v1alpha1/config",
+            and only then enforce sending string value instead of number. 
+          */
+          _setObject[colName] = colValue;
+          // _setObject[colName] = parseInt(colValue, 10); // Do not use this because of the issue: https://github.com/hasura/graphql-engine/issues/9386
         } else if (Reals.indexOf(colType) > 0) {
-          // For now this solution is suggested way of enforcing the system to send string value to the server.
-          // Better solution would be to check if the server flag(HASURA_GRAPHQL_STRINGIFY_NUMERIC_TYPES) is turned on through example: "/v1alpha1/config" 
-          const checkForQuotesOrSingleQuotesWrap = findContentBetweenQuotes(colValue);
-          if(checkForQuotesOrSingleQuotesWrap){
-            // The string should be used instead of JS Float if the env flag is used.
-            _setObject[colName] = checkForQuotesOrSingleQuotesWrap;
-          } else {
-            _setObject[colName] = parseFloat(colValue); // To not introduce breaking change.
-          }
+          /*
+            Hasura GraphQL Engine server will accept floats sent as string, and will interpret them correctly.
+            Better solution would probably be to check if the server flag(HASURA_GRAPHQL_STRINGIFY_NUMERIC_TYPES) is turned on through example: "/v1alpha1/config",
+            and only then enforce sending string value instead of number. 
+          */
+          _setObject[colName] = colValue;
+          // _setObject[colName] = parseFloat(colValue, 10) || colValue;  // Do not use this because of the issue: https://github.com/hasura/graphql-engine/issues/9386
         } else if (colType === dataSource.columnDataTypes.BOOLEAN) {
-          if (`${colValue}`.toLowerCase() === 'true' || `${colValue}` === '1' || colValue === true) {
+          if (
+            `${colValue}`.toLowerCase() === 'true' ||
+            `${colValue}` === '1' ||
+            colValue === true
+          ) {
             _setObject[colName] = true;
-          } else if (`${colValue}`.toLowerCase() === 'false' || `${colValue}` === '0' || colValue === false) {
+          } else if (
+            `${colValue}`.toLowerCase() === 'false' ||
+            `${colValue}` === '0' ||
+            colValue === false
+          ) {
             _setObject[colName] = false;
           } else {
             _setObject[colName] = null;

--- a/console/src/components/Services/Data/TableEditItem/EditActions.js
+++ b/console/src/components/Services/Data/TableEditItem/EditActions.js
@@ -51,6 +51,17 @@ const editItem = (tableName, colValues) => {
       errorMessage = 'No fields modified';
     }
 
+    const findContentBetweenQuotes = (str) => {
+      const checkForQuotesWrap = str.match(/^\"(.*)\"$/);
+      const checkForSingleQuotesWrap = str.match(/^\'(.*)\'$/);
+      if (checkForQuotesWrap) {
+        return checkForQuotesWrap[1];
+      } else if (checkForSingleQuotesWrap) {
+        return checkForSingleQuotesWrap[1];
+      }
+      return null;
+    }
+
     Object.keys(colValues).map(colName => {
       const colValue = colValues[colName];
 
@@ -61,13 +72,29 @@ const editItem = (tableName, colValues) => {
         _defaultArray.push(colName);
       } else {
         if (Integers.indexOf(colType) > 0) {
-          _setObject[colName] = parseInt(colValue, 10);
+          // For now this solution is suggested way of enforcing the system to send string value to the server.
+          // Better solution would be to check if the server flag(HASURA_GRAPHQL_STRINGIFY_NUMERIC_TYPES) is turned on through example: "/v1alpha1/config" 
+          const checkForQuotesOrSingleQuotesWrap = findContentBetweenQuotes(colValue);
+          if(checkForQuotesOrSingleQuotesWrap){
+            // The string should be used instead of JS Float if the env flag is used.
+            _setObject[colName] = checkForQuotesOrSingleQuotesWrap;
+          } else {
+            _setObject[colName] = parseInt(colValue, 10) || colValue;;// To not introduce breaking change.
+          }
         } else if (Reals.indexOf(colType) > 0) {
-          _setObject[colName] = parseFloat(colValue);
-        } else if (colType === 'boolean') {
-          if (colValue === 'true' || colValue === true) {
+          // For now this solution is suggested way of enforcing the system to send string value to the server.
+          // Better solution would be to check if the server flag(HASURA_GRAPHQL_STRINGIFY_NUMERIC_TYPES) is turned on through example: "/v1alpha1/config" 
+          const checkForQuotesOrSingleQuotesWrap = findContentBetweenQuotes(colValue);
+          if(checkForQuotesOrSingleQuotesWrap){
+            // The string should be used instead of JS Float if the env flag is used.
+            _setObject[colName] = checkForQuotesOrSingleQuotesWrap;
+          } else {
+            _setObject[colName] = parseFloat(colValue); // To not introduce breaking change.
+          }
+        } else if (colType === dataSource.columnDataTypes.BOOLEAN) {
+          if (`${colValue}`.toLowerCase() === 'true' || `${colValue}` === '1' || colValue === true) {
             _setObject[colName] = true;
-          } else if (colValue === 'false' || colValue === false) {
+          } else if (`${colValue}`.toLowerCase() === 'false' || `${colValue}` === '0' || colValue === false) {
             _setObject[colName] = false;
           } else {
             _setObject[colName] = null;

--- a/console/src/components/Services/Data/TableInsertItem/InsertActions.js
+++ b/console/src/components/Services/Data/TableInsertItem/InsertActions.js
@@ -98,46 +98,39 @@ const insertItem = (tableName, colValues, isMigration = false) => {
     let error = false;
     let errorMessage = '';
 
-    const findContentBetweenQuotes = (str) => {
-      const checkForQuotesWrap = str.match(/^\"(.*)\"$/);
-      const checkForSingleQuotesWrap = str.match(/^\'(.*)\'$/);
-      if (checkForQuotesWrap) {
-        return checkForQuotesWrap[1];
-      } else if (checkForSingleQuotesWrap) {
-        return checkForSingleQuotesWrap[1];
-      }
-      return null;
-    }
-
     Object.keys(colValues).map(colName => {
       const colSchema = columns.find(x => x.column_name === colName);
       const colType = colSchema.data_type;
       const colValue = colValues[colName];
 
       if (Integers.indexOf(colType) > 0) {
-        // For now this solution is suggested way of enforcing the system to send string value to the server.
-        // Better solution would be to check if the server flag(HASURA_GRAPHQL_STRINGIFY_NUMERIC_TYPES) is turned on through example: "/v1alpha1/config" 
-        const checkForQuotesOrSingleQuotesWrap = findContentBetweenQuotes(colValue);
-        if(checkForQuotesOrSingleQuotesWrap){
-          // The string should be used instead of JS Float if the env flag is used.
-          insertObject[colName] = checkForQuotesOrSingleQuotesWrap;
-        } else {
-          insertObject[colName] = parseInt(colValue, 10);// To not introduce breaking change.
-        }
+        /*
+          Hasura GraphQL Engine server will accept integers sent as string, and will interpret them correctly.
+          Better solution would probably be to check if the server flag(HASURA_GRAPHQL_STRINGIFY_NUMERIC_TYPES) is turned on through example: "/v1alpha1/config",
+          and only then enforce sending string value instead of number. 
+        */
+        insertObject[colName] = colValue;
+        // insertObject[colName] = parseInt(colValue, 10); // Do not use this because of the issue: https://github.com/hasura/graphql-engine/issues/9386
       } else if (Reals.indexOf(colType) > 0) {
-        // For now this solution is suggested way of enforcing the system to send string value to the server.
-        // Better solution would be to check if the server flag(HASURA_GRAPHQL_STRINGIFY_NUMERIC_TYPES) is turned on through example: "/v1alpha1/config" 
-        const checkForQuotesOrSingleQuotesWrap = findContentBetweenQuotes(colValue);
-        if(checkForQuotesOrSingleQuotesWrap){
-          // The string should be used instead of JS Float if the env flag is used.
-          insertObject[colName] = checkForQuotesOrSingleQuotesWrap;
-        } else {
-          insertObject[colName] = parseFloat(colValue, 10) || colValue;
-        }
+        /*
+          Hasura GraphQL Engine server will accept floats sent as string, and will interpret them correctly.
+          Better solution would probably be to check if the server flag(HASURA_GRAPHQL_STRINGIFY_NUMERIC_TYPES) is turned on through example: "/v1alpha1/config",
+          and only then enforce sending string value instead of number. 
+        */
+        insertObject[colName] = colValue;
+        // insertObject[colName] = parseFloat(colValue, 10) || colValue;  // Do not use this because of the issue: https://github.com/hasura/graphql-engine/issues/9386
       } else if (colType === dataSource.columnDataTypes.BOOLEAN) {
-        if (`${colValue}`.toLowerCase() === 'true' || `${colValue}` === '1' || colValue === true) {
+        if (
+          `${colValue}`.toLowerCase() === 'true' ||
+          `${colValue}` === '1' ||
+          colValue === true
+        ) {
           insertObject[colName] = true;
-        } else if (`${colValue}`.toLowerCase() === 'false' || `${colValue}` === '0' || colValue === false) {
+        } else if (
+          `${colValue}`.toLowerCase() === 'false' ||
+          `${colValue}` === '0' ||
+          colValue === false
+        ) {
           insertObject[colName] = false;
         } else {
           insertObject[colName] = null;


### PR DESCRIPTION
This PR provides fix for issue #9386 
It will fix lost precision when editing or inserting numeric records using console, it removes the parseInt and parseFloat before constructing query. Server will accept the string as valid query and save the data without losing precision.

### Description
Users can now edit bigint or numeric values without losing precision due JSON number limits. 

__Component__ : console

__Type__: bugfix

__Product__: community-edition

#### Short Changelog

Changed the InsertActions.js and EditActions.js to not parse string value from the console input fields for numeric values and pass them as string to the functions that generate GraphQL query for inserting and editing rows using a console.

<!-- Changelog Section End -->

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#9386 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
Solution for this is to pass numeric values as string instead of parsing them to JavaScript number type to not lose precision for big numbers, GraphQL server seems to correctly parse the numeric values sent as string.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

1. Create postgres table with type numeric(78,0)
2. Open the Hasura Console
3. Go to Data > select table containing numeric column > Edit a specific row
4. Change numeric column to something big
5. Save
6. Verify that data saved to db is saved as expected, and if running hasura server with flag HASURA_GRAPHQL_STRINGIFY_NUMERIC_TYPES, everything will be correctly shown in console.

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->
Could not found any limitations of the PR, with my limited testing. No breaking changes introduced. 🎉

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/latest/graphql/core/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [x] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [x] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [x] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
