### PR TITLE
cli console: differantiate API listening address and API accessing hostname (fix #7241)

### DIFF
--- a/cli/commands/console.go
+++ b/cli/commands/console.go
@@ -83,7 +83,7 @@ func NewConsoleCmd(ec *cli.ExecutionContext) *cobra.Command {
 	f := consoleCmd.Flags()
 
 	f.StringVar(&opts.APIPort, "api-port", "9693", "port for serving migrate api")
-	f.StringVar(&apiHost, "api-host", "http://localhost", "(PREVIEW: usage may change in future) host serving migrate api")
+	f.StringVar(&apiHost, "api-host", "http://localhost", "(PREVIEW: usage may change in future) host for accessing migrate api")
 	f.StringVar(&opts.ConsolePort, "console-port", "9695", "port for serving console")
 	f.StringVar(&opts.Address, "address", "localhost", "address to serve console and migration API from")
 	f.BoolVar(&opts.DontOpenBrowser, "no-browser", false, "do not automatically open console in browser")
@@ -136,7 +136,7 @@ func (o *ConsoleOptions) Run() error {
 		return errors.E(op, "cannot validate version, object is nil")
 	}
 
-	apiServer, err := console.NewAPIServer(o.APIHost.Host, o.APIPort, o.EC)
+	apiServer, err := console.NewAPIServer(o.Address, o.APIPort, o.EC)
 	if err != nil {
 		return errors.E(op, err)
 	}


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

#7519 added the `--api-host` and #8039 fixed a bit of collision with `--address`, but the merge of #8039 (f530b3ac6ffee87a97dd07fef49c03e5a4bd24de) added the listening of API on `--api-host`.

All this create a confusion between listening host and accessing hostname.

E.g. when using containers, it is an issue (when it is not possible to use `--net host`):

```sh
# Launching GraphQL Engine
docker container run --name hasura -d -p 8080:8080 -p 9695:9695 -p 9693:9693 hasura/graphql-engine:v2.17.0.cli-migrations-v3

# Launching console
docker container exec hasura hasura-cli console --no-browser --address 0.0.0.0  # 0.0.0.0 is mandatory for expose even with '-p 9695:9695'
```

When opening http://localhost:9695, browser is trying to access http://0.0.0.0:9693/apis/migrate/settings, which doesn't work (it's OK on Linux as it's redirected to 127.0.0.1, but doesn't work on other systems).

To avoid this, the use of `--api-host` is necessary:

```sh
# Launching console
docker container exec hasura hasura-cli console --no-browser --address 0.0.0.0 --api-host http://localhost
```

But this time, the browser is trying to access http://localhost:9693/apis/migrate/settings, but it doesn't work as the API is only exposed on 127.0.0.1 inside the container.

This PR differentiate the listening address of API server (using the same as the console) from the accessing (or exposed) address to use in the browser.

### Changelog

<!-- Fill this section if this is a user facing change. -->

__Component__ : cli

__Type__: bugfix

__Product__: community-edition

#### Short Changelog

<!-- One line description of this change. (optional if you choose to fill the Long Changelog section instead) -->

Use `--address` to expose the migrate API with console, `--api-host` is only used for accessing it from console UI.

#### Long Changelog

<!--
  Detailed description of this change. This might contain links to documentation, blogposts, images. Use markdown for formatting.
  (optional if you choose to fill the Short Changelog section instead)
-->


<!-- Changelog Section End -->

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

- #7241
- #7519
- #8039/#8005

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

Make API listen on `--address` instead of `--api-host`.

If we may want to listen on different interfaces, then should introduce a `--api-address`.

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

Launch console:

```sh
hasura-cli console --address 0.0.0.0 --api-host http://localhost
```

Check port 9693 is open on 0.0.0.0 (e.g. via `ss`), and console UI is calling http://localhost:9693/apis/migrate/settings

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/latest/graphql/core/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
