### PR TITLE
[console] sort types alphabetically in remote schema type dropdown (close #9412)

### DIFF
--- a/console/src/components/Services/RemoteSchema/Common/GraphQLCustomization/FieldNames.tsx
+++ b/console/src/components/Services/RemoteSchema/Common/GraphQLCustomization/FieldNames.tsx
@@ -47,7 +47,7 @@ const SelectOne = ({
     data-test={label}
   >
     <option value="">Select Type ...</option>
-    {options.map((op, i) => (
+    {[...options].sort().map((op, i) => (
       <option value={op} key={i}>
         {op}
       </option>

--- a/console/src/components/Services/RemoteSchema/Common/GraphQLCustomization/TypeMapping.tsx
+++ b/console/src/components/Services/RemoteSchema/Common/GraphQLCustomization/TypeMapping.tsx
@@ -31,7 +31,7 @@ const SelectOne = ({
     <option value="" className="text-base">
       Select Type ...
     </option>
-    {options.map((op, i) => (
+    {[...options].sort().map((op, i) => (
       <option value={op} key={i}>
         {op}
       </option>


### PR DESCRIPTION
### Description
This adds alphabetical sorting to the type dropdowns on the remote schema page in the console.

### Changelog

Sort the types in type dropdowns on the remote schema page alphabetically.

__Component__ : console

__Type__: enhancement

__Product__: community-edition

#### Short Changelog

Sort the types in type dropdowns on the remote schema page alphabetically.

<!-- Changelog Section End -->

### Related Issues
Close #9412

### Solution and Design
Added a `sort()` in the compoents that render the dropdown. I was wondering if the sort shoud actually happen furhter up the chain but opted for this for now. Also noticed there are a few other places in the codebase that `sort()` in the same place where the dropdown is rendered.

### Steps to test and verify
Check if the types are listed alphabetically in the dropdown

### Limitations, known bugs & workarounds


### Server checklist

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/latest/graphql/core/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
