### PR TITLE
optimize typescript compiler performance

### DIFF
--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -256,7 +256,7 @@
         "terser-webpack-plugin": "4.2.3",
         "ts-jest": "^27.1.4",
         "tsconfig-paths-webpack-plugin": "^3.5.1",
-        "typescript": "4.5.2",
+        "typescript": "4.9.5",
         "url-loader": "1.1.2",
         "webpack": "4.42.0",
         "webpack-cli": "4.10.0",
@@ -44827,9 +44827,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -82097,9 +82097,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "ua-parser-js": {

--- a/console/package.json
+++ b/console/package.json
@@ -326,7 +326,7 @@
     "terser-webpack-plugin": "4.2.3",
     "ts-jest": "^27.1.4",
     "tsconfig-paths-webpack-plugin": "^3.5.1",
-    "typescript": "4.5.2",
+    "typescript": "4.9.5",
     "url-loader": "1.1.2",
     "webpack": "4.42.0",
     "webpack-cli": "4.10.0",

--- a/console/src/components/Services/RemoteSchema/Permissions/Field.tsx
+++ b/console/src/components/Services/RemoteSchema/Permissions/Field.tsx
@@ -56,7 +56,6 @@ export const Field: React.FC<FieldProps> = ({
     // happens only first time when the node is created
     if (
       fieldVal &&
-      fieldVal !== {} &&
       Object.keys(fieldVal).length > 0 &&
       !isEmpty(fieldVal) &&
       !autoExpandInputPresets
@@ -67,12 +66,7 @@ export const Field: React.FC<FieldProps> = ({
   }, [autoExpandInputPresets]);
 
   useEffect(() => {
-    if (
-      fieldVal &&
-      fieldVal !== {} &&
-      Object.keys(fieldVal).length > 0 &&
-      !isEmpty(fieldVal)
-    ) {
+    if (fieldVal && Object.keys(fieldVal).length > 0 && !isEmpty(fieldVal)) {
       context.setArgTree((argTree: Record<string, any>) => {
         const tree = i.parentName
           ? {

--- a/console/src/features/Analytics/components/Analytics.tsx
+++ b/console/src/features/Analytics/components/Analytics.tsx
@@ -91,7 +91,6 @@ export function Analytics(props: AnalyticsProps) {
   // Handling the <Analytics><title>XXX</title></Analytics> edge case
   if (
     type === 'htmlElement' &&
-    // @ts-expect-error TS 4.5.2 (used in the Console at the time of writing) does not support inferring
     // the correct type of children. TS 4.8 (which I tested) works fine.
     typedChildren.type === 'title' &&
     isNotProduction

--- a/console/src/features/ControlPlane/client.ts
+++ b/console/src/features/ControlPlane/client.ts
@@ -50,7 +50,7 @@ export const createControlPlaneClient = (
 
     const request = subscriptionsClient.request({
       query: queryDoc,
-      variables,
+      variables: variables || {},
     });
     const { unsubscribe } = request.subscribe({
       next: (data: any) => {

--- a/console/src/hooks/createFetchControlPlaneData.ts
+++ b/console/src/hooks/createFetchControlPlaneData.ts
@@ -52,7 +52,7 @@ export function createFetchControlPlaneData<RESPONSE_DATA>(opts: {
         { 'content-type': 'application/json' }
       );
 
-      if ('errors' in response) {
+      if (response && typeof response === 'object' && 'errors' in response) {
         const errorMessage = response.errors?.[0]?.message ?? '';
 
         return errorMessage;

--- a/console/tsconfig.json
+++ b/console/tsconfig.json
@@ -18,7 +18,8 @@
     "noImplicitReturns": true,
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "skipLibCheck": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
### Description

This PR makes TypeScript compiler over 3x faster:

BEFORE:
<img width="702" alt="CleanShot 2023-02-27 at 14 05 48@2x" src="https://user-images.githubusercontent.com/9019397/221571827-6388c663-17e1-46d0-a04f-322bb8234370.png">

AFTER:
<img width="729" alt="CleanShot 2023-02-27 at 14 03 18@2x" src="https://user-images.githubusercontent.com/9019397/221571856-1a08e0f6-436e-423e-8aa4-3c163944fb12.png">

Long story short, I was looking at some bigger TypeScript repos to play a bit with optimizing TS performance. I generated a trace for the console and found that `react-hook-form` is quite slow (the `Controller` components turned out to be a bottleneck), so I first tried to fix that, but then found this issue: https://github.com/microsoft/TypeScript/issues/46948, and I upgraded TS to see if that helps. Turns out it does! 🔥

I also updated the code in a few places to make it work with the newest TS.

### Changelog

<!-- Fill this section if this is a user facing change. -->

N/A

### Steps to test and verify

Run extended diagnostics to see the improvement.

### Limitations, known bugs & workarounds

You could think about excluding Storybook's stories from the ts build (add it to tsconfig and possibly create a separate config for Storybook?). That would improve the time even more.
