### PR TITLE
Documentation: Typo in migrations page

### DIFF
--- a/docs/docs/migrations-metadata-seeds/manage-migrations.mdx
+++ b/docs/docs/migrations-metadata-seeds/manage-migrations.mdx
@@ -64,7 +64,7 @@ hasura migrate create "init" --from-server
 ```
 
 This will create a new folder named in the format `<timestamp>_init` within another folder of the name of the database
-in Hasura which is being referenced. It will contain only an `up.sql` file which describes in SQL how to create the
+in which Hasura is being referenced. It will contain only an `up.sql` file which describes in SQL how to create the
 schema in full for that database.
 
 ### Create a Migration manually {#create-manual-migrations}


### PR DESCRIPTION


### Description

Fixes a small typo in the documentation about database migrations

### Changelog

Fixes a small typo in the documentation about database migrations

#### Short Changelog

Typo in migrations page

#### Long Changelog

Fixes a small typo in the documentation about database migrations

