### PR TITLE
Use COPY --chmod to remove duplicated layer.

### DIFF
--- a/packaging/cli-migrations/v2/Dockerfile
+++ b/packaging/cli-migrations/v2/Dockerfile
@@ -18,9 +18,7 @@ RUN mkdir -p /.hasura \
 ENV HASURA_GRAPHQL_SHOW_UPDATE_NOTIFICATION=false
 
 COPY docker-entrypoint.sh /bin/
-COPY hasura-cli /bin/hasura-cli
-
-RUN chmod +x /bin/hasura-cli
+COPY --chmod=+x hasura-cli /bin/hasura-cli
 
 # set an env var to let the cli know that
 # it is running in server environment

--- a/packaging/cli-migrations/v3/Dockerfile
+++ b/packaging/cli-migrations/v3/Dockerfile
@@ -18,9 +18,7 @@ RUN mkdir -p /.hasura \
 ENV HASURA_GRAPHQL_SHOW_UPDATE_NOTIFICATION=false
 
 COPY docker-entrypoint.sh /bin/
-COPY hasura-cli /bin/hasura-cli
-
-RUN chmod +x /bin/hasura-cli 
+COPY --chmod=+x hasura-cli /bin/hasura-cli
 
 # set an env var to let the cli know that
 # it is running in server environment


### PR DESCRIPTION
### Description

If you look at the output of `docker inspect` you'll notice duplicated layers in the cli-migrations image.

```
"RootFS": {
            "Type": "layers",
            "Layers": [
                "sha256:ec1ff79c26dd6d2ed7f5dd2a239e909d1f97472332ac1c3e17a7d071f9de3cd3",
                "sha256:1ffdbdfaa9e141a0c5b5fd4f29cb4eaa6bebdb9389fed9868504ff3033ad6229",
                "sha256:4a61a394fb3c6fa80270c0c5ae7fb60629dc3d1cdd3042a97dac8d9b96bab1ca",
                "sha256:696932557942dae512d5d778679ac4bc74ffc8a0ee8e8606ff0213c35896894f",
                "sha256:14b786641391f669d408dac5919e589eca63b715440fc35a275be96a70917841",
                "sha256:055073d24602b3c4f290dd7a3491eb47bdd7804ccf674e7406bdf14e0da6e5bd",
                "sha256:253f77e45d2ddb11439cecaa36d9a46375afe4fa10e062cd8fa18b495c2a0ff4",
                "sha256:b34b044d137cd1c5dbb37c8fae547665d0ac13a7922d4c715fdd3b06a4177f2d",
                "sha256:1c51ee10e2a2e4a9b9e2e4c936e0d4933d92ea181bb221eca4c7b63ba05c0112",
                "sha256:0fcf13a65e8d4348eb00fe850e861570f1dbf0b6d56250e8dabf62d5157b5210",
                "sha256:6ddb3f50e6d942c9124561ba1716332b4a1be73c980e2ebd091f9ec70335c4c3",
                "sha256:9c64603824021b306dcfa207f8b5a3a7825ca7bb5c1a7d4a03086fab25e82923",
                "sha256:9c64603824021b306dcfa207f8b5a3a7825ca7bb5c1a7d4a03086fab25e82923"
            ]
        },
```

This prevents us from deploying hasura using bazel and `rules_oci` because `rules_oci` expects no duplicate layers.

#### Short Changelog
 
Remove duplicate layers in cli-migration images


