### PR TITLE
Docs: Add left/right element

### DIFF
--- a/docs/docs/api-reference/graphql-api/mutation.mdx
+++ b/docs/docs/api-reference/graphql-api/mutation.mdx
@@ -10,7 +10,12 @@ keywords:
   - mutation
 ---
 
+import LeftRight from '@site/src/components/LeftRight';
+
 # API Reference - Mutation
+
+<LeftRight>
+  <section>
 
 ## **insert** (upsert) syntax {#insert-upsert-syntax}
 
@@ -32,6 +37,9 @@ mutation [<mutation-name>] {
 | mutation-response   | true     | [MutationResponse](#mutationresponse)     | Object to be returned after mutation succeeds                   |
 | on-conflict         | false    | [OnConflictClause](#postgres-on-conflict) | In Postgres, converts _insert_ to _upsert_ by handling conflict |
 | if-matched          | false    | [IfMatchedClause](#sqlserver-if-matched)  | In MS SQL Server, converts _insert_ to _upsert_ using a match   |
+
+  </section>
+  <section>
 
 **Example: Insert**
 
@@ -58,6 +66,9 @@ mutation upsert_author {
   }
 }
 ```
+
+  </section>
+</LeftRight>
 
 ## **insert_one** syntax {#insert-upsert-one-syntax}
 

--- a/docs/src/components/LeftRight.jsx
+++ b/docs/src/components/LeftRight.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const LeftRight = ({ children }) => {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))' }}>
+      <div style={{ paddingRight: '10px' }}>{children[0]}</div>
+      <div>{children[1]}</div>
+    </div>
+  );
+};
+
+export default LeftRight;


### PR DESCRIPTION
### Description

Adds a component and an example to split a section into a left and right side. I don't think that this is an improvement the way it is, but it may be the start of a potential solution.

### Solution and Design

<img width="1016" alt="image" src="https://github.com/hasura/graphql-engine/assets/326935/1449a441-0b41-49b7-b719-5a1af187d411">

http://localhost:3000/docs/latest/api-reference/graphql-api/mutation/

### Limitations, known bugs & workarounds

Since both the right and left contents are too wide and would require scrolling, I consider this new solution worse, compared to how it is currently implemented.

If this new solution is to be considered, the contents of the document would need to span over the two red boxes in the screenshot below, so that less space is lost on the screen:

how it is at the moment:

<img width="2535" alt="image" src="https://github.com/hasura/graphql-engine/assets/326935/16fffd87-14f3-428a-b435-3969f66d8e95">

hacked together how it would make more sense to me (but probably brings other issues / doesn't make sense on every page):

<img width="2551" alt="image" src="https://github.com/hasura/graphql-engine/assets/326935/357356e2-e865-48db-887c-098d152b2b27">

Note: The `300px` in `LeftRight` is certainly not large enough, and only so small to demonstrate an example. The side-by side view should only be available if the screen is very wide IMHO.