### PR TITLE
Fix CLI in docker container

### DIFF
--- a/cli/commands/console.go
+++ b/cli/commands/console.go
@@ -136,7 +136,7 @@ func (o *ConsoleOptions) Run() error {
 		return errors.E(op, "cannot validate version, object is nil")
 	}
 
-	apiServer, err := console.NewAPIServer(o.APIHost.Host, o.APIPort, o.EC)
+	apiServer, err := console.NewAPIServer(o.Address, o.APIPort, o.EC)
 	if err != nil {
 		return errors.E(op, err)
 	}


### PR DESCRIPTION
Fix #2824

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
The api server should listen on the `--address` arg whereas the console (frontend) should use `--api-host` arg to make API requests. With this change, the following command can be used inside a docker container to run the CLI console:
```bash
hasura console --address "0.0.0.0" --api-host "http://localhost" --api-port "9693" --endpoint <GRAPHQL_ENGINE_ENDPOINT> --console-hge-endpoint <GRAPHQL_ENGINE_ENDPOINT_FOR_BROWSER> --no-browser
```

### Changelog

<!-- Fill this section if this is a user facing change. -->

__Component__ : cli <!-- choose one -->

__Type__: bugfix <!-- choose one -->

__Product__: community-edition

<!-- Changelog Section End -->
