### PR TITLE
docs: fix typo in data validations using hasura permissions section

### DIFF
--- a/docs/docs/schema/postgres/data-validations.mdx
+++ b/docs/docs/schema/postgres/data-validations.mdx
@@ -361,7 +361,7 @@ If we try to insert a customer with an invalid email, we will get a `validation-
       "message": "customer email id is not valid",
       "extensions": {
         "path": "$",
-        "code": "validation-dfailed"
+        "code": "validation-failed"
       }
     }
   ]


### PR DESCRIPTION
### Description
Fixes typo in https://hasura.io/docs/latest/schema/postgres/data-validations/#using-hasura-permissions response example.

Hi, just found it while I am reading the docs. I thought I'll fix right away. It is so minor that I did not want to create an issue for this. I hope this is fine.