### PR TITLE
fix: :bug: fix the issue where server metadata contains postgres func | close #9862

### DIFF
--- a/cli/internal/hasura/client.go
+++ b/cli/internal/hasura/client.go
@@ -44,6 +44,7 @@ const (
 	SourceKindCitus     SourceKind = "citus"
 	SourceKindCockroach SourceKind = "cockroach"
 	SourceKindBigQuery  SourceKind = "bigquery"
+	SourceKindSnowflake SourceKind = "snowflake"
 )
 
 type V2Query interface {


### PR DESCRIPTION
There is a bug in if statement that resolves the kind of the function (postgres || snowflake) causing the error and metadata export to fail, this solution checks the kind of the source to determine the type of the functions of the source.

fix #9862 

### Description
After the fix the user will be able to export or track metadata changes for sources that contain both postgres functions and snowflake functions.

### Changelog

__Component__ : cli

__Type__: bugfix

__Product__: community-edition, enterprise, cloud, etc. (same CLI is used by all products to my knowledge)

#### Short Changelog

replaced faulty if statement with the switch that looks for source.Kind

### Related Issues
#9862 

### Solution and Design
Issue is resolved by looking at the source source.Kind in the list of sources, because functions are nested by the database name it is safe to assume that the functions.yaml files in the folder of the related source be the type we are looking for. This should be preferred way then to look at the the structure of each function yaml file.

### Steps to test and verify
To verify the fix you will need to add source with postgres function and try to run `hasura metadata export` it should pass.

### Limitations, known bugs & workarounds
No limitations.

### Server checklist
No changes to the server code

#### Catalog upgrade

Does this PR change Hasura Catalog version?
- [x] No

#### Metadata

Does this PR add a new Metadata feature?
- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No Breaking changes
