### PR TITLE
Fix Event Trigger creation for MSSQL tables with reserved word columns (close #9929)

### DIFF
--- a/server/src-lib/Hasura/Backends/MSSQL/DDL/EventTrigger.hs
+++ b/server/src-lib/Hasura/Backends/MSSQL/DDL/EventTrigger.hs
@@ -757,9 +757,9 @@ generateColumnTriggerAlias op colPrefixMaybe colInfo =
         case colPrefixMaybe of
           -- prefix with the joining table's name
           -- `id` -> `inserted.id` (prefix = 'inserted')
-          Just colPrefix -> colPrefix <> "." <> dbColNameText
+          Just colPrefix -> "[" <> colPrefix <> "].[" <> dbColNameText <> "]"
           -- do not prefix anthing to the column name
-          Nothing -> dbColNameText
+          Nothing -> "[" <> dbColNameText <> "]"
       -- create the alias for the column
       -- `payload.data.old.id` (opText = old) (dbColNameText = id)
       dbColAlias = "payload.data" <> "." <> opText <> "." <> dbColNameText
@@ -802,7 +802,7 @@ mkPrimaryKeyJoinExp lhsPrefix rhsPrefix columns =
   where
     singleColExp colInfo =
       let dbColNameText = columnNameText $ ciColumn colInfo
-       in LT.toStrict $ [ST.stext| #{lhsPrefix}.#{dbColNameText} = #{rhsPrefix}.#{dbColNameText} |]
+       in LT.toStrict $ [ST.stext| [#{lhsPrefix}].[#{dbColNameText}] = [#{rhsPrefix}].[#{dbColNameText}] |]
 
 -- Creates the WHERE clause for UPDATE SQL Trigger
 -- eg: If no listenColumns are defined then the where clause is an empty text
@@ -814,7 +814,7 @@ mkListenColumnsExp lhsPrefix rhsPrefix columns =
   where
     singleColExp colInfo =
       let dbColNameText = columnNameText $ ciColumn colInfo
-       in LT.toStrict $ [ST.stext| #{lhsPrefix}.#{dbColNameText} != #{rhsPrefix}.#{dbColNameText} |]
+       in LT.toStrict $ [ST.stext| [#{lhsPrefix}].[#{dbColNameText}] != [#{rhsPrefix}].[#{dbColNameText}] |]
 
 -- | Check if primary key is present in listen columns
 -- We use this in update event trigger, to check if the primary key has been updated


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description

<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

When creating an Event Trigger in Hasura for MSSQL, if the table's column name contains reserved words like `group`, it results in an error. This PR addresses this issue by wrapping all column names with `[]` in the Trigger creation SQL issued by Hasura, ensuring proper escaping and preventing such errors.

### Changelog

<!-- Fill this section if this is a user facing change. -->

__Component__ : server <!-- choose one -->

__Type__: bugfix <!-- choose one -->

__Product__: community-edition

#### Short Changelog

<!-- One line description of this change. (optional if you choose to fill the Long Changelog section instead) -->

Fixed an issue where Event Triggers for MSSQL failed for tables with columns named after reserved words.

#### Long Changelog

<!--
  Detailed description of this change. This might contain links to documentation, blogposts, images. Use markdown for formatting.
  (optional if you choose to fill the Short Changelog section instead)
-->

- Column names in the Trigger creation SQL for MSSQL are now wrapped with `[]`, providing proper escaping.
- This change addresses a limitation where reserved words used as column names caused Event Trigger creation to fail.
- Users can now safely create Event Triggers for tables, even if they contain reserved words as column names.

<!-- Changelog Section End -->

### Related Issues

<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

#9929

### Solution and Design

<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

To address the issue where reserved words as column names caused failures, we've wrapped every column name with square brackets `[]` in the Trigger creation SQL. This ensures proper escaping and allows the SQL command to be processed without errors.

### Steps to test and verify

<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

1. Set up a MSSQL database with a table containing a column named `group` or any other reserved word.
2. Try creating an Event Trigger for this table using Hasura.
3. The process should complete successfully without any errors.



### Limitations, known bugs & workarounds

<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

No known limitations or bugs at this time.

### Server checklist

<!-- A checklist for server code -->

#### Catalog upgrade

<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?

- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/latest/graphql/core/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata

<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?

- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL

- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
  - [ ] New types and typenames are correlated
    <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
    <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes

- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:

     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
       <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->

     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
       <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->

     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
       <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
       <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->