### PR TITLE
Chore : Fixed typo in multiple files in docs folder

### DIFF
--- a/docs/docs/actions/rest-connectors.mdx
+++ b/docs/docs/actions/rest-connectors.mdx
@@ -141,7 +141,7 @@ The context variables available in transforms are:
 | $body              | Original body of action request            |
 | $base_url          | Original configured webhook handler URL    |
 | $session_variables | Session variables                          |
-| $response.status   | HTTP response staus code from the webhook  |
+| $response.status   | HTTP response status code from the webhook  |
 
 In addition to these variables, the following functions are available in addition to the standard
 [Basic Functions](/api-reference/kriti-templating.mdx#kriti-function-reference):

--- a/docs/docs/api-reference/syntax-defs.mdx
+++ b/docs/docs/api-reference/syntax-defs.mdx
@@ -1569,7 +1569,7 @@ HGE provides the following functions that can be used in the template:
 | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
 | action        | true     | remove \| transform \| x_www_form_urlencoded                                                                             | The action to perform on the request body.                                                                   |
 | template      | false    | String                                                                                                                   | The transformation template to be applied to the body. This is required if the action is _transform_.        |
-| form_template | false    | Object ([String](/schema/postgres/postgresql-types.mdx#string) : [String](/schema/postgres/postgresql-types.mdx#string)) | The key/value pairs to be used in a `x-www-url-formencoded` body. The values can be transfomation templates. |
+| form_template | false    | Object ([String](/schema/postgres/postgresql-types.mdx#string) : [String](/schema/postgres/postgresql-types.mdx#string)) | The key/value pairs to be used in a `x-www-url-formencoded` body. The values can be transformation templates. |
 
 ## TemplateEngine {#templateengine}
 

--- a/docs/docs/auth/authorization/permissions/common-roles-auth-examples.mdx
+++ b/docs/docs/auth/authorization/permissions/common-roles-auth-examples.mdx
@@ -99,7 +99,7 @@ data that belongs to that particular organization. In this case, the particular 
 which denotes the organization.
 
 Let's say we have an online store where each vendor on the store has its own products. We want to allow the manager
-of a vendor to be able to see all the products that belong to that vendor and the indentifying `vendor_id` is saved
+of a vendor to be able to see all the products that belong to that vendor and the identifying `vendor_id` is saved
 on the `products` table itself.
 
 - Create a role called `manager`.

--- a/docs/docs/deployment/performance-tuning.mdx
+++ b/docs/docs/deployment/performance-tuning.mdx
@@ -143,7 +143,7 @@ Observability tools help us track issues, alert us to errors, and allow us to mo
 is critical in production. There are many open-source and commercial services. However, you may have to combine many
 tools because of the architectural complexity. For more information, check out our
 [observability section](/observability/overview.mdx) and our
-[observability best practives](/observability/observability-best-practices.mdx).
+[observability best practices](/observability/observability-best-practices.mdx).
 
 ## Software architecture and best practices
 

--- a/docs/docs/event-triggers/recipes/product-description-chatgpt-seo.mdx
+++ b/docs/docs/event-triggers/recipes/product-description-chatgpt-seo.mdx
@@ -377,7 +377,7 @@ async def update_product_description(product_id, improved_description):
     "x-hasura-admin-secret": HASURA_ADMIN_SECRET,
   }
 
-  #Ideally store your querys in another file where you can re-use them
+  #Ideally store your queries in another file where you can re-use them
   body = {
       "query": """
           mutation UpdateProduct($id: uuid!, $description: String) {

--- a/docs/docs/event-triggers/rest-connectors.mdx
+++ b/docs/docs/event-triggers/rest-connectors.mdx
@@ -154,7 +154,7 @@ The context variables available in transforms are:
 | $base_url          | Original configured webhook URL                           |
 | $session_variables | Session variables                                         |
 | $query_params      | Query parameters and the values to be sent to the webhook |
-| $response.status   | HTTP response staus code from the webhook                 |
+| $response.status   | HTTP response status code from the webhook                 |
 
 #### Console sample context {#event-trigger-transforms-sample-context}
 

--- a/docs/docs/migrations-metadata-seeds/legacy-configs/config-v2/advanced/seed-data-migration.mdx
+++ b/docs/docs/migrations-metadata-seeds/legacy-configs/config-v2/advanced/seed-data-migration.mdx
@@ -42,7 +42,7 @@ INSERT INTO authors (id, name, address_id) VALUES
   (3, 'Rachel', 2);
 INSERT INTO articles (id, title, content, author_id) VALUES
   (1, 'How to make fajitas', 'Recipe on making the best fajitas in the world', 1),
-  (2, 'How to climb mount everest', 'Guide on successfully climbing the hightest mountain in the world', 3),
+  (2, 'How to climb mount everest', 'Guide on successfully climbing the highest mountain in the world', 3),
   (3, 'How to be successful on broadway', 'What it takes for you to be a successful performer at broadway', 2);
 ```
 

--- a/docs/docs/schema/snowflake/custom-functions.mdx
+++ b/docs/docs/schema/snowflake/custom-functions.mdx
@@ -90,7 +90,7 @@ X-Hasura-Role: admin
 
 :::info Note
 
-Snowflake doesn't currently support direct reference of tables in the return type of function definitions. To accomadate
+Snowflake doesn't currently support direct reference of tables in the return type of function definitions. To accommodate
 for this, Hasura currently requires that the response be specified in metadata.
 
 :::

--- a/docs/docs/subscriptions/postgres/streaming/index.mdx
+++ b/docs/docs/subscriptions/postgres/streaming/index.mdx
@@ -35,7 +35,7 @@ Streaming subscriptions work well with other Hasura features like
 [relationships](/schema/postgres/table-relationships/index.mdx#table-relationships) and also leverage the power of
 [subscriptions multiplexing](/subscriptions/postgres/livequery/execution.mdx#subscription-multiplexing).
 
-:::info Confguration details
+:::info Configuration details
 
 In the case of streaming subscriptions, the multiplexed batch size can be configured via
 `HASURA_GRAPHQL_STREAMING_QUERIES_MULTIPLEXED_BATCH_SIZE` and the refetch interval can be configured via

--- a/docs/wiki/docusaurus-mdx-guide/headings.mdx
+++ b/docs/wiki/docusaurus-mdx-guide/headings.mdx
@@ -99,7 +99,7 @@ They can also be generated when required using the cli command
 [write-heading-ids](https://docusaurus.io/docs/cli#docusaurus-write-heading-ids-sitedir) - Please _DO NOT OVERRIDE_
 existing ones.
 
-Skip for `h1 (#)` as the top level heading is beginining of file the direct link without `#hash-param` would work fine.
+Skip for `h1 (#)` as the top level heading is beginning of file the direct link without `#hash-param` would work fine.
 
 :::danger Please do not add id in frontmatter
 

--- a/docs/wiki/docusaurus-mdx-guide/links.mdx
+++ b/docs/wiki/docusaurus-mdx-guide/links.mdx
@@ -57,7 +57,7 @@ Read more about it from [Docusaurus Document Id Section](https://docusaurus.io/d
 
 :::
 
-To avoid repetetion of adding dull path for each link, we could take advantage of
+To avoid repetition of adding dull path for each link, we could take advantage of
 [reference-style-links](https://daringfireball.net/projects/markdown/syntax#link) syntax in markdown.
 
 :::tip Managing repeated Links in same doc

--- a/docs/wiki/style/code-blocks.mdx
+++ b/docs/wiki/style/code-blocks.mdx
@@ -49,5 +49,5 @@ slug: code-blocks
 ### YAML
 
 - YAML should always be indented by 2 spaces as per the spec.
-- Include only the relevant part of the code if it provides more clarity to the user. Indicate ommitted lines with
+- Include only the relevant part of the code if it provides more clarity to the user. Indicate omitted lines with
   `...`

--- a/docs/wiki/style/tables.mdx
+++ b/docs/wiki/style/tables.mdx
@@ -13,5 +13,5 @@ slug: tables
 - Should be in Markdown syntax due to its convenience to read as a table in code.
 - If markdown syntax becomes difficult to edit due to length, then use JSX syntax.
 
-<!-- We should include some exmaples here...the syntax needed for <table /> to
+<!-- We should include some examples here...the syntax needed for <table /> to
 render in *.md is ugly but necessary for those behemoth tables. -->

--- a/docs/wiki/working-with-docusaurus.mdx
+++ b/docs/wiki/working-with-docusaurus.mdx
@@ -27,7 +27,7 @@ All the magic happens here. [SEO](https://docusaurus.io/docs/seo), [Theme](https
 
 Please check the [API for all possible config options here](https://docusaurus.io/docs/api/docusaurus-config).
 
-## Cleint API - components, hooks etc.
+## Client API - components, hooks etc.
 
 Please check the [client API docs](https://docusaurus.io/docs/docusaurus-core) for available React components, hooks &
 modules.
@@ -62,7 +62,7 @@ To override, please add a `_category_.json` and add the `label` and `position` p
 
 :::info More about Sidebar
 
-You can also create a custom sidebar and add everthing manually.
+You can also create a custom sidebar and add everything manually.
 
 Checkout Docusaurus Docs for Sidebar - https://docusaurus.io/docs/sidebar
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

This PR fix the typo in files of docs folder.

```pseudo
staus  > status
transfomation > transformation
practives > practices
accomadate > accommodate
hightest > highest
beginining > beginning
ommitted > omitted
everthing > everything
```