### PR TITLE
console: sort filter and sort column options alphabetically, close #9966

### DIFF
--- a/frontend/libs/console/legacy-ce/src/lib/features/BrowseRows/components/RunQuery/Filter/FilterRows.tsx
+++ b/frontend/libs/console/legacy-ce/src/lib/features/BrowseRows/components/RunQuery/Filter/FilterRows.tsx
@@ -52,12 +52,14 @@ export const FilterRows = ({
     onRemove?.();
   };
 
-  const columnOptions: SelectItem[] = columns.map(column => {
-    return {
-      label: column.name,
-      value: column.name,
-    };
-  });
+  const columnOptions: SelectItem[] = columns
+    .sort((a, b) => (a.name > b.name ? 1 : -1))
+    .map(column => {
+      return {
+        label: column.name,
+        value: column.name,
+      };
+    });
 
   const operatorOptions: SelectItem[] = operators.map(operator => ({
     label: `[${operator.value}] ${operator.name}`,

--- a/frontend/libs/console/legacy-ce/src/lib/features/BrowseRows/components/RunQuery/Sort/SortRows.tsx
+++ b/frontend/libs/console/legacy-ce/src/lib/features/BrowseRows/components/RunQuery/Sort/SortRows.tsx
@@ -32,12 +32,14 @@ export const SortRows = ({
     }
   }, [initialSorts?.length]);
 
-  const columnOptions: SelectItem[] = columns.map(column => {
-    return {
-      label: column.name,
-      value: column.name,
-    };
-  });
+  const columnOptions: SelectItem[] = columns
+    .sort((a, b) => (a.name > b.name ? 1 : -1))
+    .map(column => {
+      return {
+        label: column.name,
+        value: column.name,
+      };
+    });
 
   const orderByOptions = [
     {


### PR DESCRIPTION
### Description
Sorts the columns in the filter and sort column selectors alphabetically

### Changelog

__Component__ : console

__Type__: enhancement

__Product__: community-edition

#### Short Changelog

added sort function to the select options for the filter and sort column options

#### Long Changelog

before:
![image](https://github.com/hasura/graphql-engine/assets/1710840/f5a07d2e-d25c-484c-9e03-985a4db5e32f)


after:
![image](https://github.com/hasura/graphql-engine/assets/1710840/f611e23e-7433-49cf-aaa6-409b632379be)
![image](https://github.com/hasura/graphql-engine/assets/1710840/63b25098-30cd-4ab2-a802-0e7c9d2271ae)

### Related Issues
#9966

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes: