### PR TITLE
console: prettify variable json when clicking on the prettify button, close 9968

### DIFF
--- a/frontend/libs/console/legacy-ce/src/lib/components/Services/ApiExplorer/GraphiQLWrapper/GraphiQLWrapper.js
+++ b/frontend/libs/console/legacy-ce/src/lib/components/Services/ApiExplorer/GraphiQLWrapper/GraphiQLWrapper.js
@@ -137,10 +137,23 @@ class GraphiQLWrapper extends Component {
     const handleClickPrettifyButton = () => {
       trackGraphiQlToolbarButtonClick('Prettify');
 
-      const editor = graphiqlContext.getQueryEditor();
-      const currentText = editor.getValue();
-      const prettyText = print(sdlParse(currentText));
-      editor.setValue(prettyText);
+      const queryEditor = graphiqlContext.getQueryEditor();
+      const currentQueryText = queryEditor.getValue();
+      const prettyQueryText = print(sdlParse(currentQueryText));
+      queryEditor.setValue(prettyQueryText);
+
+      try {
+        const variableEditor = graphiqlContext.getVariableEditor();
+        const currentVariableText = variableEditor.getValue();
+        const prettyVariableText = JSON.stringify(
+          JSON.parse(currentVariableText),
+          null,
+          2
+        );
+        variableEditor.setValue(prettyVariableText);
+      } catch (err) {
+        // Ignore json parse errors, since we can't format invalid json anyway
+      }
     };
 
     const handleToggleHistory = () => {


### PR DESCRIPTION
### Description
When i click the prettify button in the web console only the query is prettified, and not the json for the variables.
This PR will also prettify the variable json if it is valid json. If it is not valid json, it will leave the variable text alone.

### Changelog

__Component__ : console

__Type__: enhancement

__Product__: community-edition

#### Short Changelog

Added a second part to the handleClickPrettifyButton handler to also fetch the variable json and format it

#### Long Changelog

Added a second part to the handleClickPrettifyButton handler to also fetch the variable json, parse it to json and then stringify it back into formatted json
All this wrapped into a try catch block, so if the parsing of the json fails, we can recover.

before:
![image](https://github.com/hasura/graphql-engine/assets/1710840/f40279c4-4058-4226-88e1-309f81fbfb50)
![image](https://github.com/hasura/graphql-engine/assets/1710840/eee9fa72-a6d2-41f0-beda-a34e15617f4b)


after:
![image](https://github.com/hasura/graphql-engine/assets/1710840/c9ec9a15-64b3-41a2-ae8e-5045813097c2)
![image](https://github.com/hasura/graphql-engine/assets/1710840/ce004fcc-82fa-461b-bef8-fc0a9045c6b5)



<!-- Changelog Section End -->

### Related Issues
#9968

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes: