### PR TITLE
console: automatically select the $eq operator when filtering table rows, close 9970

### DIFF
--- a/frontend/libs/console/legacy-ce/src/lib/features/BrowseRows/components/RunQuery/Filter/FilterRow.tsx
+++ b/frontend/libs/console/legacy-ce/src/lib/features/BrowseRows/components/RunQuery/Filter/FilterRow.tsx
@@ -27,6 +27,15 @@ export const FilterRow = ({
   const localValue = watch(`${name}.value`);
 
   /**
+   * Set operator to first operator if it is empty
+   */
+  useEffect(() => {
+    if (!localOperator && operatorOptions[0]?.value) {
+      setValue(`${name}.operator`, operatorOptions[0].value);
+    }
+  }, [localOperator, operatorOptions, setValue, name]);
+
+  /**
    * Set the default value into the input field depending on the operator type
    */
   useEffect(() => {


### PR DESCRIPTION
### Description
When filtering a table 80% of the time you want to find some uuid of a specific row. Currently you always have to select the $eq operator manually.
Select the $eq operator by default. That way, 80% of the time you save the user 2 clicks when setting up a filter. And the other 20% of the time it still only takes 2 clicks to choose a different operator. So there is no downside.

### Changelog

__Component__ : console

__Type__: enhancement

__Product__: community-edition

#### Short Changelog

Always select the first operator when adding a new filter row

#### Long Changelog

When localOperator is not set when adding a filter row, set it to the first available operator by default ($eq)


before:
![image](https://github.com/hasura/graphql-engine/assets/1710840/fc82eb03-135c-42fd-9ba6-f8bebe521339)


after:
![image](https://github.com/hasura/graphql-engine/assets/1710840/3363d29a-7088-4426-af03-e3cebd18400c)



<!-- Changelog Section End -->

### Related Issues
#9970

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes: