### PR TITLE
pass full request path to the post auth webhook, maybe fix #8771

### DIFF
--- a/server/src-lib/Hasura/Server/App.hs
+++ b/server/src-lib/Hasura/Server/App.hs
@@ -197,6 +197,10 @@ data APIHandler m a where
   AHGraphQLRequest :: !(GH.ReqsText -> Handler m (HttpLogGraphQLInfo, APIResp)) -> APIHandler m GH.ReqsText
   AHPersistedGraphQLRequest :: !(ExtQueryReqs -> Handler m (HttpLogGraphQLInfo, APIResp)) -> APIHandler m ExtQueryReqs
 
+data RequestInfo = RequestInfo
+  { fullPath :: Text }
+  deriving (Show)
+
 boolToText :: Bool -> Text
 boolToText = bool "false" "true"
 
@@ -326,7 +330,9 @@ mkSpockAction appStateRef qErrEncoder qErrModifier apiHandler = do
   let origHeaders = Wai.requestHeaders req
       ipAddress = Wai.getSourceFromFallback req
       pathInfo = Wai.rawPathInfo req
+      fullPath = bsToTxt $ pathInfo <> Wai.rawQueryString req
       propagators = getOtelTracesPropagator scOpenTelemetryConfig
+      requestInfo = RequestInfo { fullPath = fullPath }
 
   -- Bytes are actually read from the socket here. Time this.
   (ioWaitTime, reqBody) <- withElapsedTime $ liftIO $ Wai.strictRequestBody req
@@ -369,7 +375,7 @@ mkSpockAction appStateRef qErrEncoder qErrModifier apiHandler = do
         res <- lift $ runHandler (_lsLogger appEnvLoggers) handlerState handler
         pure (res, userInfo, authHeaders, includeInternal, Nothing, extraUserInfo)
       AHPost handler -> do
-        (userInfo, authHeaders, handlerState, includeInternal, extraUserInfo) <- getInfo Nothing
+        (userInfo, authHeaders, handlerState, includeInternal, extraUserInfo) <- getInfo requestInfo
         (queryJSON, parsedReq) <-
           runExcept (parseBody reqBody) `onLeft` \e -> do
             logErrorAndResp (Just userInfo) requestId req (reqBody, Nothing) includeInternal origHeaders extraUserInfo (qErrModifier e)


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
Pass the full request path to the auth webhook in the AHPost handler

### Changelog

<!-- Fill this section if this is a user facing change. -->

__Component__ : server <!-- choose one -->

__Type__: enhancement <!-- choose one -->

__Product__: community-edition

#### Short Changelog
Pass the full request path to the auth webhook in the AHPost handler

<!-- One line description of this change. (optional if you choose to fill the Long Changelog section instead) -->

#### Long Changelog

<!--
  Detailed description of this change. This might contain links to documentation, blogposts, images. Use markdown for formatting.
  (optional if you choose to fill the Short Changelog section instead)
-->


<!-- Changelog Section End -->

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#8771

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
TBH I'm not sure if my solution works, I simply create a new data type and create a variable with the full request path which is the path + query params, and then pass the variable to the getInfo function, don't know if this gonna break the type checking in haskell.
I only learned a bit haskell today and put up the PR with chatgpt. Please let me know if this totally wont work and how can I make it work. Really appreciated it, my company needs to use this feature to do some callback webhook secret from query params validation.
### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->
Send a api/rest request to the engine, then full path should be included in the request body of the request sending to auth hook.
### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->
n/a
### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/latest/graphql/core/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
