### PR TITLE
Add `from_env` to dataconnector config (fix #9777)

### DIFF
--- a/server/src-lib/Hasura/Backends/DataConnector/Adapter/Types.hs
+++ b/server/src-lib/Hasura/Backends/DataConnector/Adapter/Types.hs
@@ -18,6 +18,8 @@ module Hasura.Backends.DataConnector.Adapter.Types
     scTemplateVariables,
     scTimeoutMicroseconds,
     scEnvironment,
+    resolveDataConnectorUri,
+    DataConnectorUri (..),
     DataConnectorOptions (..),
     DataConnectorInfo (..),
     TableName (..),
@@ -41,9 +43,9 @@ where
 
 import Autodocodec (HasCodec (codec), optionalField', requiredField', requiredFieldWith')
 import Autodocodec qualified as AC
-import Autodocodec.Extended (baseUrlCodec)
+import Autodocodec.Extended (baseUrlCodec, fromEnvCodec)
 import Control.Lens (makeLenses)
-import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey, genericParseJSON, genericToJSON)
+import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey, genericParseJSON, genericToJSON, parseJSON, toJSON)
 import Data.Aeson qualified as J
 import Data.Aeson.KeyMap qualified as J
 import Data.Aeson.Types (parseEither, toJSONKeyText)
@@ -56,16 +58,18 @@ import Data.OpenApi (ToSchema)
 import Data.Text qualified as Text
 import Data.Text.Extended (ToTxt (..))
 import Hasura.Backends.DataConnector.API qualified as API
+import Hasura.Base.Error
 import Hasura.Base.ErrorValue qualified as ErrorValue
 import Hasura.Base.ToErrorValue (ToErrorValue (..))
 import Hasura.Prelude
 import Hasura.RQL.IR.BoolExp qualified as IR
+import Hasura.RQL.Types.Common (getEnv)
 import Hasura.RQL.Types.Backend (Backend)
 import Hasura.RQL.Types.BackendType (BackendType (..))
 import Hasura.RQL.Types.DataConnector
 import Language.GraphQL.Draft.Syntax qualified as GQL
 import Network.HTTP.Client qualified as HTTP
-import Servant.Client (BaseUrl)
+import Servant.Client (BaseUrl, parseBaseUrl)
 import Witch qualified
 
 --------------------------------------------------------------------------------
@@ -304,17 +308,61 @@ instance AC.HasCodec FunctionReturnType where
 
 ------------
 
+data DataConnectorUri
+  = RawUri BaseUrl
+  | FromEnvironment Text
+  deriving stock (Show, Eq, Generic)
+
+instance NFData DataConnectorUri
+
+instance HasCodec DataConnectorUri where
+  codec =
+    AC.dimapCodec
+      (either RawUri FromEnvironment)
+      (\case RawUri m -> Left m; FromEnvironment wEnv -> Right wEnv)
+      $ AC.disjointEitherCodec baseUrlCodec fromEnvCodec
+
+instance ToJSON DataConnectorUri where
+  toJSON =
+    \case
+      (RawUri m) -> toJSON m
+      (FromEnvironment wEnv) -> J.object ["from_env" J..= wEnv]
+
+instance FromJSON DataConnectorUri where
+  parseJSON =
+    \case
+      (J.Object o) -> FromEnvironment <$> o J..: "from_env"
+      s@(J.String _) -> RawUri <$> parseJSON s
+      _ -> fail "one of string or object must be provided"
+
+resolveDataConnectorUri ::
+  (MonadError QErr m) =>
+  Environment ->
+  DataConnectorUri ->
+  m BaseUrl
+resolveDataConnectorUri env =
+  \case
+    (RawUri uri) -> pure uri
+    (FromEnvironment envVar) -> do
+      envValue <- getEnv env envVar
+      case Text.unpack envValue of
+        uriStr -> onNothing
+          (parseBaseUrl uriStr)
+          (throw400 InvalidParams $ "Invalid URL for " <> envVar)
+
+------------
+
 data DataConnectorOptions = DataConnectorOptions
-  { _dcoUri :: BaseUrl,
+  { _dcoUri :: DataConnectorUri,
     _dcoDisplayName :: Maybe Text
   }
-  deriving stock (Eq, Ord, Show, Generic)
+  deriving stock (Show, Eq, Generic)
 
 instance HasCodec DataConnectorOptions where
   codec =
     AC.object "DataConnectorOptions"
       $ DataConnectorOptions
-      <$> requiredFieldWith' "uri" baseUrlCodec
+      <$> requiredField' "uri"
       AC..= _dcoUri
         <*> optionalField' "display_name"
       AC..= _dcoDisplayName

--- a/server/src-lib/Hasura/RQL/DDL/DataConnector.hs
+++ b/server/src-lib/Hasura/RQL/DDL/DataConnector.hs
@@ -90,7 +90,7 @@ runAddDataConnectorAgent ::
   m EncJSON
 runAddDataConnectorAgent DCAddAgent {..} = do
   let agent :: DC.Types.DataConnectorOptions
-      agent = DC.Types.DataConnectorOptions _gdcaUrl _gdcaDisplayName
+      agent = DC.Types.DataConnectorOptions (DC.Types.RawUri _gdcaUrl) _gdcaDisplayName
   sourceKinds <- (:) "postgres" . fmap _skiSourceKind . unSourceKinds <$> agentSourceKinds
   if
     | toTxt _gdcaName `elem` sourceKinds -> Error.throw400 Error.AlreadyExists $ "SourceKind '" <> toTxt _gdcaName <> "' already exists."

--- a/server/src-lib/Hasura/RQL/DDL/Schema/Cache.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Cache.hs
@@ -610,7 +610,7 @@ buildSchemaCacheRule logger env mSchemaRegistryContext = proc (MetadataWithResou
       let backendInvalidationKeys =
             Inc.selectMaybeD #unBackendInvalidationKeysWrapper
               $ BackendMap.lookupD @b backendInvalidationMap
-      backendInfo <- resolveBackendInfo @b logger -< (backendInvalidationKeys, unBackendConfigWrapper backendConfigWrapper)
+      backendInfo <- resolveBackendInfo @b logger env -< (backendInvalidationKeys, unBackendConfigWrapper backendConfigWrapper)
       returnA -< BackendMap.singleton (BackendInfoWrapper @b backendInfo)
 
     resolveBackendCache ::

--- a/server/src-lib/Hasura/RQL/Types/Metadata/Backend.hs
+++ b/server/src-lib/Hasura/RQL/Types/Metadata/Backend.hs
@@ -84,14 +84,16 @@ class
       ProvidesNetwork m
     ) =>
     Logger Hasura ->
+    Env.Environment ->
     (Inc.Dependency (Maybe (BackendInvalidationKeys b)), BackendConfig b) `arr` BackendInfo b
   default resolveBackendInfo ::
     ( Arrow arr,
       BackendInfo b ~ ()
     ) =>
     Logger Hasura ->
+    Env.Environment ->
     (Inc.Dependency (Maybe (BackendInvalidationKeys b)), BackendConfig b) `arr` BackendInfo b
-  resolveBackendInfo = const $ arr $ const ()
+  resolveBackendInfo _env = const $ arr $ const ()
 
   -- | Function that resolves the connection related source configuration, and
   -- creates a connection pool (and other related parameters) in the process


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

This PR enables `backend_configs.yaml` to specify data connector URIs through environment variables. As discussed in #9777, this use-case is particularly helpful for organizations who deploy the same configuration to multiple Hasura environments and utilize environment variables for env-specific arguments.

Apologies in advance for any Haskell-specific errors, this is my first time working with the language.

### Changelog

<!-- Fill this section if this is a user facing change. -->

__Component__ : server

__Type__: enhancement

__Product__: community-edition

#### Short Changelog

Creates a new data object, `DataConnectorUri`, that can be either `BaseUrl` or a `from_env` string. Calling objects use a new parsing function, `resolveDataConnectorUri`, to recover the original `BaseUrl`.

### Steps to test and verify
This has been tested by running [hasura/weaviate_gdc](https://github.com/hasura/weaviate_gdc) in a container, starting Hasura with an env var set to the new (i.e. `WEAVIATE_GDC_HOST=http://localhost:8100`), then using the Hasura CLI to deploy new metadata with the following `backend_config.yaml`

```yaml
dataconnector:
  weaviate:
    uri:
      from_env: WEAVIATE_GDC_HOST
```

### Limitations, known bugs & workarounds

No frontend considerations have been made.

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [X] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/latest/graphql/core/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [ ] No
- [X] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [X] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [X] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [X] Yes
    - [ ] Not required


#### GraphQL
- [X] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [X] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
