### PR TITLE
DOCS: Update metadata database url env var for k8s guide

### DIFF
--- a/docs/docs/deployment/deployment-guides/kubernetes.mdx
+++ b/docs/docs/deployment/deployment-guides/kubernetes.mdx
@@ -37,7 +37,7 @@ Edit `deployment.yaml` and set the right database url:
 
 ```yaml {2}
 env:
-  - name: HASURA_METADATA_DATABASE_URL
+  - name: HASURA_GRAPHQL_METADATA_DATABASE_URL
     value: postgres://<username>:<password>@hostname:<port>/<dbname>
 ```
 

--- a/docs/docs/deployment/deployment-guides/kubernetes.mdx
+++ b/docs/docs/deployment/deployment-guides/kubernetes.mdx
@@ -41,7 +41,7 @@ env:
     value: postgres://<username>:<password>@hostname:<port>/<dbname>
 ```
 
-Examples of `HASURA_METADATA_DATABASE_URL`:
+Examples of `HASURA_GRAPHQL_METADATA_DATABASE_URL`:
 
 - `postgres://admin:password@localhost:5432/my-db`
 - `postgres://admin:@localhost:5432/my-db` _(if there is no password)_
@@ -49,7 +49,7 @@ Examples of `HASURA_METADATA_DATABASE_URL`:
 :::info Note
 
 - If your **password contains special characters** (e.g. #, %, $, @, etc.), you need to URL encode them in the
-  `HASURA_METADATA_DATABASE_URL` env var (e.g. %40 for @).
+  `HASURA_GRAPHQL_METADATA_DATABASE_URL` env var (e.g. %40 for @).
 
   You can check the [logs](#kubernetes-logs) to see if the database credentials are proper and if Hasura is able to
   connect to the database.
@@ -104,7 +104,7 @@ spec:
      command: ["graphql-engine"]
      args: ["serve", "--enable-console"]
      env:
-     - name: HASURA_METADATA_DATABASE_URL
+     - name: HASURA_GRAPHQL_METADATA_DATABASE_URL
        value: postgres://<username>:<password>@hostname:<port>/<dbname>
      - name: HASURA_GRAPHQL_ADMIN_SECRET
        value: mysecretkey


### PR DESCRIPTION
### Description
When reviewing the environment variables here: https://hasura.io/docs/latest/deployment/graphql-engine-flags/reference/#metadata-database-url

I noticed that the metadata database URL env var was not current on the kubernetes deployment guide.

#### Catalog upgrade
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [x] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [x] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [x] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code

  2. GraphQL API

     Schema Generation:
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names

     Schema Resolve:-
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed

