### PR TITLE
Alter log level of garbage collector message (fix #10172)

### DIFF
--- a/server/src-lib/Hasura/GC.hs
+++ b/server/src-lib/Hasura/GC.hs
@@ -75,7 +75,7 @@ ourIdleGC (Logger logger) idleInterval minGCInterval maxNoGCInterval =
               else do
                 when (areOverdue && not areIdle)
                   $ logger
-                  $ UnstructuredLog LevelWarn
+                  $ UnstructuredLog LevelInfo
                   $ "Overdue for a major GC: forcing one even though we don't appear to be idle"
                 performMajorGC
                 startTimer >>= go (gcs + 1) (major_gcs + 1) True


### PR DESCRIPTION
### Description
The garbage collector runs periodically to free unused memory with the default operation set to occur during quiet periods. In the event that a quiet period does not arise, the garbage collector is forced and a warning generated to inform users this has occured.

As warnings require users to take action, this log message causes confusion. Therefore, the log level of the garbage collection message has been altered from LevelWarn to LevelInfo to provide information that this has occured without expectation of users to take action.

### Changelog

Instead of a warning when the GC is forced to run, an info message will be generated.

__Component__ : server

__Type__: bugfix

__Product__: community-edition

#### Short Changelog

Instead of a warning when the GC is forced to run, an info message will be generated.

#### Long Changelog

<!--
  Detailed description of this change. This might contain links to documentation, blogposts, images. Use markdown for formatting.
  (optional if you choose to fill the Short Changelog section instead)
-->


<!-- Changelog Section End -->

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [ ] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/latest/graphql/core/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code

  2. GraphQL API

     Schema Generation:
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names

     Schema Resolve:-
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
