### PR TITLE
Update action-handlers.mdx to use dashes intead of underscores in the headers

### DIFF
--- a/docs/docs/actions/action-handlers.mdx
+++ b/docs/docs/actions/action-handlers.mdx
@@ -202,7 +202,7 @@ Update the definition of your action by adding the action secret as a header:
        handler: http://localhost:3000
        forward_client_headers: true
        headers:
-         - name: ACTION_SECRET
+         - name: ACTION-SECRET
            value_from_env: ACTION_SECRET_ENV
 ```
 
@@ -228,7 +228,7 @@ X-Hasura-Role: admin
       "type": "query",
       "headers": [
         {
-          "name": "ACTION_SECRET",
+          "name": "ACTION-SECRET",
           "value_from_env": "ACTION_SECRET_ENV"
         }
       ],
@@ -301,7 +301,7 @@ function authorizationMiddleware(req, res, next) {
 // check if the secret sent in the header equals to the secret stored as an env variable
 function correctSecretProvided(req) {
   const requiredSecret = process.env.ACTION_SECRET_ENV;
-  const providedSecret = req.headers['ACTION_SECRET'];
+  const providedSecret = req.headers['ACTION-SECRET'];
   return requiredSecret === providedSecret;
 }
 


### PR DESCRIPTION
### Description
Using underscores in headers can cause issues with nginx.  Given the number of  comments on this stackoverflow:

https://stackoverflow.com/questions/22856136/why-do-http-servers-forbid-underscores-in-http-header-names

And nginx being the a very common production server: https://nginx.org/en/docs/http/ngx_http_core_module.html#underscores_in_headers

I recommend you update the docs to use dashes instead of underscores.  While underscores are technically valid according to RFC, you are causing undo pain on devs finding this querk.

### Changelog

<!-- Fill this section if this is a user facing change. -->

__Component__ : documentation

__Type__: enhancement

__Product__: community-edition

#### Short Changelog

Changed `ACTION_SECRET` to `ACTION-SECRET` on the action handlers documentation


### Solution and Design

Nginx and other server configs drop headers with underscores.  This isn't widely known, and as mentioned in the description, many developers have wasted many hours finding this out the hard way.

By using action-secret instead of action_secret, we implicitly guide developers to not deal with this issue.

### Steps to test and verify
This is a documentation enhancement.  To test nginx settings... I don't know, spin up a server?

### Limitations, known bugs & workarounds
You could go further and warn people about the underscore issue, but I don't think hasura docs is the place for that.


#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?

- [x] No
- [ ] Yes

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
