### PR TITLE
fix #10640: the interface fails to be queried，/v1/graphql

### DIFF
--- a/frontend/libs/console/legacy-ce/src/lib/features/SchemaRegistry/hooks/useGetSchemaRegistryNotificationColor.ts
+++ b/frontend/libs/console/legacy-ce/src/lib/features/SchemaRegistry/hooks/useGetSchemaRegistryNotificationColor.ts
@@ -3,6 +3,7 @@ import { FETCH_SCHEMA_REGISTRY_NOTIFICATION_QUERY_NAME } from '../constants';
 import { FETCH_SCHEMA_REGISTRY_NOTIFICATION_QUERY } from '../queries';
 import { GetSchemaRegistryNotificationResponseWithError } from '../types';
 import { schemaRegsitryControlPlaneClient } from '../utils';
+import globals from '../../../Globals';
 
 type FetchSchemaRegistryNotificationResponse =
   | {
@@ -21,6 +22,9 @@ type FetchSchemaRegistryNotificationResponse =
 export const useGetSchemaRegistryNotificationColor = (
   projectId: string
 ): FetchSchemaRegistryNotificationResponse => {
+  // Skip API calls if running in CE mode or schema registry host is not configured
+  const isSchemaRegistryAvailable = !!globals.schemaRegistryHost && globals.consoleType !== 'oss';
+
   const fetchSchemaRegistyNotificationFn = (projectId: string) => {
     return schemaRegsitryControlPlaneClient.query<
       GetSchemaRegistryNotificationResponseWithError,
@@ -34,7 +38,17 @@ export const useGetSchemaRegistryNotificationColor = (
     queryFn: () => fetchSchemaRegistyNotificationFn(projectId),
     refetchOnMount: 'always',
     refetchOnWindowFocus: true,
+    // Skip the query completely if schema registry is not available
+    enabled: isSchemaRegistryAvailable,
   });
+
+  // Return loading state if schema registry is not available
+  if (!isSchemaRegistryAvailable) {
+    return {
+      kind: 'loading',
+    };
+  }
+  
   if (isLoading) {
     return {
       kind: 'loading',


### PR DESCRIPTION
The schema registry notification color hook has been updated to improve performance. A check was added to skip API calls if running in CE mode or if the schema registry host is not configured. This change also includes a modification that skips the query completely when the schema registry is unavailable, and returns a loading state instead. These enhancements aim to optimize resource usage and provide better user experience.
