### PR TITLE
Improve relationship nullability and joins without LATERAL (closes #8977)

### DIFF
--- a/server/lib/schema-parsers/src/Hasura/GraphQL/Parser/DirectiveName.hs
+++ b/server/lib/schema-parsers/src/Hasura/GraphQL/Parser/DirectiveName.hs
@@ -8,6 +8,9 @@ module Hasura.GraphQL.Parser.DirectiveName
     _skip,
     _ttl,
     __multiple_top_level_fields,
+    _overrideTo,
+    _lateral,
+    _nullable,
   )
 where
 
@@ -34,3 +37,12 @@ _ttl = [G.name|ttl|]
 
 __multiple_top_level_fields :: G.Name
 __multiple_top_level_fields = [G.name|_multiple_top_level_fields|]
+
+_overrideTo :: G.Name
+_overrideTo = [G.name|override_to|]
+
+_lateral :: G.Name
+_lateral = [G.name|lateral|]
+
+_nullable :: G.Name
+_nullable = [G.name|nullable|]

--- a/server/src-lib/Hasura/Backends/BigQuery/Instances/Schema.hs
+++ b/server/src-lib/Hasura/Backends/BigQuery/Instances/Schema.hs
@@ -429,7 +429,7 @@ bqComputedField ComputedFieldInfo {..} tableName tableInfo = runMaybeT do
       let fieldArgsParser = liftA2 (,) functionArgsParser selectArgsParser
       pure
         $ P.subselection fieldName fieldDescription fieldArgsParser selectionSetParser
-        <&> \((functionArgs', args), fields) ->
+        <&> \((functionArgs', args), fields, directives) ->
           IR.AFComputedField _cfiXComputedFieldInfo _cfiName
             $ IR.CFSTable JASMultipleRows
             $ IR.AnnSelectG
@@ -437,6 +437,7 @@ bqComputedField ComputedFieldInfo {..} tableName tableInfo = runMaybeT do
                 IR._asnFrom = IR.FromFunction (_cffName _cfiFunction) functionArgs' Nothing,
                 IR._asnPerm = tablePermissionsInfo returnTablePermissions,
                 IR._asnArgs = args,
+                IR._asnDirectives = (Just directives),
                 IR._asnStrfyNum = stringifyNumbers,
                 IR._asnNamingConvention = Nothing
               }
@@ -456,7 +457,7 @@ bqComputedField ComputedFieldInfo {..} tableName tableInfo = runMaybeT do
           <&> parsedSelectionsToFields IR.AFExpression
       pure
         $ P.subselection fieldName fieldDescription functionArgsParser selectionSetParser
-        <&> \(functionArgs', fields) ->
+        <&> \(functionArgs', fields, directives) ->
           IR.AFComputedField _cfiXComputedFieldInfo _cfiName
             $ IR.CFSTable JASMultipleRows
             $ IR.AnnSelectG
@@ -464,6 +465,7 @@ bqComputedField ComputedFieldInfo {..} tableName tableInfo = runMaybeT do
                 IR._asnFrom = IR.FromFunction (_cffName _cfiFunction) functionArgs' Nothing,
                 IR._asnPerm = IR.noTablePermissions,
                 IR._asnArgs = IR.noSelectArgs,
+                IR._asnDirectives = (Just directives),
                 IR._asnStrfyNum = stringifyNumbers,
                 IR._asnNamingConvention = Nothing
               }

--- a/server/src-lib/Hasura/Backends/DataConnector/Adapter/Schema.hs
+++ b/server/src-lib/Hasura/Backends/DataConnector/Adapter/Schema.hs
@@ -205,12 +205,13 @@ selectFunction mkRootFieldName fi@RQL.FunctionInfo {..} description = runMaybeT 
         functionFieldName = RQL.runMkRootFieldName mkRootFieldName _fiGQLName
     pure
       $ P.subselection functionFieldName description argsParser selectionSetParser
-      <&> \((funcArgs, tableArgs''), fields) ->
+      <&> \((funcArgs, tableArgs''), fields, directives) ->
         IR.AnnSelectG
           { IR._asnFields = fields,
             IR._asnFrom = IR.FromFunction _fiSQLName funcArgs Nothing,
             IR._asnPerm = GS.C.tablePermissionsInfo selectPermissions,
             IR._asnArgs = tableArgs'',
+            IR._asnDirectives = (Just directives),
             IR._asnStrfyNum = stringifyNumbers,
             IR._asnNamingConvention = Just tCase
           }
@@ -439,7 +440,7 @@ updateCustomOp (API.UpdateColumnOperatorName operatorName) operatorUsages = GS.U
             argumentType <-
               ( HashMap.lookup columnScalarType operatorUsages
                   <&> (\API.UpdateColumnOperatorDefinition {..} -> RQL.ColumnScalar $ Witch.from _ucodArgumentType)
-                )
+              )
                 -- This shouldn't happen 😬 because updateOperatorApplicableColumn should protect this
                 -- parser from being used with unsupported column types
                 `onNothing` throw500 ("updateOperatorParser: Unable to find argument type for update column operator " <> toTxt operatorName <> " used with column scalar type " <> toTxt columnScalarType)

--- a/server/src-lib/Hasura/Backends/MSSQL/FromIr/MutationResponse.hs
+++ b/server/src-lib/Hasura/Backends/MSSQL/FromIr/MutationResponse.hs
@@ -50,7 +50,7 @@ mkMutationOutputSelect stringifyNum withAlias = \case
       IR.Fields (IR.AnnFieldG 'MSSQL Void Expression) ->
       FromIr Select
     mkSelect jsonAggSelect annFields = do
-      let annSelect = IR.AnnSelectG annFields (IR.FromIdentifier $ IR.FIIdentifier withAlias) IR.noTablePermissions IR.noSelectArgs stringifyNum Nothing
+      let annSelect = IR.AnnSelectG annFields (IR.FromIdentifier $ IR.FIIdentifier withAlias) IR.noTablePermissions IR.noSelectArgs Nothing stringifyNum Nothing
       fromSelect jsonAggSelect annSelect
 
     -- SELECT COUNT(*) AS "count" FROM [with_alias]

--- a/server/src-lib/Hasura/Backends/MSSQL/FromIr/Query.hs
+++ b/server/src-lib/Hasura/Backends/MSSQL/FromIr/Query.hs
@@ -205,6 +205,7 @@ fromRemoteRelationFieldsG existingJoins joinColumns (IR.FieldName name, field) =
         (IR.RelName $ mkNonEmptyTextUnsafe name)
         joinColumns
         IR.Nullable
+        Nothing
         annotatedRelationship
 
 -- | Top/root-level 'Select'. All descendent/sub-translations are collected to produce a root TSQL.Select.
@@ -280,7 +281,7 @@ mkNodesSelect Args {..} foreignKeyConditions filterExpression permissionBasedTop
             aliasedAlias = IR.getFieldNameTxt fieldName
           }
     )
-    | (index, (fieldName, fieldSources)) <- nodes
+  | (index, (fieldName, fieldSources)) <- nodes
   ]
 
 --
@@ -335,7 +336,7 @@ mkAggregateSelect Args {..} foreignKeyConditions filterExpression selectFrom agg
             aliasedAlias = IR.getFieldNameTxt fieldName
           }
     )
-    | (index, (fieldName, projections)) <- aggregates
+  | (index, (fieldName, projections)) <- aggregates
   ]
 
 fromNativeQuery :: IR.NativeQuery 'MSSQL Expression -> FromIr TSQL.From

--- a/server/src-lib/Hasura/Backends/Postgres/Execute/Mutation.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Execute/Mutation.hs
@@ -312,7 +312,7 @@ mutateAndFetchCols userInfo qt cols (cte, p) strfyNum tCase = do
       <$> mkSQLSelect
         userInfo
         JASMultipleRows
-        ( AnnSelectG selFlds tabFrom tabPerm noSelectArgs strfyNum tCase
+        ( AnnSelectG selFlds tabFrom tabPerm noSelectArgs Nothing strfyNum tCase
         )
   let selectWith =
         S.SelectWith
@@ -473,9 +473,9 @@ validateDeleteMutation env manager logger userInfo resolvedWebHook confHeaders t
           --     id
           --    }
           -- }
-          do
-            let deleteInputValByPk = J.object ["pk_columns" J..= deleteInputVal]
-            return (J.object ["input" J..= [deleteInputValByPk]])
+            do
+              let deleteInputValByPk = J.object ["pk_columns" J..= deleteInputVal]
+              return (J.object ["input" J..= [deleteInputValByPk]])
           else return (J.object ["input" J..= [deleteInputVal]])
       Nothing -> return J.Null
   validateMutation env manager logger userInfo resolvedWebHook confHeaders timeout forwardClientHeaders reqHeaders inputData headerPrecedence

--- a/server/src-lib/Hasura/Backends/Postgres/Translate/Returning.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Translate/Returning.hs
@@ -114,7 +114,7 @@ mkMutFldExp userInfo cteAlias preCalAffRows strfyNum tCase = \case
           <$> mkSQLSelect
             userInfo
             JASMultipleRows
-            ( AnnSelectG selFlds tabFrom tabPerm noSelectArgs strfyNum tCase
+            ( AnnSelectG selFlds tabFrom tabPerm noSelectArgs Nothing strfyNum tCase
             )
 
 toFIIdentifier :: TableIdentifier -> FIIdentifier
@@ -213,7 +213,7 @@ mkMutationOutputExp userInfo qt allCols preCalAffRows cte mutOutput strfyNum tCa
                   <$> mkSQLSelect
                     userInfo
                     JASSingleObject
-                    ( AnnSelectG annFlds tabFrom tabPerm noSelectArgs strfyNum tCase
+                    ( AnnSelectG annFlds tabFrom tabPerm noSelectArgs Nothing strfyNum tCase
                     )
 
 mkCheckErrorExp :: TableIdentifier -> S.SQLExp

--- a/server/src-lib/Hasura/Backends/Postgres/Translate/Select/Internal/GenerateSelect.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Translate/Select/Internal/GenerateSelect.hs
@@ -250,12 +250,15 @@ defaultGenerateSQLSelect selectRewriter joinCondition selectSource selectNode =
     arrayRelationToFromItem ::
       (ArrayRelationSource, MultiRowSelectNode) -> (S.FromItem, S.JoinType)
     arrayRelationToFromItem (arrayRelationSource, arraySelectNode) =
-      let ArrayRelationSource _ colMapping source = arrayRelationSource
+      let ArrayRelationSource _ colMapping source nullable = arrayRelationSource
           alias = S.toTableAlias $ _ssPrefix source
           select =
             generateSQLSelectFromArrayNode @pgKind source arraySelectNode
               $ mkJoinCond baseSelectIdentifier colMapping
-       in (S.mkLateralFromItem select alias, S.LeftOuter)
+          joinType = case nullable of
+            Nullable -> S.LeftOuter
+            NotNullable -> S.Inner
+       in (S.mkLateralFromItem select alias, joinType)
 
     arrayConnectionToFromItem ::
       (ArrayConnectionSource, MultiRowSelectNode) -> (S.FromItem, S.JoinType)

--- a/server/src-lib/Hasura/Backends/Postgres/Translate/Select/Internal/OrderBy.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Translate/Select/Internal/OrderBy.hs
@@ -133,9 +133,11 @@ processOrderByItems userInfo sourcePrefix' selectSourceQual fieldAlias' similarA
             $ S.mkQIdenExp baseTableIdentifier
             $ ciColumn pgColInfo
         AOCObjectRelation relInfo relFilter rest -> withWriteObjectRelation $ do
-          let RelInfo {riName = relName, riMapping = RelMapping colMapping, riTarget = relTarget} = relInfo
+          let RelInfo {riName = relName, riMapping = RelMapping colMapping, riTarget = relTarget, riManualNullable = manualNullable, riIsManual = isManual} = relInfo
               relSourcePrefix = mkObjectRelationTableAlias sourcePrefix relName
               fieldName = mkOrderByFieldName relName
+              -- Determine nullability based on manual relationship settings
+              nullable = if isManual && not manualNullable then NotNullable else Nullable
           case relTarget of
             RelTargetNativeQuery _ -> error "processAnnotatedOrderByElement RelTargetNativeQuery (AOCObjectRelation)"
             RelTargetTable relTable -> do
@@ -147,14 +149,16 @@ processOrderByItems userInfo sourcePrefix' selectSourceQual fieldAlias' similarA
                       (tableIdentifierToIdentifier relSourcePrefix)
                       (S.FISimple relTable Nothing)
                       boolExp
-                  relSource = ObjectRelationSource relName colMapping selectSource Nullable
+                  relSource = ObjectRelationSource relName colMapping selectSource nullable
               pure
                 ( relSource,
                   InsOrdHashMap.singleton relOrderByAlias relOrdByExp,
                   S.mkQIdenExp relSourcePrefix relOrderByAlias
                 )
         AOCArrayAggregation relInfo relFilter aggOrderBy -> withWriteArrayRelation $ do
-          let RelInfo {riName = relName, riMapping = RelMapping colMapping, riTarget = relTarget} = relInfo
+          let RelInfo {riName = relName, riMapping = RelMapping colMapping, riTarget = relTarget, riManualNullable = manualNullable, riIsManual = isManual} = relInfo
+              -- Determine nullability based on manual relationship settings
+              nullable = if isManual && not manualNullable then NotNullable else Nullable
           case relTarget of
             RelTargetNativeQuery _ -> error "processAnnotatedOrderByElement RelTargetNativeQuery (AOCArrayAggregation)"
             RelTargetTable relTable -> do
@@ -174,7 +178,7 @@ processOrderByItems userInfo sourcePrefix' selectSourceQual fieldAlias' similarA
                       (S.FISimple relTable Nothing)
                       boolExp
                       noSortingAndSlicing
-                  relSource = ArrayRelationSource relAlias colMapping selectSource
+                  relSource = ArrayRelationSource relAlias colMapping selectSource nullable
               extractorExps <- aggregateFieldsToExtractorExps relSourcePrefix userInfo fields
               pure
                 ( relSource,

--- a/server/src-lib/Hasura/Backends/Postgres/Translate/Select/Internal/OrderBy.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Translate/Select/Internal/OrderBy.hs
@@ -149,7 +149,7 @@ processOrderByItems userInfo sourcePrefix' selectSourceQual fieldAlias' similarA
                       (tableIdentifierToIdentifier relSourcePrefix)
                       (S.FISimple relTable Nothing)
                       boolExp
-                  relSource = ObjectRelationSource relName colMapping selectSource nullable
+                  relSource = ObjectRelationSource relName colMapping selectSource nullable Nothing
               pure
                 ( relSource,
                   InsOrdHashMap.singleton relOrderByAlias relOrdByExp,
@@ -178,7 +178,7 @@ processOrderByItems userInfo sourcePrefix' selectSourceQual fieldAlias' similarA
                       (S.FISimple relTable Nothing)
                       boolExp
                       noSortingAndSlicing
-                  relSource = ArrayRelationSource relAlias colMapping selectSource nullable
+                  relSource = ArrayRelationSource relAlias colMapping selectSource nullable Nothing
               extractorExps <- aggregateFieldsToExtractorExps relSourcePrefix userInfo fields
               pure
                 ( relSource,

--- a/server/src-lib/Hasura/Backends/Postgres/Translate/Select/Internal/Process.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Translate/Select/Internal/Process.hs
@@ -510,7 +510,7 @@ processArrayRelation ::
 processArrayRelation userInfo sourcePrefixes fieldAlias relAlias arrSel _tCase =
   case arrSel of
     ASSimple annArrRel -> withWriteArrayRelation $ do
-      let AnnRelationSelectG _ colMapping _ sel = annArrRel
+      let AnnRelationSelectG _ colMapping nullable sel = annArrRel
           permLimitSubQuery =
             maybe PLSQNotRequired PLSQRequired $ _tpLimit $ _asnPerm sel
       (source, nodeExtractors) <-
@@ -522,17 +522,17 @@ processArrayRelation userInfo sourcePrefixes fieldAlias relAlias arrSel _tCase =
               permLimitSubQuery
               $ orderByForJsonAgg source
       pure
-        ( ArrayRelationSource relAlias colMapping source,
+        ( ArrayRelationSource relAlias colMapping source nullable,
           topExtr,
           nodeExtractors,
           ()
         )
     ASAggregate aggSel -> withWriteArrayRelation $ do
-      let AnnRelationSelectG _ colMapping _ sel = aggSel
+      let AnnRelationSelectG _ colMapping nullable sel = aggSel
       (source, nodeExtractors, topExtr) <-
         processAnnAggregateSelect userInfo sourcePrefixes fieldAlias sel
       pure
-        ( ArrayRelationSource relAlias colMapping source,
+        ( ArrayRelationSource relAlias colMapping source nullable,
           topExtr,
           nodeExtractors,
           ()

--- a/server/src-lib/Hasura/Backends/Postgres/Translate/Select/Internal/Process.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Translate/Select/Internal/Process.hs
@@ -273,7 +273,7 @@ processAnnAggregateSelect userInfo sourcePrefixes fieldAlias annAggSel = do
 
   pure (selectSource, nodeExtractors, topLevelExtractor)
   where
-    AnnSelectG aggSelFields tableFrom tablePermissions tableArgs strfyNum tCase = annAggSel
+    AnnSelectG aggSelFields tableFrom tablePermissions tableArgs _ strfyNum tCase = annAggSel
     permLimit = _tpLimit tablePermissions
     orderBy = _saOrderBy tableArgs
     permLimitSubQuery = mkPermissionLimitSubQuery permLimit aggSelFields orderBy
@@ -335,7 +335,7 @@ processAnnFields userInfo sourcePrefix fieldAlias annFields tCase = do
         AFNodeId _ sn tn pKeys -> pure $ mkNodeId sn tn pKeys
         AFColumn c -> toSQLCol c
         AFObjectRelation objSel -> withWriteObjectRelation $ do
-          let AnnRelationSelectG relName relMapping nullable annObjSel = objSel
+          let AnnRelationSelectG relName relMapping nullable directives annObjSel = objSel
               AnnObjectSelectG objAnnFields target targetFilter = annObjSel
           (objRelSourcePrefix, ident, filterExp) <- case target of
             FromNativeQuery nq -> do
@@ -367,7 +367,7 @@ processAnnFields userInfo sourcePrefix fieldAlias annFields tCase = do
             other -> error $ "processAnnFields: " <> show other
           let sourcePrefixes = mkSourcePrefixes objRelSourcePrefix
               selectSource = ObjectSelectSource (_pfThis sourcePrefixes) ident filterExp
-              objRelSource = ObjectRelationSource relName relMapping selectSource nullable
+              objRelSource = ObjectRelationSource relName relMapping selectSource nullable directives
           annFieldsExtr <- processAnnFields userInfo (identifierToTableIdentifier $ _pfThis sourcePrefixes) fieldName objAnnFields tCase
           pure
             ( objRelSource,
@@ -510,7 +510,7 @@ processArrayRelation ::
 processArrayRelation userInfo sourcePrefixes fieldAlias relAlias arrSel _tCase =
   case arrSel of
     ASSimple annArrRel -> withWriteArrayRelation $ do
-      let AnnRelationSelectG _ colMapping nullable sel = annArrRel
+      let AnnRelationSelectG _ colMapping nullable directives sel = annArrRel
           permLimitSubQuery =
             maybe PLSQNotRequired PLSQRequired $ _tpLimit $ _asnPerm sel
       (source, nodeExtractors) <-
@@ -522,23 +522,23 @@ processArrayRelation userInfo sourcePrefixes fieldAlias relAlias arrSel _tCase =
               permLimitSubQuery
               $ orderByForJsonAgg source
       pure
-        ( ArrayRelationSource relAlias colMapping source nullable,
+        ( ArrayRelationSource relAlias colMapping source nullable directives,
           topExtr,
           nodeExtractors,
           ()
         )
     ASAggregate aggSel -> withWriteArrayRelation $ do
-      let AnnRelationSelectG _ colMapping nullable sel = aggSel
+      let AnnRelationSelectG _ colMapping nullable directives sel = aggSel
       (source, nodeExtractors, topExtr) <-
         processAnnAggregateSelect userInfo sourcePrefixes fieldAlias sel
       pure
-        ( ArrayRelationSource relAlias colMapping source nullable,
+        ( ArrayRelationSource relAlias colMapping source nullable directives,
           topExtr,
           nodeExtractors,
           ()
         )
     ASConnection connSel -> withWriteArrayConnection $ do
-      let AnnRelationSelectG _ colMapping _ sel = connSel
+      let AnnRelationSelectG _ colMapping _ _ sel = connSel
       (source, topExtractor, nodeExtractors) <-
         processConnectionSelect userInfo sourcePrefixes fieldAlias relAlias colMapping sel
       pure
@@ -634,7 +634,7 @@ processAnnSimpleSelect userInfo sourcePrefixes fieldAlias permLimitSubQuery annS
   let allExtractors = InsOrdHashMap.fromList $ annFieldsExtr : orderByAndDistinctExtrs
   pure (selectSource, allExtractors)
   where
-    AnnSelectG annSelFields tableFrom tablePermissions tableArgs _ tCase = annSimpleSel
+    AnnSelectG annSelFields tableFrom tablePermissions tableArgs _ _ tCase = annSimpleSel
     similarArrayFields =
       mkSimilarArrayFields annSelFields $ _saOrderBy tableArgs
 
@@ -695,7 +695,7 @@ processConnectionSelect userInfo sourcePrefixes fieldAlias relAlias colMapping c
     )
   where
     ConnectionSelect _ primaryKeyColumns maybeSplit maybeSlice select = connectionSelect
-    AnnSelectG fields selectFrom tablePermissions tableArgs _ tCase = select
+    AnnSelectG fields selectFrom tablePermissions tableArgs _ _ tCase = select
     fieldIdentifier = toIdentifier fieldAlias
     thisPrefix = identifierToTableIdentifier $ _pfThis sourcePrefixes
     permLimitSubQuery = PLSQNotRequired

--- a/server/src-lib/Hasura/Backends/Postgres/Translate/Select/Streaming.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Translate/Select/Streaming.hs
@@ -109,7 +109,7 @@ mkStreamSQLSelect userInfo (AnnSelectStreamG () fields from perm args strfyNum) 
             _saOffset = Nothing,
             _saDistinct = Nothing
           }
-      sqlSelect = AnnSelectG fields from perm selectArgs strfyNum Nothing
+      sqlSelect = AnnSelectG fields from perm selectArgs Nothing strfyNum Nothing
       permLimitSubQuery = PLSQNotRequired
   ((selectSource, nodeExtractors), SelectWriter {_swJoinTree = joinTree, _swCustomSQLCTEs = customSQLCTEs}) <-
     runWriterT

--- a/server/src-lib/Hasura/Backends/Postgres/Translate/Types.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Translate/Types.hs
@@ -184,7 +184,8 @@ deriving instance Eq ObjectRelationSource
 data ArrayRelationSource = ArrayRelationSource
   { _arsAlias :: Postgres.TableAlias,
     _arsRelationMapping :: HashMap.HashMap Postgres.PGCol Postgres.PGCol,
-    _arsSelectSource :: SelectSource
+    _arsSelectSource :: SelectSource,
+    _arsNullable :: Nullable
   }
   deriving (Generic, Show)
 

--- a/server/src-lib/Hasura/GraphQL/Execute/Action.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/Action.hs
@@ -416,7 +416,7 @@ resolveAsyncActionQuery userInfo annAction responseErrorsConfig =
                       { RS._saWhere = Just tableBoolExpression
                       }
                   tablePermissions = RS.TablePerm annBoolExpTrue Nothing
-               in RS.AnnSelectG annotatedFields tableFromExp tablePermissions tableArguments stringifyNumerics Nothing
+               in RS.AnnSelectG annotatedFields tableFromExp tablePermissions tableArguments Nothing stringifyNumerics Nothing
   where
     mkQErrFromErrorValue :: J.Value -> QErr
     mkQErrFromErrorValue actionLogResponseError =
@@ -799,7 +799,7 @@ processOutputSelectionSet ::
   Options.StringifyNumbers ->
   RS.AnnSimpleSelectG ('Postgres 'Vanilla) Void v
 processOutputSelectionSet tableRowInput actionOutputType definitionList actionFields strfyNum =
-  RS.AnnSelectG annotatedFields selectFrom RS.noTablePermissions RS.noSelectArgs strfyNum Nothing
+  RS.AnnSelectG annotatedFields selectFrom RS.noTablePermissions RS.noSelectArgs Nothing strfyNum Nothing
   where
     annotatedFields = fmap actionFieldToAnnField <$> actionFields
     jsonbToPostgresRecordFunction =

--- a/server/src-lib/Hasura/GraphQL/Execute/Backend.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/Backend.hs
@@ -221,11 +221,11 @@ convertRemoteSourceRelationship
 
       relationshipField = case relationship of
         SourceRelationshipObject s ->
-          AFObjectRelation $ AnnRelationSelectG relName columnMapping Nullable s
+          AFObjectRelation $ AnnRelationSelectG relName columnMapping Nullable Nothing s
         SourceRelationshipArray s ->
-          AFArrayRelation $ ASSimple $ AnnRelationSelectG relName columnMapping Nullable s
+          AFArrayRelation $ ASSimple $ AnnRelationSelectG relName columnMapping Nullable Nothing s
         SourceRelationshipArrayAggregate s ->
-          AFArrayRelation $ ASAggregate $ AnnRelationSelectG relName columnMapping Nullable s
+          AFArrayRelation $ ASAggregate $ AnnRelationSelectG relName columnMapping Nullable Nothing s
 
       argumentIdField =
         ( fromCol @b argumentIdColumn,
@@ -245,6 +245,7 @@ convertRemoteSourceRelationship
             _asnFrom = selectFrom,
             _asnPerm = TablePerm annBoolExpTrue Nothing,
             _asnArgs = noSelectArgs,
+            _asnDirectives = Nothing,
             _asnStrfyNum = stringifyNumbers,
             _asnNamingConvention = Nothing
           }

--- a/server/src-lib/Hasura/GraphQL/Namespace.hs
+++ b/server/src-lib/Hasura/GraphQL/Namespace.hs
@@ -93,7 +93,7 @@ customizeNamespace (Just _) _ _ [] = [] -- The nampespace doesn't contain any Fi
 customizeNamespace (Just namespace) fromParsedSelection mkNamespaceTypename fieldParsers =
   -- Source or remote schema has a namespace field so wrap the parsers
   -- in a new namespace field parser.
-  [P.subselection_ namespace Nothing parser]
+  [fmap fst $ P.subselection_ namespace Nothing parser]
   where
     parser :: Parser 'Output n (NamespacedField a)
     parser =

--- a/server/src-lib/Hasura/GraphQL/Schema/Relay.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema/Relay.hs
@@ -113,7 +113,7 @@ nodeField sourceCache context options = do
     RelaySchema nodeBuilder -> runNodeBuilder nodeBuilder context options
   pure
     $ P.subselection Name._node Nothing idArgument nodeObject
-    `P.bindField` \(ident, parseds) -> do
+    `P.bindField` \(ident, parseds, _) -> do
       nodeId <- parseNodeId ident
       case nodeId of
         NodeIdV1 (V1NodeId tableName pKeys) -> do
@@ -185,6 +185,7 @@ nodeField sourceCache context options = do
                   IR._saOffset = Nothing,
                   IR._saDistinct = Nothing
                 },
+            IR._asnDirectives = Nothing,
             IR._asnStrfyNum = stringifyNumbers,
             IR._asnNamingConvention = Just $ _rscNamingConvention $ _siCustomization sourceInfo
           }

--- a/server/src-lib/Hasura/GraphQL/Schema/Remote.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema/Remote.hs
@@ -455,7 +455,6 @@ remoteInputObjectParser schemaDoc defn@(G.InputObjectTypeDefinition desc name _ 
     else -- At least one field is not a preset, meaning we have the guarantee that there will be at least
     -- one field in the input object. We have to memoize this branch as we might recursively call
     -- the same parser.
-
       Right <$> P.memoizeOn 'remoteInputObjectParser defn do
         typename <- asks getter <&> \mkTypename -> runMkTypename mkTypename name
 
@@ -988,7 +987,7 @@ remoteField sdoc remoteRelationships parentTypeName fieldName description argsDe
       FieldParser n (IR.GraphQLField (IR.RemoteRelationshipField IR.UnpreparedValue) RemoteSchemaVariable)
     mkFieldParserWithSelectionSet customizedFieldName argsParser outputParser =
       P.rawSubselection customizedFieldName description argsParser outputParser
-        <&> \(alias, _, (_, args), selSet) -> mkField alias customizedFieldName args selSet
+        <&> \(alias, _, (_, args), selSet, _) -> mkField alias customizedFieldName args selSet
 
 -- | helper function to get a parser of an object with it's name
 --   This function is called from 'remoteSchemaInterface' and

--- a/server/src-lib/Hasura/GraphQL/Schema/RemoteRelationship.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema/RemoteRelationship.hs
@@ -213,7 +213,7 @@ remoteRelationshipToSourceField context options sourceCache RemoteSourceFieldInf
               Just selectionSetParser ->
                 pure
                   $ P.subselection_ fieldName Nothing selectionSetParser
-                  <&> \fields ->
+                  <&> \(fields, _) ->
                     IR.SourceRelationshipObject
                       $ IR.AnnObjectSelectG fields (IR.FromTable _rsfiTable)
                       $ IR._tpFilter

--- a/server/src-lib/Hasura/GraphQL/Schema/SubscriptionStream.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema/SubscriptionStream.hs
@@ -81,7 +81,7 @@ cursorOrderingArgParser = do
       [ ( define enumNameVal,
           snd enumNameVal
         )
-        | enumNameVal <- [(Name._ASC, COAscending), (Name._DESC, CODescending)]
+      | enumNameVal <- [(Name._ASC, COAscending), (Name._DESC, CODescending)]
       ]
   where
     define (name, val) =
@@ -271,7 +271,7 @@ selectStreamTable tableInfo fieldName description = runMaybeT $ do
       pure
         $ P.setFieldParserOrigin (MOSourceObjId sourceName (AB.mkAnyBackend $ SMOTable @b tableName))
         $ P.subselection fieldName description tableStreamArgsParser selectionSetParser
-        <&> \(args, fields) ->
+        <&> \(args, fields, _) ->
           IR.AnnSelectStreamG
             { IR._assnXStreamingSubscription = xStreamSubscription,
               IR._assnFields = fields,

--- a/server/src-lib/Hasura/GraphQL/Schema/Update/Batch.hs
+++ b/server/src-lib/Hasura/GraphQL/Schema/Update/Batch.hs
@@ -69,7 +69,15 @@ buildAnnotatedUpdateGField scenario tableInfo fieldName description parseOutput 
   updateVariantParser <- mkUpdateVariantParser updatePerms
   pure
     $ P.setFieldParserOrigin (MOSourceObjId sourceName (AB.mkAnyBackend $ SMOTable @b tableName))
-    $ mkAnnotatedUpdateG tableName columns updatePerms (Just tCase) validateInput
+    $ ( \(updateVariant, output, _) ->
+          mkAnnotatedUpdateG
+            tableName
+            columns
+            updatePerms
+            (Just tCase)
+            validateInput
+            (updateVariant, output)
+      )
     <$> P.subselection fieldName description updateVariantParser outputParser
 
 -- | Construct a root field, normally called update_tablename, that can be used

--- a/server/src-lib/Hasura/RQL/DDL/Schema/LegacyCatalog.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/LegacyCatalog.hs
@@ -933,4 +933,4 @@ recreateSystemMetadata = do
         $ RelManualTableConfig
         $ RelManualTableConfigC
           (QualifiedObject schemaName tableName)
-          (RelManualCommon (RelMapping $ HashMap.fromList columns) Nothing)
+          (RelManualCommon (RelMapping $ HashMap.fromList columns) Nothing True)

--- a/server/src-lib/Hasura/RQL/DDL/Schema/Rename.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Rename.hs
@@ -302,9 +302,9 @@ updateRelDefs source qt rn renameTable = do
     updateObjRelDef (oldQT, newQT) =
       rdUsing %~ \case
         RUFKeyOn fk -> RUFKeyOn fk
-        RUManual (RelManualTableConfig (RelManualTableConfigC origQT (RelManualCommon rmCols rmIO))) ->
+        RUManual (RelManualTableConfig (RelManualTableConfigC origQT (RelManualCommon rmCols rmIO rmManualNullable))) ->
           let updQT = bool origQT newQT $ oldQT == origQT
-           in RUManual $ RelManualTableConfig $ RelManualTableConfigC updQT (RelManualCommon rmCols rmIO)
+           in RUManual $ RelManualTableConfig $ RelManualTableConfigC updQT (RelManualCommon rmCols rmIO rmManualNullable)
         RUManual (RelManualNativeQueryConfig nqc) ->
           RUManual (RelManualNativeQueryConfig nqc)
 
@@ -314,9 +314,9 @@ updateRelDefs source qt rn renameTable = do
         RUFKeyOn (ArrRelUsingFKeyOn origQT c) ->
           let updQT = getUpdQT origQT
            in RUFKeyOn $ ArrRelUsingFKeyOn updQT c
-        RUManual (RelManualTableConfig (RelManualTableConfigC origQT (RelManualCommon rmCols rmIO))) ->
+        RUManual (RelManualTableConfig (RelManualTableConfigC origQT (RelManualCommon rmCols rmIO rmManualNullable))) ->
           let updQT = getUpdQT origQT
-           in RUManual $ RelManualTableConfig $ RelManualTableConfigC updQT (RelManualCommon rmCols rmIO)
+           in RUManual $ RelManualTableConfig $ RelManualTableConfigC updQT (RelManualCommon rmCols rmIO rmManualNullable)
         RUManual (RelManualNativeQueryConfig nqc) ->
           RUManual (RelManualNativeQueryConfig nqc)
       where
@@ -746,10 +746,10 @@ updateRelManualConfig ::
   RenameCol b ->
   RelManualConfig b ->
   RelManualConfig b
-updateRelManualConfig fromQT toQT rnCol (RelManualTableConfig (RelManualTableConfigC tn (RelManualCommon colMap io))) =
-  RelManualTableConfig (RelManualTableConfigC tn (RelManualCommon (updateColMap fromQT toQT rnCol colMap) io))
-updateRelManualConfig fromQT toQT rnCol (RelManualNativeQueryConfig (RelManualNativeQueryConfigC nqn (RelManualCommon colMap io))) =
-  RelManualNativeQueryConfig (RelManualNativeQueryConfigC nqn (RelManualCommon (updateColMap fromQT toQT rnCol colMap) io))
+updateRelManualConfig fromQT toQT rnCol (RelManualTableConfig (RelManualTableConfigC tn (RelManualCommon colMap io rmManualNullable))) =
+  RelManualTableConfig (RelManualTableConfigC tn (RelManualCommon (updateColMap fromQT toQT rnCol colMap) io rmManualNullable))
+updateRelManualConfig fromQT toQT rnCol (RelManualNativeQueryConfig (RelManualNativeQueryConfigC nqn (RelManualCommon colMap io rmManualNullable))) =
+  RelManualNativeQueryConfig (RelManualNativeQueryConfigC nqn (RelManualCommon (updateColMap fromQT toQT rnCol colMap) io rmManualNullable))
 
 updateColMap ::
   forall b.

--- a/server/src-lib/Hasura/RQL/DML/Select.hs
+++ b/server/src-lib/Hasura/RQL/DML/Select.hs
@@ -248,7 +248,7 @@ convSelectQ sqlGen table fieldInfoMap selPermInfo selQ sessVarBldr prepValBldr =
       tabPerm = TablePerm resolvedSelFltr mPermLimit
       tabArgs = SelectArgs wClause annOrdByM mQueryLimit (fromIntegral <$> mQueryOffset) Nothing
       strfyNum = stringifyNum sqlGen
-  pure $ AnnSelectG annFlds tabFrom tabPerm tabArgs strfyNum Nothing
+  pure $ AnnSelectG annFlds tabFrom tabPerm tabArgs Nothing strfyNum Nothing
   where
     mQueryOffset = sqOffset selQ
     mQueryLimit = sqLimit selQ
@@ -297,7 +297,7 @@ convExtRel sqlGen fieldInfoMap relName mAlias selQ sessVarBldr prepValBldr = do
       when misused $ throw400 UnexpectedPayload objRelMisuseMsg
       pure
         $ Left
-        $ AnnRelationSelectG (fromMaybe relName mAlias) colMapping Nullable
+        $ AnnRelationSelectG (fromMaybe relName mAlias) colMapping Nullable Nothing
         $ AnnObjectSelectG (_asnFields annSel) (FromTable relTableName)
         $ _tpFilter
         $ _asnPerm annSel
@@ -309,6 +309,7 @@ convExtRel sqlGen fieldInfoMap relName mAlias selQ sessVarBldr prepValBldr = do
           (fromMaybe relName mAlias)
           colMapping
           Nullable
+          Nothing
           annSel
   where
     pgWhenRelErr = "only relationships can be expanded"

--- a/server/src-lib/Hasura/RQL/IR/Select/AnnSelectG.hs
+++ b/server/src-lib/Hasura/RQL/IR/Select/AnnSelectG.hs
@@ -11,6 +11,7 @@ where
 
 import Data.Bifoldable
 import Data.Kind (Type)
+import Hasura.GraphQL.Parser.Directives (ParsedDirectives)
 import Hasura.Prelude
 import Hasura.RQL.IR.Select.Args
 import Hasura.RQL.IR.Select.From
@@ -28,6 +29,7 @@ data AnnSelectG (b :: BackendType) (f :: Type -> Type) (v :: Type) = AnnSelectG
     _asnFrom :: SelectFromG b v,
     _asnPerm :: TablePermG b v,
     _asnArgs :: SelectArgsG b v,
+    _asnDirectives :: Maybe ParsedDirectives,
     _asnStrfyNum :: StringifyNumbers,
     _asnNamingConvention :: Maybe NamingCase
   }
@@ -52,7 +54,8 @@ data
   AnnSelectStreamG
     (b :: BackendType)
     (f :: Type -> Type)
-    (v :: Type) = AnnSelectStreamG
+    (v :: Type)
+  = AnnSelectStreamG
   { -- | type to indicate if streaming subscription has been enabled in the `BackendType`.
     --   This type helps avoiding missing case match patterns for backends where it's disabled.
     _assnXStreamingSubscription :: XStreamingSubscription b,

--- a/server/src-lib/Hasura/RQL/IR/Select/Lenses.hs
+++ b/server/src-lib/Hasura/RQL/IR/Select/Lenses.hs
@@ -18,6 +18,7 @@ module Hasura.RQL.IR.Select.Lenses
     aarColumnMapping,
     aarRelationshipName,
     aarNullable,
+    aarDirectives,
     anosSupportsNestedObjects,
     anosColumn,
     anosFields,

--- a/server/src-lib/Hasura/RQL/IR/Select/RelationSelect.hs
+++ b/server/src-lib/Hasura/RQL/IR/Select/RelationSelect.hs
@@ -7,6 +7,7 @@ module Hasura.RQL.IR.Select.RelationSelect
   )
 where
 
+import Hasura.GraphQL.Parser.Directives (ParsedDirectives)
 import Hasura.Prelude
 import Hasura.RQL.Types.Backend
 import Hasura.RQL.Types.BackendType
@@ -19,6 +20,7 @@ data AnnRelationSelectG (b :: BackendType) a = AnnRelationSelectG
   { _aarRelationshipName :: RelName, -- Relationship name
     _aarColumnMapping :: HashMap (ColumnPath b) (ColumnPath b), -- Column of left table to join with
     _aarNullable :: Nullable, -- is the target object allowed to be missing?
+    _aarDirectives :: Maybe ParsedDirectives, -- Directives on the relationship field
     _aarAnnSelect :: a -- Current table. Almost ~ to SQL Select
   }
   deriving stock (Functor, Foldable, Traversable)

--- a/server/src-lib/Hasura/RQL/Types/Relationships/Local.hs
+++ b/server/src-lib/Hasura/RQL/Types/Relationships/Local.hs
@@ -117,7 +117,8 @@ deriving instance (Backend b) => Show (RelManualNativeQueryConfig b)
 
 data RelManualCommon (b :: BackendType) = RelManualCommon
   { rmColumns :: RelMapping b,
-    rmInsertOrder :: Maybe InsertOrder
+    rmInsertOrder :: Maybe InsertOrder,
+    rmManualNullable :: Bool
   }
   deriving (Generic)
 
@@ -150,6 +151,10 @@ instance (Backend b) => AC.HasObjectCodec (RelManualCommon b) where
       AC..= rmColumns
         <*> optionalFieldOrIncludedNull' "insertion_order"
       AC..= rmInsertOrder
+        <*> AC.optionalFieldWithDefault "nullable" True nullableDoc
+      AC..= rmManualNullable
+    where
+      nullableDoc = "Is manual relationship nullable or not?"
 
 data RelUsing (b :: BackendType) a
   = RUFKeyOn a
@@ -439,7 +444,8 @@ data RelInfo (b :: BackendType) = RelInfo
     riMapping :: RelMapping b,
     riTarget :: RelTarget b,
     riIsManual :: Bool,
-    riInsertOrder :: InsertOrder
+    riInsertOrder :: InsertOrder,
+    riManualNullable :: Bool
   }
   deriving (Generic)
 

--- a/server/src-lib/Hasura/StoredProcedure/Schema.hs
+++ b/server/src-lib/Hasura/StoredProcedure/Schema.hs
@@ -94,7 +94,7 @@ defaultBuildStoredProcedureRootFields StoredProcedureInfo {..} = runMaybeT $ do
           <*> storedProcedureArgsParser
       )
       selectionListParser
-    <&> \((lmArgs, spArgs), fields) ->
+    <&> \((lmArgs, spArgs), fields, directives) ->
       QDBMultipleRows
         $ IR.AnnSelectG
           { IR._asnFields = fields,
@@ -108,6 +108,7 @@ defaultBuildStoredProcedureRootFields StoredProcedureInfo {..} = runMaybeT $ do
                   },
             IR._asnPerm = logicalModelPermissions,
             IR._asnArgs = lmArgs,
+            IR._asnDirectives = (Just directives),
             IR._asnStrfyNum = stringifyNumbers,
             IR._asnNamingConvention = Just tCase
           }

--- a/server/src-test/Hasura/Backends/Postgres/RQLGenerator/GenAnnSelectG.hs
+++ b/server/src-test/Hasura/Backends/Postgres/RQLGenerator/GenAnnSelectG.hs
@@ -3,6 +3,7 @@ module Hasura.Backends.Postgres.RQLGenerator.GenAnnSelectG
   )
 where
 
+import Data.HashMap.Strict qualified as HashMap
 import Hasura.Backends.Postgres.RQLGenerator.GenSelectArgsG (genSelectArgsG)
 import Hasura.Backends.Postgres.RQLGenerator.GenSelectFromG (genSelectFromG)
 import Hasura.Backends.Postgres.RQLGenerator.GenTablePermG (genTablePermG)
@@ -24,6 +25,7 @@ genAnnSelectG genA genFA =
     <*> genSelectFromG genA
     <*> genTablePermG genA
     <*> genArgs
+    <*> genDirectives
     <*> genStringifyNumbers
     <*> (pure Nothing)
   where
@@ -32,3 +34,4 @@ genAnnSelectG genA genFA =
         False -> Options.Don'tStringifyNumbers
         True -> Options.StringifyNumbers
     genArgs = genSelectArgsG genA
+    genDirectives = Gen.maybe (pure HashMap.empty)

--- a/server/src-test/Hasura/GraphQL/Schema/BoolExp/AggregationPredicatesSpec.hs
+++ b/server/src-test/Hasura/GraphQL/Schema/BoolExp/AggregationPredicatesSpec.hs
@@ -310,7 +310,8 @@ spec = do
           riMapping = RelMapping $ HashMap.fromList [("id", "album_id")],
           riTarget = RelTargetTable (mkTable "track"),
           riIsManual = False,
-          riInsertOrder = AfterParent
+          riInsertOrder = AfterParent,
+          riManualNullable = True
         }
 
     sourceInfo :: SourceInfo ('Postgres 'Vanilla)

--- a/server/src-test/Hasura/RQL/IR/Generator.hs
+++ b/server/src-test/Hasura/RQL/IR/Generator.hs
@@ -239,6 +239,7 @@ genRelInfo genTableName genColumn =
     <*> genRelTarget genTableName
     <*> bool_
     <*> genInsertOrder
+    <*> bool_
 
 genRelTarget :: (MonadGen m) => m (TableName b) -> m (RelTarget b)
 genRelTarget genTableName =


### PR DESCRIPTION
### Description
Allows users to manually describe the nullability of a relationship (Object & Array), either by statically specifying it in the metadata configuration or dynamically by using new directives in the graphql query.

Also exposes another directive to use JOINS without LATERAL on Object relationships.

NOTE: Currently there is not much documentation on when Hasura uses LEFT OUTER vs INNER joins but it is quite simple. I think a more detailed documentation is needed on that, specially the implication of using Views (which is my case).

Simple performance test (check changelog for more information about directives):
```graphql
query Query {
  assets(limit: 2, order_by: {firstAppearedInBlock: {forgedAt: asc}}) {
    assetId
    firstAppearedInBlock @nullable @lateral {
      epoch @nullable @lateral {
        number
      }
      transactions(limit: 2, order_by: {id: desc}) @nullable {
        id
        outputs(where: {index: {_eq: "0"}}) @nullable {
          id
          paymentAddress @nullable @lateral {
            address
            firstAppearedInTx @nullable @lateral {
              id
            }
          }
        }
      }
    }
  }
}

Before (without directives):
Response Time
2045689 ms (34 minutes)
Response Size
708 bytes

After (with directives):
Response Time
5087 ms (5 seconds)
Response Size
716 bytes
```

### Changelog

__Component__ : server
__Type__: feature
__Product__: community-edition

#### Long Changelog

- Add a new `nullable: bool` option in `manual_configuration` metadata configuration. It follows the same `logical_models` nullability schema. This option is passed into `RelInfo` to latter be used to calculate LEFT OUTER vs INNER joins.
-- This is also implemented for Array relationships. It may not make much sense, because you can filter it and end up with no results, but the core of this is to just improve* query performance.
- Add a new INNER JOIN (without LATERAL) generated query for Object relationships. This massively improves* performance specially on nested order_by
- Add two new directives `@nullable` & `@lateral` to dynamically configure an Array or Object relationship to make use of this new feature. This allows to configure querys with LEFT OUTER JOIN LATERAL & INNER JOIN (LATERAL) at execution time
- Modify the schema-parser to extract the directives information (only selectionSets) and inject them into the necessary components.
-- `@nullable(override_to: boolean) -> defaults to False`
-- `@lateral(override_to: boolean) -> defaults to False`

NOTE: `@nullable` directive overrides the new nullable option set by manual_configuration and also overrides any previous nullability (FKEY joins)

`*` More tests needed to check performance improvements

### Related Issues
May close (at least for me) #8977
Improves on closed #1965
May close by setting nullable option on metadata #7662
May close by using the new lateral (to a false) directive #5949
May close #7079
May close #6448
May help on #8333
...

### Extra
This can be the start of fixing other issues like being able to rename fields. You only need to modify the parser like i did for selectionSets but for simple selections and apply the renaming in the query:
```graphql
query Query {
  table {
    field @rename(to: "something")
  }
```

### Solution and Design
- Implement non LATERAL joins for object relationships
- Implement manual nullability

### Steps to test and verify
Use the directives specially on nested order_by queries

### Limitations, known bugs & workarounds
I currently only tested SELECT queries with array/object_relationships with manual_configuration. A lot more tests are needed...

DO NOT MERGE TIS PR AS-IS. Previously i had 0 knowledge on Hasura codebase, and 0,1 on Haskell. The code, more than the logic, was heavily created using AI it may contain unexpected results. This aims to start a conversation to finally solve in some way or another a long running issue...

#### Metadata

Does this PR add a new Metadata feature?
- [ x] Yes


#### GraphQL
- [ x] New GraphQL schema is being generated:
   - It modifies the nullability of a field

#### Breaking changes

- [ x] No Breaking changes

It should not break nor change the current Hasura execution unless the new metadata field is present or with the use of the new directives. 

