### PR TITLE
Remove __typename from inline fragments in allowlist normalization

### DIFF
--- a/server/src-lib/Hasura/RQL/Types/Allowlist.hs
+++ b/server/src-lib/Hasura/RQL/Types/Allowlist.hs
@@ -192,6 +192,9 @@ normalizeQuery =
           else
             let newSelset = filterSelSet $ G._fSelectionSet f
              in Just $ G.SelectionField f {G._fSelectionSet = newSelset}
+      G.SelectionInlineFragment frag ->
+        let newSelset = filterSelSet $ G._ifSelectionSet frag
+         in Just $ G.SelectionInlineFragment frag {G._ifSelectionSet = newSelset}
       _ -> Just s
 
 -- | InlinedAllowlist is the data type with which the allowlist is represented


### PR DESCRIPTION
  ### Description

  This PR fixes a bug in the GraphQL query allowlist normalization where `__typename` fields were not being removed from inline fragments. The normalization logic was only handling
   regular field selections but not inline fragments, causing queries with inline fragments containing `__typename` to fail allowlist validation even when they should be allowed.

  ### Changelog

  __Component__ : server

  __Type__: bugfix

  __Product__: community-edition

  #### Short Changelog
  Fix allowlist normalization to properly remove `__typename` from inline fragments

  ### Related Issues
  N/A

  ### Solution and Design
  The issue was in the `filterSelSet` function in `Hasura/RQL/Types/Allowlist.hs`. The function was handling `SelectionField` to recursively filter nested selection sets and remove
   `__typename`, but was not handling `SelectionInlineFragment`.

  The fix adds a case for `SelectionInlineFragment` that recursively applies the same filtering logic to the inline fragment's selection set, ensuring `__typename` fields are
  removed consistently across all selection types.

  ### Steps to test and verify

  1. Setup Allow List including inline fragments without __typename
  2. Execute the query with `__typename` fields in the inline fragments
  3. Verify that the query is properly validated and executed without errors

I also tested the logic with a script:

<details>
<summary>script</summary>

```hs
{-# LANGUAGE OverloadedStrings #-}

module Main where

import qualified Data.Text as T

-- Simplified AST and normalization implementation for testing
data ExecutableDocument = ExecutableDocument [ExecutableDefinition]
  deriving (Show, Eq)

data ExecutableDefinition = ExecutableDefinitionOperation OperationDefinition
  deriving (Show, Eq)

data OperationDefinition = OperationDefinitionTyped TypedOperationDefinition
  deriving (Show, Eq)

data TypedOperationDefinition = TypedOperationDefinition
  { todName :: Maybe T.Text
  , todSelectionSet :: SelectionSet
  }
  deriving (Show, Eq)

type SelectionSet = [Selection]

data Selection
  = SelectionField Field
  | SelectionInlineFragment InlineFragment
  deriving (Show, Eq)

data Field = Field
  { fName :: T.Text
  , fSelectionSet :: SelectionSet
  }
  deriving (Show, Eq)

data InlineFragment = InlineFragment
  { ifTypeCondition :: Maybe T.Text
  , ifSelectionSet :: SelectionSet
  }
  deriving (Show, Eq)

-- Manual AST construction for testing
astWithTypename :: ExecutableDocument
astWithTypename = ExecutableDocument
  [ ExecutableDefinitionOperation $ OperationDefinitionTyped $ TypedOperationDefinition
      { todName = Just "GetNotifications"
      , todSelectionSet = 
          [ SelectionField $ Field
              { fName = "notifications"
              , fSelectionSet = 
                  [ SelectionField $ Field "id" []
                  , SelectionField $ Field "createdAt" []
                  , SelectionInlineFragment $ InlineFragment
                      { ifTypeCondition = Just "CommentNotification"
                      , ifSelectionSet = 
                          [ SelectionField $ Field "__typename" []  -- This should be removed
                          , SelectionField $ Field "comment" []
                          , SelectionField $ Field "author" []
                          ]
                      }
                  , SelectionInlineFragment $ InlineFragment
                      { ifTypeCondition = Just "LikeNotification"
                      , ifSelectionSet = 
                          [ SelectionField $ Field "__typename" []  -- This should be removed
                          , SelectionField $ Field "postId" []
                          , SelectionField $ Field "likedBy" []
                          ]
                      }
                  ]
              }
          ]
      }
  ]

astWithoutTypename :: ExecutableDocument
astWithoutTypename = ExecutableDocument
  [ ExecutableDefinitionOperation $ OperationDefinitionTyped $ TypedOperationDefinition
      { todName = Just "GetNotifications"
      , todSelectionSet = 
          [ SelectionField $ Field
              { fName = "notifications"
              , fSelectionSet = 
                  [ SelectionField $ Field "id" []
                  , SelectionField $ Field "createdAt" []
                  , SelectionInlineFragment $ InlineFragment
                      { ifTypeCondition = Just "CommentNotification"
                      , ifSelectionSet = 
                          [ SelectionField $ Field "comment" []
                          , SelectionField $ Field "author" []
                          ]
                      }
                  , SelectionInlineFragment $ InlineFragment
                      { ifTypeCondition = Just "LikeNotification"
                      , ifSelectionSet = 
                          [ SelectionField $ Field "postId" []
                          , SelectionField $ Field "likedBy" []
                          ]
                      }
                  ]
              }
          ]
      }
  ]

-- Normalization function (with the fix applied)
normalizeQuery :: ExecutableDocument -> ExecutableDocument
normalizeQuery (ExecutableDocument defs) =
  ExecutableDocument $ map normalizeExecDef defs
  where
    normalizeExecDef (ExecutableDefinitionOperation opDef) =
      ExecutableDefinitionOperation $ normalizeOpDef opDef
    
    normalizeOpDef (OperationDefinitionTyped typeOpDef) =
      OperationDefinitionTyped typeOpDef { todSelectionSet = filterSelSet (todSelectionSet typeOpDef) }
    
    filterSelSet :: SelectionSet -> SelectionSet
    filterSelSet = concatMap filterSel
    
    filterSel :: Selection -> SelectionSet
    filterSel (SelectionField f) =
      if fName f == "__typename"
        then []  -- Remove __typename fields
        else [SelectionField f { fSelectionSet = filterSelSet (fSelectionSet f) }]
    filterSel (SelectionInlineFragment inf) =
      -- The fix: recursively process inline fragment's selection set
      [SelectionInlineFragment inf { ifSelectionSet = filterSelSet (ifSelectionSet inf) }]

-- Test function
testNormalization :: IO ()
testNormalization = do
  putStrLn "=== Testing allowlist normalization fix for inline fragments ==="
  putStrLn ""
  putStrLn "Test case: GetNotifications query with union types"
  putStrLn "- CommentNotification and LikeNotification inline fragments"
  putStrLn "- Each fragment contains __typename field that should be removed"
  putStrLn ""
  
  let normalized1 = normalizeQuery astWithTypename
  let normalized2 = normalizeQuery astWithoutTypename
  
  putStrLn "=== Test Result ==="
  if normalized1 == normalized2
    then do
      putStrLn "✓ Test passed: Queries normalize to the same result"
      putStrLn "✓ __typename fields in inline fragments are correctly removed"
      putStrLn "✓ Allowlist matching will work correctly"
    else do
      putStrLn "✗ Test failed: Normalized queries differ"
      putStrLn "✗ __typename fields in inline fragments were not properly removed"
      putStrLn "\nNormalized AST with __typename:"
      print normalized1
      putStrLn "\nNormalized AST without __typename:"
      print normalized2

main :: IO ()
main = testNormalization
```
</details>


  ### Limitations, known bugs & workarounds
  None

  ### Server checklist

  #### Catalog upgrade
  Does this PR change Hasura Catalog version?
  - [x] No
  - [ ] Yes

  #### Metadata
  Does this PR add a new Metadata feature?
  - [x] No
  - [ ] Yes

  #### GraphQL
  - [x] No new GraphQL schema is generated
  - [ ] New GraphQL schema is being generated

  #### Breaking changes
  - [x] No Breaking changes
  - [ ] There are breaking changes