### PR TITLE
[Console] Fix column duplication when deselecting column type in table schema editor

### DIFF
--- a/frontend/libs/console/legacy-ce/src/lib/components/Services/Data/Add/TableColumn.js
+++ b/frontend/libs/console/legacy-ce/src/lib/components/Services/Data/Add/TableColumn.js
@@ -45,8 +45,6 @@ const TableColumn = props => {
 
   const areArrayTypesSupported = isFeatureSupported('tables.create.arrayTypes');
 
-  const [colTypeIdentifier, setColTypeIdentifier] = useState(i);
-
   const [colTypeValue, setColTypeValue] = useState(column.type || '');
 
   useEffect(() => {
@@ -60,9 +58,7 @@ const TableColumn = props => {
 
     const newType = getNewType({ oldType: selectedOption.value, isArray });
 
-    onColTypeChange(selectedOption.colIdentifier, newType);
-
-    setColTypeIdentifier(selectedOption.colIdentifier);
+    onColTypeChange(i, newType);
     setColTypeValue(newType);
   };
 
@@ -73,7 +69,7 @@ const TableColumn = props => {
     if (colTypeValue) {
       const newType = getNewType({ oldType: colTypeValue, isArray });
 
-      onColTypeChange(colTypeIdentifier, newType);
+      onColTypeChange(i, newType);
       setColTypeValue(newType);
     }
   };


### PR DESCRIPTION
### Description
This PR fixes a bug in the Hasura Console where deselecting or clearing a column type in the table schema editor causes existing columns to be duplicated in the schema.

---

### Video Demo

**Before**

https://github.com/user-attachments/assets/64bcf11b-707b-4287-8cb8-8cdfb755d0c9

**After**

https://github.com/user-attachments/assets/b0e3dd4c-3ee7-4a6d-908c-dd0130885f0d

---

### Changelog

__Component__: console

__Type__: bugfix

__Product__: community-edition

---

#### Short Changelog
Fixed column duplication bug in table schema editor when deselecting column types.

---

#### Long Changelog
When editing a table schema in Hasura Console, deselecting the column type for a column was causing existing table columns to be duplicated in the schema editor. For example, if a table had columns `id` and `admin_name`, and a user added a new column `session_id` with an incorrect type, attempting to deselect or clear the column type would duplicate the existing columns.

This issue was caused by incorrect column index usage in the `TableColumn` component. The code was using `selectedOption.colIdentifier` and the `colTypeIdentifier` state variable instead of consistently using the current column index `i`, causing type changes to be applied to the wrong column.

---

### Related Issues
Closes #10807 titled `Hasura Console duplicates existing columns when deselecting column_type during column edit`

---

### Solution and Design
The fix ensures consistent column index usage by:

1. **Removing `colTypeIdentifier` state**: Eliminated the problematic state variable that was storing stale column indices
2. **Fixing `handleColTypeChange`**: Updated to always use the current column index `i` instead of `selectedOption.colIdentifier`
3. **Fixing `onColArrayChange`**: Updated to always use the current column index `i` instead of the removed `colTypeIdentifier` state

Key changes in `TableColumn.js`:
- Removed: `const [colTypeIdentifier, setColTypeIdentifier] = useState(i);`
- Changed: `onColTypeChange(selectedOption.colIdentifier, newType);` → `onColTypeChange(i, newType);`
- Changed: `onColTypeChange(colTypeIdentifier, newType);` → `onColTypeChange(i, newType);`

This ensures each column component only manages its own type changes using its own index, preventing cross-column contamination.

---

### Steps to test and verify
1. Open Hasura Console → Data → Create a Table
2. Add initial columns (e.g., `id` as `bigint`, `admin_name` as `text`)
3. Add a new column (e.g., `session_id`)
4. Set the column type to `bigint` by mistake
5. Use the column type dropdown and try to deselect/clear the selected type
6. **Verify**: Existing columns should not be duplicated
7. **Verify**: Only the currently edited column's type should be affected
8. Test with multiple columns and various type changes

---

### Limitations, known bugs & workarounds
None. This fix addresses the root cause and doesn't introduce new limitations.

---

### Server checklist

---

#### Catalog upgrade
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes

---

#### Metadata
Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes

---

#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated

---

#### Breaking changes
- [x] No Breaking changes
- [ ] There are breaking changes