### PR TITLE
feat(server): add log-masked-variables option to mask sensitive data in query logs (close #10814)

### DIFF
--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -1229,6 +1229,7 @@ test-suite graphql-engine-tests
     Hasura.EncJSONSpec
     Hasura.EventingSpec
     Hasura.Generator.Common
+    Hasura.GraphQL.Logging.QueryLogSpec
     Hasura.GraphQL.NamespaceSpec
     Hasura.GraphQL.Schema.BoolExp.AggregationPredicatesSpec
     Hasura.GraphQL.Schema.Build.UpdateSpec

--- a/server/src-lib/Hasura/App.hs
+++ b/server/src-lib/Hasura/App.hs
@@ -107,6 +107,7 @@ import Hasura.GraphQL.Execute.Action.Subscription
 import Hasura.GraphQL.Execute.Subscription.Poll qualified as ES
 import Hasura.GraphQL.Execute.Subscription.State qualified as ES
 import Hasura.GraphQL.Logging (MonadExecutionLog (..), MonadQueryLog (..))
+import Hasura.GraphQL.Logging.QueryLog (maskQueryLog)
 import Hasura.GraphQL.Transport.HTTP
   ( CacheResult (..),
     MonadExecuteQuery (..),
@@ -477,7 +478,7 @@ initialiseAppEnv env BasicConnectionInfo {..} serveOptions@ServeOptions {..} liv
           appEnvMetadataVersionRef = metaVersionRef,
           appEnvInstanceId = instanceId,
           appEnvEnableMaintenanceMode = soEnableMaintenanceMode,
-          appEnvLoggingSettings = LoggingSettings soEnabledLogTypes soEnableMetadataQueryLogging soHttpLogQueryOnlyOnError,
+          appEnvLoggingSettings = LoggingSettings soEnabledLogTypes soEnableMetadataQueryLogging soHttpLogQueryOnlyOnError soLogMaskedVariables,
           appEnvEventingMode = soEventingMode,
           appEnvEnableReadOnlyMode = soReadOnlyMode,
           appEnvServerMetrics = serverMetrics,
@@ -789,7 +790,9 @@ instance MonadGQLApiHandler AppM where
       EqrAPQReq _ -> throw400 NotSupported "PersistedQueryNotSupported"
 
 instance MonadQueryLog AppM where
-  logQueryLog logger = unLoggerTracing logger
+  logQueryLog logger ql = do
+    maskedKeys <- asks (_lsLogMaskedVariables . appEnvLoggingSettings)
+    unLoggerTracing logger (maskQueryLog maskedKeys ql)
 
 instance MonadExecutionLog AppM where
   logExecutionLog logger = unLoggerTracing logger

--- a/server/src-lib/Hasura/GraphQL/Logging/QueryLog.hs
+++ b/server/src-lib/Hasura/GraphQL/Logging/QueryLog.hs
@@ -6,19 +6,26 @@ module Hasura.GraphQL.Logging.QueryLog
     GeneratedQuery (..),
     MonadQueryLog (..),
     QueryLogKind (..),
+    maskQueryLog,
+    maskJsonValue,
   )
 where
 
 import Data.Aeson qualified as J
+import Data.Aeson.Key qualified as K
+import Data.Aeson.KeyMap qualified as KM
 import Data.HashMap.Strict qualified as HashMap
+import Data.HashSet qualified as HashSet
 import Data.Text.Extended
 import Hasura.GraphQL.Namespace (RootFieldAlias)
 import Hasura.GraphQL.Transport.HTTP.Protocol (GQLReqUnparsed)
+import Hasura.GraphQL.Transport.HTTP.Protocol qualified as Protocol
 import Hasura.Logging qualified as L
 import Hasura.Prelude
 import Hasura.RQL.DDL.ConnectionTemplate (BackendResolvedConnectionTemplate (..))
 import Hasura.Server.Types (RequestId)
 import Hasura.Tracing (TraceT)
+import Language.GraphQL.Draft.Syntax qualified as G
 
 -- | A GraphQL query, optionally generated SQL, and the request id makes up the
 -- | 'QueryLog'
@@ -89,3 +96,50 @@ instance (MonadQueryLog m) => MonadQueryLog (ReaderT r m) where
 
 instance (MonadQueryLog m) => MonadQueryLog (TraceT m) where
   logQueryLog logger l = lift $ logQueryLog logger l
+
+-- | Mask sensitive variable values in a 'QueryLog' before it is emitted.
+-- If the set of keys to mask is empty, the original 'QueryLog' is returned
+-- unchanged in O(1) time.
+maskQueryLog :: HashSet Text -> QueryLog -> QueryLog
+maskQueryLog maskedKeys ql
+  | HashSet.null maskedKeys = ql
+  | otherwise =
+      ql
+        { _qlQuery = maskGQLReqVariables maskedKeys (_qlQuery ql),
+          _qlGeneratedSql = fmap (fmap (maskGeneratedQuery maskedKeys)) (_qlGeneratedSql ql)
+        }
+
+-- | Mask variable values in the GraphQL request whose names match the
+-- configured set of masked variable names.
+maskGQLReqVariables :: HashSet Text -> GQLReqUnparsed -> GQLReqUnparsed
+maskGQLReqVariables maskedKeys (Protocol.GQLReq opName query vars) =
+  Protocol.GQLReq opName query (fmap (maskVariableValues maskedKeys) vars)
+
+-- | Replace values in a 'VariableValues' map with "[MASKED]" when their
+-- key name is in the masked set.
+maskVariableValues :: HashSet Text -> Protocol.VariableValues -> Protocol.VariableValues
+maskVariableValues maskedKeys = HashMap.mapWithKey maskIfSensitive
+  where
+    maskIfSensitive :: G.Name -> J.Value -> J.Value
+    maskIfSensitive name val
+      | G.unName name `HashSet.member` maskedKeys = J.String "[MASKED]"
+      | otherwise = maskJsonValue maskedKeys val
+
+-- | Mask sensitive keys in a 'GeneratedQuery''s prepared arguments.
+maskGeneratedQuery :: HashSet Text -> GeneratedQuery -> GeneratedQuery
+maskGeneratedQuery maskedKeys gq =
+  gq {_gqPreparedArgs = maskJsonValue maskedKeys (_gqPreparedArgs gq)}
+
+-- | Recursively traverse a JSON 'Value', replacing the values of any object
+-- keys that match the masked set with "[MASKED]".
+maskJsonValue :: HashSet Text -> J.Value -> J.Value
+maskJsonValue maskedKeys = go
+  where
+    go (J.Object obj) = J.Object $ KM.mapWithKey maskKey obj
+    go (J.Array arr) = J.Array $ fmap go arr
+    go other = other
+
+    maskKey :: K.Key -> J.Value -> J.Value
+    maskKey k v
+      | K.toText k `HashSet.member` maskedKeys = J.String "[MASKED]"
+      | otherwise = go v

--- a/server/src-lib/Hasura/Server/Init.hs
+++ b/server/src-lib/Hasura/Server/Init.hs
@@ -236,6 +236,7 @@ mkServeOptions sor@ServeOptionsRaw {..} = do
       NativeQuery.NeverValidateNativeQueries -> pure NativeQuery.NeverValidateNativeQueries
   soPreserve401Errors <- withOptionSwitch' rsoPreserve401Errors (\case { MapEverythingTo200 -> False; Preserve401Errors -> True }, bool MapEverythingTo200 Preserve401Errors) preserve401ErrorsOption
   soServerTimeout <- withOptionDefault rsoServerTimeout serverTimeoutOption
+  soLogMaskedVariables <- withOptionDefault rsoLogMaskedVariables logMaskedVariablesOption
   pure ServeOptions {..}
 
 -- | Fetch Postgres 'Query.ConnParams' components from the environment

--- a/server/src-lib/Hasura/Server/Init/Arg/Command/Serve.hs
+++ b/server/src-lib/Hasura/Server/Init/Arg/Command/Serve.hs
@@ -76,6 +76,7 @@ module Hasura.Server.Init.Arg.Command.Serve
     configuredHeaderPrecedenceOption,
     traceQueryStatusOption,
     serverTimeoutOption,
+    logMaskedVariablesOption,
 
     -- * Pretty Printer
     serveCmdFooter,
@@ -179,6 +180,7 @@ serveCommandParser =
     <*> parseDisableNativeQueryValidation
     <*> parsePreserve401Errors
     <*> parseServerTimeout
+    <*> parseLogMaskedVariables
 
 --------------------------------------------------------------------------------
 -- Serve Options
@@ -1448,6 +1450,26 @@ parseServerTimeout =
           <> Opt.help (Config._helpMessage serverTimeoutOption)
       )
 
+parseLogMaskedVariables :: Opt.Parser (Maybe (HashSet Text))
+parseLogMaskedVariables =
+  Opt.optional
+    $ Opt.option
+      (Opt.eitherReader Env.fromEnv)
+      ( Opt.long "log-masked-variables"
+          <> Opt.help (Config._helpMessage logMaskedVariablesOption)
+      )
+
+logMaskedVariablesOption :: Config.Option (HashSet Text)
+logMaskedVariablesOption =
+  Config.Option
+    { Config._default = HashSet.empty,
+      Config._envVar = "HASURA_GRAPHQL_LOG_MASKED_VARIABLES",
+      Config._helpMessage =
+        "Comma separated list of variable names to mask in query logs "
+          <> "(default: none). When set, the values of these variables will be "
+          <> "replaced with \"[MASKED]\" in query-log output."
+    }
+
 --------------------------------------------------------------------------------
 -- Pretty Printer
 
@@ -1556,6 +1578,7 @@ serveCmdFooter =
         Config.optionPP persistedQueriesTtlOption,
         Config.optionPP configuredHeaderPrecedenceOption,
         Config.optionPP preserve401ErrorsOption,
-        Config.optionPP serverTimeoutOption
+        Config.optionPP serverTimeoutOption,
+        Config.optionPP logMaskedVariablesOption
       ]
     eventEnvs = [Config.optionPP graphqlEventsHttpPoolSizeOption, Config.optionPP graphqlEventsFetchIntervalOption]

--- a/server/src-lib/Hasura/Server/Init/Config.hs
+++ b/server/src-lib/Hasura/Server/Init/Config.hs
@@ -340,7 +340,8 @@ data ServeOptionsRaw impl = ServeOptionsRaw
     rsoTraceQueryStatus :: Maybe Server.Types.TraceQueryStatus,
     rsoDisableNativeQueryValidation :: NativeQuery.Validation.DisableNativeQueryValidation,
     rsoPreserve401Errors :: Preserve401ErrorsStatus,
-    rsoServerTimeout :: Maybe (Refined NonNegative Int)
+    rsoServerTimeout :: Maybe (Refined NonNegative Int),
+    rsoLogMaskedVariables :: Maybe (HashSet Text)
   }
 
 deriving stock instance (Show (Logging.EngineLogType impl)) => Show (ServeOptionsRaw impl)
@@ -669,7 +670,8 @@ data ServeOptions impl = ServeOptions
     soTraceQueryStatus :: Server.Types.TraceQueryStatus,
     soDisableNativeQueryValidation :: NativeQuery.Validation.DisableNativeQueryValidation,
     soPreserve401Errors :: Preserve401ErrorsStatus,
-    soServerTimeout :: Refined NonNegative Int
+    soServerTimeout :: Refined NonNegative Int,
+    soLogMaskedVariables :: HashSet Text
   }
 
 -- | 'ResponseInternalErrorsConfig' represents the encoding of the

--- a/server/src-lib/Hasura/Server/Init/Env.hs
+++ b/server/src-lib/Hasura/Server/Init/Env.hs
@@ -351,6 +351,9 @@ instance FromEnv [Auth.JWTConfig] where
 instance (Logging.EnabledLogTypes impl) => FromEnv (HashSet (Logging.EngineLogType impl)) where
   fromEnv = fmap HashSet.fromList . Logging.parseEnabledLogTypes
 
+instance FromEnv (HashSet Text) where
+  fromEnv = Right . HashSet.fromList . filter (not . Text.null) . map Text.strip . Text.splitOn "," . Text.pack
+
 instance FromEnv Logging.LogLevel where
   fromEnv s = case Text.toLower $ Text.strip $ Text.pack s of
     "debug" -> Right Logging.LevelDebug

--- a/server/src-lib/Hasura/Server/Logging.hs
+++ b/server/src-lib/Hasura/Server/Logging.hs
@@ -276,7 +276,10 @@ data LoggingSettings = LoggingSettings
     _lsEnabledLogTypes :: HashSet (EngineLogType Hasura),
     -- See Note [Disable query printing for metadata queries]
     _lsMetadataQueryLoggingMode :: MetadataQueryLoggingMode,
-    _lsHttpLogQueryOnlyOnError :: HttpLogQueryOnlyOnError
+    _lsHttpLogQueryOnlyOnError :: HttpLogQueryOnlyOnError,
+    -- | Set of variable names whose values should be masked in query logs.
+    -- When a variable name matches, its value is replaced with "[MASKED]".
+    _lsLogMaskedVariables :: HashSet Text
   }
   deriving (Eq)
 

--- a/server/src-test/Hasura/GraphQL/Logging/QueryLogSpec.hs
+++ b/server/src-test/Hasura/GraphQL/Logging/QueryLogSpec.hs
@@ -1,0 +1,167 @@
+module Hasura.GraphQL.Logging.QueryLogSpec
+  ( spec,
+  )
+where
+
+import Data.Aeson qualified as J
+import Data.HashMap.Strict qualified as HashMap
+import Data.HashSet qualified as HashSet
+import Hasura.GraphQL.Logging.QueryLog
+import Hasura.GraphQL.Namespace (RootFieldAlias (..))
+import Hasura.GraphQL.Transport.HTTP.Protocol qualified as Protocol
+import Hasura.Prelude
+import Hasura.Server.Types (RequestId (..))
+import Language.GraphQL.Draft.Syntax qualified as G
+import Test.Hspec qualified as Hspec
+
+spec :: Hspec.Spec
+spec = Hspec.describe "QueryLog Masking" $ do
+  maskQueryLogSpec
+  maskJsonValueSpec
+
+mkName :: Text -> G.Name
+mkName t = fromMaybe (error "invalid name") (G.mkName t)
+
+mkVariableValues :: [(Text, J.Value)] -> Protocol.VariableValues
+mkVariableValues = HashMap.fromList . map (first mkName)
+
+mkTestQueryLog :: Protocol.VariableValues -> Maybe GeneratedQuery -> QueryLog
+mkTestQueryLog vars mGenSql =
+  QueryLog
+    { _qlQuery =
+        Protocol.GQLReq
+          { Protocol._grOperationName = Nothing,
+            Protocol._grQuery = Protocol.GQLQueryText "query { test }",
+            Protocol._grVariables = Just vars
+          },
+      _qlGeneratedSql = fmap (\gq -> (RootFieldAlias Nothing (mkName "testField"), gq)) mGenSql,
+      _qlRequestId = RequestId "test-request-id",
+      _qlKind = QueryLogKindDatabase Nothing
+    }
+
+maskQueryLogSpec :: Hspec.Spec
+maskQueryLogSpec =
+  Hspec.describe "maskQueryLog" $ do
+    Hspec.it "returns unchanged QueryLog when maskedKeys is empty" $ do
+      let vars = mkVariableValues [("password", J.String "secret123"), ("name", J.String "Alice")]
+          ql = mkTestQueryLog vars Nothing
+          result = maskQueryLog HashSet.empty ql
+
+      Protocol._grVariables (_qlQuery result)
+        `Hspec.shouldBe` Just vars
+
+    Hspec.it "masks matching variable values" $ do
+      let vars = mkVariableValues [("password", J.String "secret123"), ("name", J.String "Alice")]
+          ql = mkTestQueryLog vars Nothing
+          maskedKeys = HashSet.fromList ["password"]
+          result = maskQueryLog maskedKeys ql
+          expected = mkVariableValues [("password", J.String "[MASKED]"), ("name", J.String "Alice")]
+
+      Protocol._grVariables (_qlQuery result)
+        `Hspec.shouldBe` Just expected
+
+    Hspec.it "masks multiple variable keys" $ do
+      let vars = mkVariableValues [("password", J.String "secret"), ("email", J.String "a@b.com"), ("name", J.String "Alice")]
+          ql = mkTestQueryLog vars Nothing
+          maskedKeys = HashSet.fromList ["password", "email"]
+          result = maskQueryLog maskedKeys ql
+
+      let Just resultVars = Protocol._grVariables (_qlQuery result)
+      HashMap.lookup (mkName "password") resultVars `Hspec.shouldBe` Just (J.String "[MASKED]")
+      HashMap.lookup (mkName "email") resultVars `Hspec.shouldBe` Just (J.String "[MASKED]")
+      HashMap.lookup (mkName "name") resultVars `Hspec.shouldBe` Just (J.String "Alice")
+
+    Hspec.it "masks prepared_arguments in generated SQL" $ do
+      let vars = mkVariableValues [("name", J.String "Alice")]
+          genQuery =
+            GeneratedQuery
+              { _gqQueryString = "SELECT * FROM users WHERE password = $1",
+                _gqPreparedArgs =
+                  J.object
+                    [ "password" J..= J.String "secret",
+                      "name" J..= J.String "Alice"
+                    ]
+              }
+          ql = mkTestQueryLog vars (Just genQuery)
+          maskedKeys = HashSet.fromList ["password"]
+          result = maskQueryLog maskedKeys ql
+
+      case _qlGeneratedSql result of
+        Just (_, gq) -> do
+          let expected =
+                J.object
+                  [ "password" J..= J.String "[MASKED]",
+                    "name" J..= J.String "Alice"
+                  ]
+          _gqPreparedArgs gq `Hspec.shouldBe` expected
+        Nothing -> Hspec.expectationFailure "Expected generated SQL to be present"
+
+    Hspec.it "handles Nothing variables gracefully" $ do
+      let ql =
+            QueryLog
+              { _qlQuery =
+                  Protocol.GQLReq
+                    { Protocol._grOperationName = Nothing,
+                      Protocol._grQuery = Protocol.GQLQueryText "query { test }",
+                      Protocol._grVariables = Nothing
+                    },
+                _qlGeneratedSql = Nothing,
+                _qlRequestId = RequestId "test-request-id",
+                _qlKind = QueryLogKindDatabase Nothing
+              }
+          maskedKeys = HashSet.fromList ["password"]
+          result = maskQueryLog maskedKeys ql
+
+      Protocol._grVariables (_qlQuery result) `Hspec.shouldBe` Nothing
+
+maskJsonValueSpec :: Hspec.Spec
+maskJsonValueSpec =
+  Hspec.describe "maskJsonValue" $ do
+    Hspec.it "masks nested object keys" $ do
+      let input =
+            J.object
+              [ "user"
+                  J..= J.object
+                    [ "password" J..= J.String "secret",
+                      "name" J..= J.String "Alice"
+                    ]
+              ]
+          maskedKeys = HashSet.fromList ["password"]
+          result = maskJsonValue maskedKeys input
+          expected =
+            J.object
+              [ "user"
+                  J..= J.object
+                    [ "password" J..= J.String "[MASKED]",
+                      "name" J..= J.String "Alice"
+                    ]
+              ]
+
+      result `Hspec.shouldBe` expected
+
+    Hspec.it "masks keys inside arrays" $ do
+      let input =
+            J.toJSON
+              [ J.object ["password" J..= J.String "a"],
+                J.object ["password" J..= J.String "b"]
+              ]
+          maskedKeys = HashSet.fromList ["password"]
+          result = maskJsonValue maskedKeys input
+          expected =
+            J.toJSON
+              [ J.object ["password" J..= J.String "[MASKED]"],
+                J.object ["password" J..= J.String "[MASKED]"]
+              ]
+
+      result `Hspec.shouldBe` expected
+
+    Hspec.it "leaves scalar values unchanged" $ do
+      let input = J.String "hello"
+          maskedKeys = HashSet.fromList ["password"]
+
+      maskJsonValue maskedKeys input `Hspec.shouldBe` input
+
+    Hspec.it "does nothing when maskedKeys is empty" $ do
+      let input = J.object ["password" J..= J.String "secret"]
+
+      maskJsonValue HashSet.empty input `Hspec.shouldBe` input

--- a/server/src-test/Hasura/Server/InitSpec.hs
+++ b/server/src-test/Hasura/Server/InitSpec.hs
@@ -107,7 +107,8 @@ emptyServeOptionsRaw =
       rsoTraceQueryStatus = Nothing,
       rsoDisableNativeQueryValidation = NativeQuery.AlwaysValidateNativeQueries,
       rsoPreserve401Errors = UUT.MapEverythingTo200,
-      rsoServerTimeout = Nothing
+      rsoServerTimeout = Nothing,
+      rsoLogMaskedVariables = Nothing
     }
 
 mkServeOptionsSpec :: Hspec.Spec
@@ -1483,3 +1484,34 @@ mkServeOptionsSpec =
             result = UUT.runWithEnv env (UUT.mkServeOptions @Hasura rawServeOptions)
 
         fmap UUT.soExtensionsSchema result `Hspec.shouldBe` Right (MonadTx.ExtensionsSchema "other")
+
+    Hspec.describe "soLogMaskedVariables" $ do
+      Hspec.it "Default == empty" $ do
+        let -- Given
+            rawServeOptions = emptyServeOptionsRaw
+            -- When
+            env = []
+            -- Then
+            result = UUT.runWithEnv env (UUT.mkServeOptions @Hasura rawServeOptions)
+
+        fmap UUT.soLogMaskedVariables result `Hspec.shouldBe` Right Set.empty
+
+      Hspec.it "Env > Nothing" $ do
+        let -- Given
+            rawServeOptions = emptyServeOptionsRaw
+            -- When
+            env = [(UUT._envVar UUT.logMaskedVariablesOption, "password,email,ssn")]
+            -- Then
+            result = UUT.runWithEnv env (UUT.mkServeOptions @Hasura rawServeOptions)
+
+        fmap UUT.soLogMaskedVariables result `Hspec.shouldBe` Right (Set.fromList ["password", "email", "ssn"])
+
+      Hspec.it "Arg > Env" $ do
+        let -- Given
+            rawServeOptions = emptyServeOptionsRaw {UUT.rsoLogMaskedVariables = Just (Set.fromList ["secret"])}
+            -- When
+            env = [(UUT._envVar UUT.logMaskedVariablesOption, "password,email")]
+            -- Then
+            result = UUT.runWithEnv env (UUT.mkServeOptions @Hasura rawServeOptions)
+
+        fmap UUT.soLogMaskedVariables result `Hspec.shouldBe` Right (Set.fromList ["secret"])


### PR DESCRIPTION
### Description

Add a new `HASURA_GRAPHQL_LOG_MASKED_VARIABLES` environment variable (and `--log-masked-variables` CLI flag) that allows specifying a comma-separated list of variable names whose values should be replaced with `"[MASKED]"` in query-log output. This enables teams to keep `query-log` enabled for observability while preventing sensitive data (passwords, emails, SSNs, etc.) from leaking into centralized logging systems.

### Changelog

__Component__ : server

__Type__: feature

__Product__: community-edition

#### Short Changelog

Add `HASURA_GRAPHQL_LOG_MASKED_VARIABLES` env var / `--log-masked-variables` CLI flag to mask sensitive variable values in query logs.

#### Long Changelog

Introduces a configurable variable masking feature for Hasura v2 query logs. When the `HASURA_GRAPHQL_LOG_MASKED_VARIABLES` environment variable or `--log-masked-variables` CLI flag is set with a comma-separated list of variable names, the engine will:

1. Replace matching keys in the GraphQL request `variables` with `"[MASKED]"` before emitting the query log.
2. Recursively traverse the `prepared_arguments` in generated SQL and mask matching keys there as well.
3. Skip the masking step entirely (O(1)) when no variable names are configured, ensuring zero performance degradation for users who don't use this feature.

**Configuration example:**
```
HASURA_GRAPHQL_LOG_MASKED_VARIABLES="password,email,ssn"
```

or

```
graphql-engine serve --log-masked-variables "password,email,ssn"
```

### Related Issues

Closes #10814
Also addresses the core request in #3445

### Solution and Design

The implementation follows the existing patterns for server options:

1. **Config layer** (`ServeOptionsRaw` / `ServeOptions`): A new `rsoLogMaskedVariables` / `soLogMaskedVariables` field of type `Maybe (HashSet Text)` / `HashSet Text` stores the set of variable names to mask.

2. **Arg parsing** (`Serve.hs`): `parseLogMaskedVariables` and `logMaskedVariablesOption` handle the CLI flag and env var (`HASURA_GRAPHQL_LOG_MASKED_VARIABLES`).

3. **Env parsing** (`Env.hs`): A `FromEnv (HashSet Text)` instance parses comma-separated text values, stripping whitespace and filtering empty entries.

4. **Logging settings** (`LoggingSettings`): The masked variable set is stored in `_lsLogMaskedVariables` alongside other logging configuration.

5. **Masking logic** (`QueryLog.hs`):
   - `maskQueryLog` is the entry point: if the set is empty, returns the original `QueryLog` unchanged (O(1) early return).
   - `maskGQLReqVariables` masks the `_grVariables` in the GraphQL request by comparing `G.Name` keys against the configured set.
   - `maskGeneratedQuery` masks `_gqPreparedArgs` in the generated SQL.
   - `maskJsonValue` provides recursive JSON traversal, replacing values of matching object keys with `"[MASKED]"`.

6. **Integration** (`App.hs`): The `MonadQueryLog AppM` instance reads the masked variable set from `AppEnv` and applies `maskQueryLog` before delegating to the logger.

### Steps to test and verify

1. Start the engine with `HASURA_GRAPHQL_LOG_MASKED_VARIABLES="password,email"` and `HASURA_GRAPHQL_ENABLED_LOG_TYPES` including `query-log`.
2. Execute a GraphQL mutation with `password` and `email` variables.
3. Observe in the query log that the values of `password` and `email` are replaced with `"[MASKED]"` while other variables remain visible.
4. Verify that without setting the env var, query logs behave exactly as before (no masking, no performance impact).

### Limitations, known bugs & workarounds

- Masking is key-name based and case-sensitive. Variable names must match exactly as configured.
- The masking applies only to query logs, not to error responses or HTTP logs.

### Server checklist

#### Catalog upgrade
Does this PR change Hasura Catalog version?
- [x] No

#### Metadata

Does this PR add a new Metadata feature?
- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated

#### Breaking changes

- [x] No Breaking changes