### PR TITLE
Fix 'occured' -> 'occurred' typos in v3 graphql validation error messages

### DIFF
--- a/v3/crates/graphql/lang-graphql/src/validation/error.rs
+++ b/v3/crates/graphql/lang-graphql/src/validation/error.rs
@@ -38,10 +38,10 @@ pub enum Error {
     },
     #[error("no such type defined in the document: {0}")]
     UnknownType(ast::TypeName),
-    #[error("an internal error occured during validation: type lookup failed for {type_name}")]
+    #[error("an internal error occurred during validation: type lookup failed for {type_name}")]
     InternalTypeNotFound { type_name: ast::TypeName },
     #[error(
-        "an internal error occured during validation: field {field_name} lookup failed for sub type '{sub_type_name}' of type '{type_name}'"
+        "an internal error occurred during validation: field {field_name} lookup failed for sub type '{sub_type_name}' of type '{type_name}'"
     )]
     InternalNoFieldOnSubtype {
         type_name: ast::TypeName,
@@ -105,7 +105,7 @@ pub enum Error {
         type_name: ast::TypeName,
     },
     #[error(
-        "an internal error occured: expected {type_name} to be an input type but is of {actual_type}"
+        "an internal error occurred: expected {type_name} to be an input type but is of {actual_type}"
     )]
     InternalNotInputType {
         type_name: ast::TypeName,


### PR DESCRIPTION
Three `#[error(...)]` thiserror attributes on `InternalError` variants in `v3/crates/graphql/lang-graphql/src/validation/error.rs` read `an internal error occured`:

- line 41: `an internal error occured during validation: type lookup failed for {type_name}`
- line 44: `an internal error occured during validation: field {field_name} lookup failed ...`
- line 108: `an internal error occured: expected {type_name} to be an input type but is of {actual_type}`

All three messages are surfaced to API clients as the `Display` impl when validation fails. String-literal-only change.