### PR TITLE
docs: clarify local database access from DDN connectors

### DIFF
--- a/docs/cspell.config.yaml
+++ b/docs/cspell.config.yaml
@@ -77,6 +77,7 @@ words:
   - qualifiedtable
   - bigquerytablename
   - sourcename
+  - supergraph
   - functionname
   - qualifiedfunction
   - bigqueryfunctionname

--- a/docs/docs/databases/data-connectors/ddn-connectors.mdx
+++ b/docs/docs/databases/data-connectors/ddn-connectors.mdx
@@ -34,11 +34,25 @@ project, thereby allowing you to use the new connector.
 
 Start by [creating a new Hasura DDN project](https://hasura.io/docs/3.0/getting-started/build/prerequisites) locally.
 
+:::info Connecting Docker-based connectors to local databases
+
+If your DDN connector runs in Docker and needs to connect to a database running on your host machine, do not use
+`localhost` or `127.0.0.1` in the connector connection string. Inside a Docker container, those addresses point to the
+container itself. Use `local.hasura.dev` instead, for example:
+
+```bash
+postgresql://postgres:password@local.hasura.dev:5432/postgres
+```
+
+If the database runs as another service in the same Docker Compose file, use the Compose service name instead.
+
+:::
+
 :::info Choose a connector
 
-When creating a new project, you'll be prompted to select which connector you'd like to include in your project. You 
-can see the full list on the [Connector Hub](https://hasura.io/connectors). This connector will connect to your data
-source, introspect it, and generate the required metadata to create a GraphQL API with Hasura DDN.
+When creating a new project, you'll be prompted to select which connector you'd like to include in your project. You can
+see the full list on the [Connector Hub](https://hasura.io/connectors). This connector will connect to your data source,
+introspect it, and generate the required metadata to create a GraphQL API with Hasura DDN.
 
 :::
 

--- a/v3/README.md
+++ b/v3/README.md
@@ -104,6 +104,33 @@ Add the following entry to your `/etc/hosts` file:
 
 This mapping ensures proper resolution of connector URLs by the engine.
 
+When a connector runs in Docker, `localhost` and `127.0.0.1` refer to the
+connector container itself, not to your host machine. If the connector needs to
+reach a database running on your host machine, use `local.hasura.dev` in the
+connector connection URI:
+
+```bash
+CONNECTION_URI=postgresql://postgres:password@local.hasura.dev:5432/postgres
+```
+
+If the database is another service in the same Docker Compose file, use that
+service name instead. For example, the bundled Postgres service in
+`docker-compose.yaml` is available to the bundled Postgres connectors as
+`postgres`, so the sample connection URI is:
+
+```bash
+CONNECTION_URI=postgresql://postgres:password@postgres
+```
+
+The Docker Compose file maps `local.hasura.dev` to the host gateway for the
+engine and Postgres connector containers. On Docker versions or environments
+where `host-gateway` is not available, set `LOCALHOST_GATEWAY` to the gateway IP
+before starting Docker Compose:
+
+```bash
+LOCALHOST_GATEWAY=172.17.0.1 docker compose up
+```
+
 ## Running tests
 
 To run the test suite, you need to docker login to `ghcr.io` first:

--- a/v3/docker-compose.yaml
+++ b/v3/docker-compose.yaml
@@ -149,6 +149,8 @@ services:
     image: ghcr.io/hasura/ndc-postgres:122d80f6c
     ports:
       - 8080:8080
+    extra_hosts:
+      - local.hasura.dev=${LOCALHOST_GATEWAY:-host-gateway}
     environment:
       CONNECTION_URI: "postgresql://postgres:password@postgres"
       OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://jaeger:4317"
@@ -167,6 +169,8 @@ services:
     image: ghcr.io/hasura/ndc-postgres:dev-main
     ports:
       - 8082:8080
+    extra_hosts:
+      - local.hasura.dev=${LOCALHOST_GATEWAY:-host-gateway}
     environment:
       CONNECTION_URI: "postgresql://postgres:password@postgres"
       OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://jaeger:4317"


### PR DESCRIPTION
## Summary

Refs #10378.

- document that Docker-based DDN connectors must use `local.hasura.dev` instead of `localhost` when connecting to databases running on the host machine
- clarify when to use a Docker Compose service name such as `postgres` instead
- add the `local.hasura.dev` host-gateway mapping to the bundled v3 Postgres connector services, matching the guidance already used by the engine service
- add `supergraph` to the docs spellcheck dictionary because the touched DDN docs page already uses this product term

## Testing

- `npx --yes prettier --check v3/README.md v3/docker-compose.yaml docs/docs/databases/data-connectors/ddn-connectors.mdx docs/cspell.config.yaml`
- `npx --yes cspell@6.18.1 docs/docs/databases/data-connectors/ddn-connectors.mdx --config docs/cspell.config.yaml`
- `docker compose -f v3/docker-compose.yaml config`
- `git diff --check`