### PR TITLE
Add cascade support for removing remote schemas

### DIFF
--- a/server/src-lib/Hasura/RemoteSchema/MetadataAPI/Core.hs
+++ b/server/src-lib/Hasura/RemoteSchema/MetadataAPI/Core.hs
@@ -18,8 +18,6 @@ import Data.HashMap.Strict qualified as HashMap
 import Data.HashMap.Strict.InsOrd qualified as InsOrdHashMap
 import Data.HashSet qualified as S
 import Data.Text.Extended
-import Hasura.Authentication.Role (RoleName)
-import Hasura.Authentication.User (UserInfoM)
 import Hasura.Base.Error
 import Hasura.EncJSON
 import Hasura.GraphQL.RemoteServer
@@ -56,13 +54,19 @@ instance J.ToJSON AddRemoteSchemaQuery where
   toJSON = J.genericToJSON hasuraJSON
   toEncoding = J.genericToEncoding hasuraJSON
 
-newtype RemoteSchemaNameQuery = RemoteSchemaNameQuery
-  { _rsnqName :: RemoteSchemaName
+data RemoteSchemaNameQuery = RemoteSchemaNameQuery
+  { _rsnqName :: RemoteSchemaName,
+    _rsnqCascade :: Bool
   }
   deriving (Show, Eq, Generic)
 
 instance J.FromJSON RemoteSchemaNameQuery where
-  parseJSON = J.genericParseJSON hasuraJSON
+  parseJSON = J.withObject "RemoteSchemaNameQuery" $ \o -> do
+    name <- o J..: "name"
+    cascade <-
+      o J..:? "cascade"
+        >>= maybe (o J..:? "cascade_dependents" J..!= False) pure
+    pure $ RemoteSchemaNameQuery name cascade
 
 instance J.ToJSON RemoteSchemaNameQuery where
   toJSON = J.genericToJSON hasuraJSON
@@ -106,28 +110,31 @@ addRemoteSchemaP1 name = do
     <<> " already exists"
 
 runRemoveRemoteSchema ::
-  (QErrM m, UserInfoM m, CacheRWM m, MetadataM m) =>
+  (QErrM m, CacheRWM m, MetadataM m) =>
   RemoteSchemaNameQuery ->
   m EncJSON
-runRemoveRemoteSchema (RemoteSchemaNameQuery rsn) = do
-  void $ removeRemoteSchemaP1 rsn
+runRemoveRemoteSchema (RemoteSchemaNameQuery rsn cascade) = do
+  deps <- removeRemoteSchemaP1 rsn cascade
+  metadataModifier <- execWriterT $ do
+    traverse_ purgeSourceAndSchemaDependencies deps
+    tell $ dropRemoteSchemaInMetadata rsn
   withNewInconsistentObjsCheck
     $ buildSchemaCache
-    $ dropRemoteSchemaInMetadata rsn
+    $ metadataModifier
   pure successMsg
 
 removeRemoteSchemaP1 ::
-  (UserInfoM m, QErrM m, CacheRM m) =>
+  (QErrM m, CacheRM m) =>
   RemoteSchemaName ->
-  m [RoleName]
-removeRemoteSchemaP1 rsn = do
+  Bool ->
+  m [SchemaObjId]
+removeRemoteSchemaP1 rsn cascade = do
   sc <- askSchemaCache
   let rmSchemas = scRemoteSchemas sc
   void
     $ onNothing (HashMap.lookup rsn rmSchemas)
     $ throw400 NotExists "no such remote schema"
   let depObjs = getDependentObjs sc remoteSchemaDepId
-      roles = mapMaybe getRole depObjs
       nonPermDependentObjs = filter nonPermDependentObjPredicate depObjs
   -- report non permission dependencies (if any), this happens
   -- mostly when a remote relationship is defined with
@@ -135,15 +142,10 @@ removeRemoteSchemaP1 rsn = do
 
   -- we only report the non permission dependencies because we
   -- drop the related permissions
-  unless (null nonPermDependentObjs) $ reportDependentObjectsExist nonPermDependentObjs
-  pure roles
+  unless (cascade || null nonPermDependentObjs) $ reportDependentObjectsExist nonPermDependentObjs
+  pure nonPermDependentObjs
   where
     remoteSchemaDepId = SORemoteSchema rsn
-
-    getRole depObj =
-      case depObj of
-        SORemoteSchemaPermission _ role -> Just role
-        _ -> Nothing
 
     nonPermDependentObjPredicate (SORemoteSchemaPermission _ _) = False
     nonPermDependentObjPredicate _ = True
@@ -152,7 +154,7 @@ runReloadRemoteSchema ::
   (QErrM m, CacheRWM m, MetadataM m) =>
   RemoteSchemaNameQuery ->
   m EncJSON
-runReloadRemoteSchema (RemoteSchemaNameQuery name) = do
+runReloadRemoteSchema (RemoteSchemaNameQuery name _) = do
   remoteSchemas <- getAllRemoteSchemas <$> askSchemaCache
   unless (name `elem` remoteSchemas)
     $ throw400 NotExists
@@ -168,7 +170,7 @@ runReloadRemoteSchema (RemoteSchemaNameQuery name) = do
 
 runIntrospectRemoteSchema ::
   (CacheRM m, QErrM m) => RemoteSchemaNameQuery -> m EncJSON
-runIntrospectRemoteSchema (RemoteSchemaNameQuery rsName) = do
+runIntrospectRemoteSchema (RemoteSchemaNameQuery rsName _) = do
   sc <- askSchemaCache
   RemoteSchemaCtx {..} <-
     HashMap.lookup rsName (scRemoteSchemas sc) `onNothing` throw400 NotExists ("remote schema: " <> rsName <<> " not found")

--- a/server/tests-py/test_remote_relationships.py
+++ b/server/tests-py/test_remote_relationships.py
@@ -93,6 +93,17 @@ class TestDeleteRemoteRelationship:
         hge_ctx.v1q_f(self.dir() + 'remove_remote_schema.yaml', expected_status_code = 400)
         hge_ctx.v1q_f(self.dir() + 'delete_remote_rel.yaml')
 
+    def test_delete_dependencies_with_cascade_dependents(self, hge_ctx):
+        hge_ctx.v1q_f(self.dir() + 'setup_remote_rel_basic.yaml')
+        hge_ctx.v1q({
+            'type': 'remove_remote_schema',
+            'args': {
+                'name': 'my-remote-schema',
+                'cascade_dependents': True,
+            }
+        })
+        self._check_no_remote_relationships(hge_ctx, 'profiles')
+
     def test_deleting_column_with_remote_relationship_dependency(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + 'drop_col_with_remote_rel_dependency.yaml')
         self._check_no_remote_relationships(hge_ctx, 'profiles')
@@ -110,7 +121,7 @@ class TestDeleteRemoteRelationship:
         tables = resp['sources'][0]['tables']
         for t in tables:
             if t['table']['name'] == table:
-                assert 'event_triggers' not in t
+                assert 'remote_relationships' not in t
 
 @use_test_fixtures
 class TestUpdateRemoteRelationship:


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Changelog

<!-- Fill this section if this is a user facing change. -->

__Component__ : server / cli / console / build <!-- choose one -->

__Type__: bugfix / feature / enhancement <!-- choose one -->

__Product__: community-edition

#### Short Changelog

<!-- One line description of this change. (optional if you choose to fill the Long Changelog section instead) -->

#### Long Changelog

<!--
  Detailed description of this change. This might contain links to documentation, blogposts, images. Use markdown for formatting.
  (optional if you choose to fill the Short Changelog section instead)
-->


<!-- Changelog Section End -->

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [ ] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/latest/graphql/core/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [ ] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [ ] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [ ] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
