### PR TITLE
Fix TypeError when experimental_features is null in useRootFieldPermissions.ts

### DIFF
--- a/frontend/libs/console/legacy-ce/src/lib/components/Services/Data/TablePermissions/RootFieldPermissions/useRootFieldPermissions.ts
+++ b/frontend/libs/console/legacy-ce/src/lib/components/Services/Data/TablePermissions/RootFieldPermissions/useRootFieldPermissions.ts
@@ -31,7 +31,7 @@ export const useRootFieldPermissions = ({
 }: Props) => {
   const { data: configData } = useServerConfig();
   const isSubscriptionStreamingEnabled =
-    !!configData?.experimental_features.includes('streaming_subscriptions');
+    !!configData?.experimental_features?.includes('streaming_subscriptions');
 
   const isRootPermissionsSwitchedOn =
     subscriptionRootPermissions !== null && queryRootPermissions !== null;


### PR DESCRIPTION
Fixes #10848.

Fix TypeError when experimental_features is null in useRootFieldPermissions.ts. The bug is caused by missing optional chaining on `experimental_features`. When `experimental_features` is null (default when HASURA_GRAPHQL_EXPERIMENTAL_FEATURES is not set), calling `.includes()` on null throws TypeError. Adding `?.` after `experimental_features` prevents this.

I ran the available lightweight check for the frontend change.