### PR TITLE
console: allow empty update trigger columns

### DIFF
--- a/frontend/libs/console/legacy-ce/src/lib/components/Services/Events/EventTriggers/Add/Add.tsx
+++ b/frontend/libs/console/legacy-ce/src/lib/components/Services/Events/EventTriggers/Add/Add.tsx
@@ -26,7 +26,6 @@ import {
   setRequestUrlTransform,
   setRequestPayloadTransform,
 } from '../../../../Common/ConfigureTransformation/requestTransformState';
-import { showErrorNotification } from '../../../Common/Notification';
 import {
   QueryParams,
   RequestTransformContentType,
@@ -294,21 +293,6 @@ const Add: React.FC<Props> = props => {
 
   const submit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (
-      state.operationColumns.every(
-        operationColumn => !operationColumn.enabled
-      ) &&
-      state.operations.update
-    ) {
-      dispatch(
-        showErrorNotification(
-          'Creating event trigger failed.',
-          'Please select at-least one trigger column for the update trigger operation.'
-        )
-      );
-      return;
-    }
-
     const newState = { ...state };
 
     /* don't cleanup_config if console type is oss */

--- a/frontend/libs/console/legacy-ce/src/lib/components/Services/Events/EventTriggers/Common/ColumnList.tsx
+++ b/frontend/libs/console/legacy-ce/src/lib/components/Services/Events/EventTriggers/Common/ColumnList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { QualifiedTable } from '../../../../../metadata/types';
 import { Button } from '../../../../../new-components/Button';
 import { ETOperationColumn } from '../../types';
@@ -23,11 +23,11 @@ const ColumnList: React.FC<ColumnListProps> = props => {
     handleOperationsColumnsChange,
   } = props;
 
-  const [allColEnabled, setAllColEnabled] = useState(true);
-
   if (!table.name) {
     return <i>Select a table first to get column list</i>;
   }
+
+  const hasSelectedColumns = operationColumns.some(col => col.enabled);
 
   const handleToggleColumn = (opCol: ETOperationColumn) => {
     const newCols = operationColumns.map(o => {
@@ -40,25 +40,13 @@ const ColumnList: React.FC<ColumnListProps> = props => {
   };
 
   const handleToggleAllColumns = () => {
-    if (allColEnabled) {
-      const cols = operationColumns.map(col => {
-        return {
-          ...col,
-          enabled: false,
-        };
-      });
-      handleOperationsColumnsChange(cols);
-      setAllColEnabled(false);
-    } else {
-      const cols = operationColumns.map(col => {
-        return {
-          ...col,
-          enabled: true,
-        };
-      });
-      handleOperationsColumnsChange(cols);
-      setAllColEnabled(true);
-    }
+    const cols = operationColumns.map(col => {
+      return {
+        ...col,
+        enabled: !hasSelectedColumns,
+      };
+    });
+    handleOperationsColumnsChange(cols);
   };
 
   return (
@@ -78,7 +66,7 @@ const ColumnList: React.FC<ColumnListProps> = props => {
                 size="sm"
                 onClick={() => handleToggleAllColumns()}
               >
-                Toggle All
+                {hasSelectedColumns ? 'Unselect All' : 'Select All'}
               </Button>
             </div>
             {operationColumns.map(opCol => (

--- a/frontend/libs/console/legacy-ce/src/lib/components/Services/Events/EventTriggers/Modify/Modify.tsx
+++ b/frontend/libs/console/legacy-ce/src/lib/components/Services/Events/EventTriggers/Modify/Modify.tsx
@@ -44,7 +44,6 @@ import {
   parseValidateApiData,
   getTransformState,
 } from '../../../../../components/Common/ConfigureTransformation/utils';
-import { showErrorNotification } from '../../../../../components/Services/Common/Notification';
 import { Button } from '../../../../../new-components/Button';
 import { isProConsole } from '../../../../../utils/proConsole';
 import globals from '../../../../../Globals';
@@ -329,21 +328,6 @@ const Modify: React.FC<Props> = props => {
   const saveWrapper =
     (property?: EventTriggerProperty) =>
     (successCb?: () => void, errorCb?: () => void) => {
-      if (
-        state.operationColumns.every(
-          operationColumn => !operationColumn.enabled
-        ) &&
-        state.operations.update
-      ) {
-        dispatch(
-          showErrorNotification(
-            'Updating event trigger failed.',
-            'Please select at-least one trigger column for the update trigger operation.'
-          )
-        );
-        return;
-      }
-
       const modifyTriggerState = { ...state };
 
       /* don't pass cleanup config if it's empty or just have only paused */

--- a/frontend/libs/console/legacy-ce/src/lib/components/Services/Events/EventTriggers/Modify/OperationEditor.tsx
+++ b/frontend/libs/console/legacy-ce/src/lib/components/Services/Events/EventTriggers/Modify/OperationEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Button } from '../../../../../new-components/Button';
 import Editor from '../../../../Common/Layout/ExpandableEditor/Editor';
 import {
@@ -40,7 +40,6 @@ export const OperationEditor: React.FC<OperationEditorProps> = props => {
     isAllColumnChecked,
     handleColumnRadioButton,
   } = props;
-  const [allColEnabled, setAllColEnabled] = useState(true);
   const etDef = currentTrigger.configuration.definition;
   const existingOps = parseEventTriggerOperations(etDef);
   const columnInfo =
@@ -57,120 +56,113 @@ export const OperationEditor: React.FC<OperationEditorProps> = props => {
   };
 
   const handleToggleAllColumns = () => {
-    if (allColEnabled) {
-      const cols = operationColumns.map(o => {
-        return {
-          ...o,
-          enabled: false,
-        };
-      });
-      setOperationColumns(cols);
-      setAllColEnabled(false);
-    } else {
-      const cols = operationColumns.map(o => {
-        return {
-          ...o,
-          enabled: true,
-        };
-      });
-      setOperationColumns(cols);
-      setAllColEnabled(true);
-    }
+    const hasSelectedColumns = operationColumns.some(col => col.enabled);
+    const cols = operationColumns.map(o => {
+      return {
+        ...o,
+        enabled: !hasSelectedColumns,
+      };
+    });
+    setOperationColumns(cols);
   };
 
   const renderEditor = (
     ops: Record<EventTriggerOperation, boolean>,
     opCols: ETOperationColumn[],
     readOnly: boolean
-  ) => (
-    <div>
-      <label className="block text-gray-600 font-medium mb-sm">
-        Trigger Method
-      </label>
-      <div className="flex">
-        <div className="mb-sm w-full p-0">
-          <Operations
-            selectedOperations={ops}
-            setOperations={setOperations}
-            readOnly={readOnly}
-            tableName={currentTrigger.table_name}
-          />
+  ) => {
+    const hasSelectedColumns = opCols.some(col => col.enabled);
+
+    return (
+      <div>
+        <label className="block text-gray-600 font-medium mb-sm">
+          Trigger Method
+        </label>
+        <div className="flex">
+          <div className="mb-sm w-full p-0">
+            <Operations
+              selectedOperations={ops}
+              setOperations={setOperations}
+              readOnly={readOnly}
+              tableName={currentTrigger.table_name}
+            />
+          </div>
+        </div>
+        <div>
+          <label className="block text-gray-600 font-medium mb-xs">
+            Trigger Columns
+          </label>
+          <p className="text-sm text-gray-600 mb-sm">
+            Trigger columns to listen to for updates.
+          </p>
+        </div>
+        <div>
+          {ops.update ? (
+            <>
+              <div className={`w-full p-0 mr-md mt-md ${focusYellowRing}`}>
+                <ColumnSelectionRadioButton
+                  isAllColumnChecked={isAllColumnChecked}
+                  handleColumnRadioButton={handleColumnRadioButton}
+                  readOnly={readOnly}
+                />
+              </div>
+              {!isAllColumnChecked ? (
+                <div className="w-full p-0 mt-sm">
+                  <div>
+                    List of columns to select:
+                    <Button
+                      className="ml-2"
+                      size="sm"
+                      onClick={() => handleToggleAllColumns()}
+                      disabled={readOnly}
+                    >
+                      {hasSelectedColumns ? 'Unselect All' : 'Select All'}
+                    </Button>
+                  </div>
+                  {opCols.map(col => {
+                    const toggle = () => {
+                      if (!readOnly) {
+                        const newCols = opCols.map(oc => {
+                          return {
+                            ...oc,
+                            enabled:
+                              col.name === oc.name ? !oc.enabled : oc.enabled,
+                          };
+                        });
+                        setOperationColumns(newCols);
+                      }
+                    };
+                    return (
+                      <label
+                        className="mr-md my-md p-0 pointer-cursor"
+                        key={col.name}
+                        onChange={toggle}
+                      >
+                        <input
+                          type="checkbox"
+                          name={`column-${col.name}`}
+                          className={`!mr-xs cursor-pointer ${focusYellowRing} disabled:bg-gray-200 disabled:cursor-not-allowed disabled:text-gray-200 border-gray-200 rounded-sm bg-white`}
+                          checked={col.enabled}
+                          disabled={readOnly}
+                          readOnly
+                        />
+                        {col.name}
+                        <small className="p-xs"> ({col.type})</small>
+                      </label>
+                    );
+                  })}
+                </div>
+              ) : null}
+            </>
+          ) : (
+            <div className="w-full p-0">
+              <i>Applicable only if update operation is selected.</i>
+            </div>
+          )}
         </div>
       </div>
-      <div>
-        <label className="block text-gray-600 font-medium mb-xs">
-          Trigger Columns
-        </label>
-        <p className="text-sm text-gray-600 mb-sm">
-          Trigger columns to listen to for updates.
-        </p>
-      </div>
-      <div>
-        {ops.update ? (
-          <>
-            <div className={`w-full p-0 mr-md mt-md ${focusYellowRing}`}>
-              <ColumnSelectionRadioButton
-                isAllColumnChecked={isAllColumnChecked}
-                handleColumnRadioButton={handleColumnRadioButton}
-                readOnly={readOnly}
-              />
-            </div>
-            {!isAllColumnChecked ? (
-              <div className="w-full p-0 mt-sm">
-                <div>
-                  List of columns to select:
-                  <Button
-                    className="ml-2"
-                    size="sm"
-                    onClick={() => handleToggleAllColumns()}
-                    disabled={readOnly}
-                  >
-                    Toggle All
-                  </Button>
-                </div>
-                {opCols.map(col => {
-                  const toggle = () => {
-                    if (!readOnly) {
-                      const newCols = opCols.map(oc => {
-                        return {
-                          ...oc,
-                          enabled:
-                            col.name === oc.name ? !oc.enabled : oc.enabled,
-                        };
-                      });
-                      setOperationColumns(newCols);
-                    }
-                  };
-                  return (
-                    <label
-                      className="mr-md my-md p-0 pointer-cursor"
-                      key={col.name}
-                      onChange={toggle}
-                    >
-                      <input
-                        type="checkbox"
-                        name={`column-${col.name}`}
-                        className={`!mr-xs cursor-pointer ${focusYellowRing} disabled:bg-gray-200 disabled:cursor-not-allowed disabled:text-gray-200 border-gray-200 rounded-sm bg-white`}
-                        checked={col.enabled}
-                        disabled={readOnly}
-                        readOnly
-                      />
-                      {col.name}
-                      <small className="p-xs"> ({col.type})</small>
-                    </label>
-                  );
-                })}
-              </div>
-            ) : null}
-          </>
-        ) : (
-          <div className="w-full p-0">
-            <i>Applicable only if update operation is selected.</i>
-          </div>
-        )}
-      </div>
-    </div>
-  );
+    );
+  };
 
   const collapsed = () => renderEditor(existingOps, existingOpColumns, true);
 

--- a/frontend/libs/console/legacy-ce/src/lib/metadata/__tests__/__snapshots__/generateCreateEventTriggerQuery.test.ts.snap
+++ b/frontend/libs/console/legacy-ce/src/lib/metadata/__tests__/__snapshots__/generateCreateEventTriggerQuery.test.ts.snap
@@ -1,5 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Testing generateCreateEventTriggerQuery while creating ET allows update triggers with no selected columns 1`] = `
+{
+  "args": {
+    "delete": null,
+    "enable_manual": false,
+    "headers": [],
+    "insert": {
+      "columns": "*",
+    },
+    "name": "trigger_name_1",
+    "replace": false,
+    "request_transform": undefined,
+    "retry_conf": {
+      "interval_sec": 10,
+      "num_retries": 0,
+      "timeout_sec": 60,
+    },
+    "source": "default",
+    "table": {
+      "name": "table_name",
+      "schema": "public",
+    },
+    "update": {
+      "columns": [],
+    },
+    "webhook": "http://httpbin.org/post",
+    "webhook_from_env": null,
+  },
+  "type": "pg_create_event_trigger",
+}
+`;
+
 exports[`Testing generateCreateEventTriggerQuery while creating ET with request transform 1`] = `
 {
   "args": {

--- a/frontend/libs/console/legacy-ce/src/lib/metadata/__tests__/generateCreateEventTriggerQuery.test.ts
+++ b/frontend/libs/console/legacy-ce/src/lib/metadata/__tests__/generateCreateEventTriggerQuery.test.ts
@@ -54,6 +54,21 @@ describe('Testing generateCreateEventTriggerQuery while creating ET', () => {
     expect(res?.args?.request_transform).toEqual(undefined);
     expect(res).toMatchSnapshot();
   });
+  it('allows update triggers with no selected columns', () => {
+    const res = generateCreateEventTriggerQuery(
+      {
+        ...eventTriggerStateWithoutHeaders,
+        operations: {
+          ...eventTriggerStateWithoutHeaders.operations,
+          update: true,
+        },
+      },
+      source,
+      false
+    );
+    expect(res?.args?.update?.columns).toEqual([]);
+    expect(res).toMatchSnapshot();
+  });
 });
 
 describe('Testing generateCreateEventTriggerQuery while mofifying ET', () => {


### PR DESCRIPTION
## Summary
- allow event triggers to save an explicit update column list with zero selected columns
- replace the ambiguous Trigger Columns bulk action with Select All / Unselect All labels derived from the current selection
- add a metadata query regression test covering `columns: []`

## Why
Issue #4972 asks for the Console event trigger advanced settings to support starting with no selected update columns or unselecting all columns. The UI already serializes an explicit column list, but the create/modify submit paths blocked the empty-list case.

Closes #4972

## Validation
- `NX_DAEMON=false ./node_modules/.bin/nx test console-legacy-ce --testFile=libs/console/legacy-ce/src/lib/metadata/__tests__/generateCreateEventTriggerQuery.test.ts`
- `./node_modules/.bin/prettier --check libs/console/legacy-ce/src/lib/components/Services/Events/EventTriggers/Add/Add.tsx libs/console/legacy-ce/src/lib/components/Services/Events/EventTriggers/Common/ColumnList.tsx libs/console/legacy-ce/src/lib/components/Services/Events/EventTriggers/Modify/Modify.tsx libs/console/legacy-ce/src/lib/components/Services/Events/EventTriggers/Modify/OperationEditor.tsx libs/console/legacy-ce/src/lib/metadata/__tests__/generateCreateEventTriggerQuery.test.ts`
- `./node_modules/.bin/eslint libs/console/legacy-ce/src/lib/components/Services/Events/EventTriggers/Add/Add.tsx libs/console/legacy-ce/src/lib/components/Services/Events/EventTriggers/Common/ColumnList.tsx libs/console/legacy-ce/src/lib/components/Services/Events/EventTriggers/Modify/Modify.tsx libs/console/legacy-ce/src/lib/components/Services/Events/EventTriggers/Modify/OperationEditor.tsx libs/console/legacy-ce/src/lib/metadata/__tests__/generateCreateEventTriggerQuery.test.ts`

ESLint completed with existing warnings in the touched legacy files and no errors.

## Note
I used AI assistance to prepare this patch and reviewed/tested the result locally.