### PR TITLE
cli: fix mismatched godoc comment names

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -259,7 +259,7 @@ func (c *ServerConfig) GetVersionEndpoint() string {
 	return nurl.String()
 }
 
-// GetQueryEndpoint provides the url to contact the query API
+// GetV1QueryEndpoint provides the url to contact the query API
 func (c *ServerConfig) GetV1QueryEndpoint() string {
 	nurl := *c.ParsedEndpoint
 	nurl.Path = path.Join(nurl.Path, c.APIPaths.V1Query)
@@ -284,7 +284,7 @@ func (c *ServerConfig) GetV1GraphqlEndpoint() string {
 	return nurl.String()
 }
 
-// GetQueryEndpoint provides the url to contact the query API
+// GetV1MetadataEndpoint provides the url to contact the metadata API
 func (c *ServerConfig) GetV1MetadataEndpoint() string {
 	nurl := *c.ParsedEndpoint
 	nurl.Path = path.Join(nurl.Path, c.APIPaths.V1Metadata)

--- a/cli/directory.go
+++ b/cli/directory.go
@@ -105,7 +105,7 @@ func ValidateDirectory(dir string) error {
 	return nil
 }
 
-// CheckFilesystemBiundary returns an error if dir is filesystem root
+// CheckFilesystemBoundary returns an error if dir is filesystem root
 func CheckFilesystemBoundary(dir string) error {
 	var op errors.Op = "cli.CheckFilesystemBoundary"
 	// since filepath.Abs calls filepath.Clean the path is expected to be in "clean" state


### PR DESCRIPTION
A few exported functions in the CLI had doc comments that didn't match the function name (Go convention is that a doc comment begins with the name of the symbol it documents):

- `GetV1QueryEndpoint` (cli/cli.go): doc comment said `GetQueryEndpoint`
- `GetV1MetadataEndpoint` (cli/cli.go): doc comment said `GetQueryEndpoint` and described the query API; updated to the metadata API
- `CheckFilesystemBoundary` (cli/directory.go): typo `CheckFilesystemBiundary` in the doc comment

Comment-only change; no behavior change.