### PR TITLE
server/mssql: stop emitting redundant IIF null-handling sort keys in ORDER BY so indexes can be used (close #10844)

### DIFF
--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -1141,6 +1141,7 @@ test-suite graphql-engine-tests
     , monad-control
     , mtl
     , network-uri
+    , odbc
     , openapi3
     , optparse-applicative
     , pg-client
@@ -1208,6 +1209,7 @@ test-suite graphql-engine-tests
     Hasura.Backends.DataConnector.API.V0.SchemaSpec
     Hasura.Backends.DataConnector.API.V0.TableSpec
     Hasura.Backends.DataConnector.API.V0.TargetSpec
+    Hasura.Backends.MSSQL.FromIr.QuerySpec
     Hasura.Backends.Postgres.Connection.VersionCheckSpec
     Hasura.Backends.Postgres.Execute.PrepareSpec
     Hasura.Backends.Postgres.NativeQueries.NativeQueriesSpec

--- a/server/src-lib/Hasura/Backends/MSSQL/FromIr/Query.hs
+++ b/server/src-lib/Hasura/Backends/MSSQL/FromIr/Query.hs
@@ -967,29 +967,44 @@ fromAnnotatedOrderByItemG ::
   IR.AnnotatedOrderByItemG 'MSSQL Expression ->
   WriterT (Seq UnfurledJoin) (ReaderT EntityAlias FromIr) OrderBy
 fromAnnotatedOrderByItemG IR.OrderByItemG {obiType, obiColumn = obiColumn, obiNulls} = do
-  (orderByExpression, orderByType) <- unfurlAnnotatedOrderByElement obiColumn
-  let orderByNullsOrder = fromMaybe NullsAnyOrder obiNulls
+  (orderByExpression, orderByType, nullability) <- unfurlAnnotatedOrderByElement obiColumn
+  let orderByNullsOrder = case nullability of
+        -- When the ordering expression can never evaluate to NULL, a nulls
+        -- ordering would only add a redundant @IIF(.. IS NULL, ..)@ sort key
+        -- to the generated query, so we drop it.
+        IR.NotNullable -> NullsAnyOrder
+        IR.Nullable -> fromMaybe NullsAnyOrder obiNulls
       orderByOrder = fromMaybe AscOrder obiType
   pure OrderBy {..}
 
 -- | Unfurl the nested set of object relations (tell'd in the writer)
 -- that are terminated by field name (IR.AOCColumn and
 -- IR.AOCArrayAggregation).
+--
+-- Also reports whether the resulting ordering expression may evaluate to
+-- NULL, so that null handling can be skipped when it provably cannot.
 unfurlAnnotatedOrderByElement ::
   IR.AnnotatedOrderByElement 'MSSQL Expression ->
-  WriterT (Seq UnfurledJoin) (ReaderT EntityAlias FromIr) (Expression, Maybe TSQL.ScalarType)
+  WriterT (Seq UnfurledJoin) (ReaderT EntityAlias FromIr) (Expression, Maybe TSQL.ScalarType, IR.Nullable)
 unfurlAnnotatedOrderByElement =
   \case
     IR.AOCColumn columnInfo redactionExp -> do
       fieldName <- lift (fromColumnInfo columnInfo)
       ex <- lift $ potentiallyRedacted redactionExp (ColumnExpression fieldName)
+      let nullability = case redactionExp of
+            -- Redaction wraps the column in a conditional that can produce
+            -- NULL even for non-nullable columns.
+            IR.NoRedaction
+              | not (IR.ciIsNullable columnInfo) -> IR.NotNullable
+            _ -> IR.Nullable
       pure
         ( ex,
           case IR.ciType columnInfo of
             IR.ColumnScalar t -> Just t
             -- Above: It is of interest to us whether the type is
             -- text/ntext/image. See ToQuery for more explanation.
-            _ -> Nothing
+            _ -> Nothing,
+          nullability
         )
     IR.AOCObjectRelation IR.RelInfo {riMapping = IR.RelMapping mapping, riTarget = IR.RelTargetNativeQuery nativeQueryName} annBoolExp annOrderByElementG -> do
       let name = T.toTxt (getNativeQueryName nativeQueryName)
@@ -1059,7 +1074,10 @@ unfurlAnnotatedOrderByElement =
         )
       pure
         ( ColumnExpression $ FieldName {fieldNameEntity = joinAliasEntity, fieldName = alias},
-          Nothing
+          Nothing,
+          -- Conservative: aggregates other than COUNT (e.g. MIN, SUM) yield
+          -- NULL when no rows match.
+          IR.Nullable
         )
   where
     genObjectRelation mapping annBoolExp annOrderByElementG joinAliasEntity selectFrom table = do
@@ -1099,9 +1117,14 @@ unfurlAnnotatedOrderByElement =
                 unfurledObjectTableAlias = Just (table, EntityAlias joinAliasEntity)
               }
         )
-      local
-        (const (EntityAlias joinAliasEntity))
-        (unfurlAnnotatedOrderByElement annOrderByElementG)
+      (ex, ty, _) <-
+        local
+          (const (EntityAlias joinAliasEntity))
+          (unfurlAnnotatedOrderByElement annOrderByElementG)
+      -- The object relation is joined with an OUTER APPLY: even when the
+      -- targeted expression itself can never be NULL, the joined row as a
+      -- whole may be missing, making the ordering expression NULL.
+      pure (ex, ty, IR.Nullable)
 
 tableNameText :: TableName -> Text
 tableNameText (TableName {tableName}) = tableName

--- a/server/src-lib/Hasura/Backends/MSSQL/Instances/Schema.hs
+++ b/server/src-lib/Hasura/Backends/MSSQL/Instances/Schema.hs
@@ -279,23 +279,30 @@ msOrderByOperators _tCase =
     $
     -- NOTE: NamingCase is not being used here as we don't support naming conventions for this DB
     NE.fromList
+      -- SQL Server sorts NULL as the lowest possible value: ascending order
+      -- places nulls first and descending order places nulls last, natively.
+      -- Operators that ask for exactly that placement are given
+      -- 'NullsAnyOrder' so no @IIF(.. IS NULL, ..)@ sort key is emitted for
+      -- them (such a computed sort key defeats index use, see #10844). Only
+      -- the two operators that invert the native placement need an explicit
+      -- nulls order.
       [ ( define Name._asc "in ascending order, nulls first",
-          (MSSQL.AscOrder, MSSQL.NullsFirst)
+          (MSSQL.AscOrder, MSSQL.NullsAnyOrder)
         ),
         ( define Name._asc_nulls_first "in ascending order, nulls first",
-          (MSSQL.AscOrder, MSSQL.NullsFirst)
+          (MSSQL.AscOrder, MSSQL.NullsAnyOrder)
         ),
         ( define Name._asc_nulls_last "in ascending order, nulls last",
           (MSSQL.AscOrder, MSSQL.NullsLast)
         ),
         ( define Name._desc "in descending order, nulls last",
-          (MSSQL.DescOrder, MSSQL.NullsLast)
+          (MSSQL.DescOrder, MSSQL.NullsAnyOrder)
         ),
         ( define Name._desc_nulls_first "in descending order, nulls first",
           (MSSQL.DescOrder, MSSQL.NullsFirst)
         ),
         ( define Name._desc_nulls_last "in descending order, nulls last",
-          (MSSQL.DescOrder, MSSQL.NullsLast)
+          (MSSQL.DescOrder, MSSQL.NullsAnyOrder)
         )
       ]
   where

--- a/server/src-test/Hasura/Backends/MSSQL/FromIr/QuerySpec.hs
+++ b/server/src-test/Hasura/Backends/MSSQL/FromIr/QuerySpec.hs
@@ -1,0 +1,125 @@
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "avoid Language.GraphQL.Draft.Syntax.unsafeMkName" #-}
+
+-- | Tests translating query IR into TSQL 'Select' values, in particular the
+-- ORDER BY null handling: the @IIF(.. IS NULL, ..)@ sort key must only be
+-- generated when the ordering expression can actually evaluate to NULL.
+module Hasura.Backends.MSSQL.FromIr.QuerySpec (spec) where
+
+import Data.Text qualified as T
+import Database.ODBC.SQLServer qualified as ODBC
+import Hasura.Backends.MSSQL.FromIr (runFromIrUseCTEs)
+import Hasura.Backends.MSSQL.FromIr.Query (fromSelect)
+import Hasura.Backends.MSSQL.Instances.Types ()
+import Hasura.Backends.MSSQL.ToQuery qualified as ToQuery
+import Hasura.Backends.MSSQL.Types.Internal qualified as TSQL
+import Hasura.Base.Error (showQErr)
+import Hasura.Prelude
+import Hasura.RQL.IR qualified as IR
+import Hasura.RQL.Types.BackendType
+import Hasura.RQL.Types.Column qualified as IR
+import Hasura.RQL.Types.Common qualified as IR
+import Hasura.RQL.Types.Schema.Options qualified as Options
+import Language.GraphQL.Draft.Syntax qualified as G
+import Test.Hspec
+
+spec :: Spec
+spec = describe "fromSelect: ORDER BY null handling" do
+  let nullableCol = mkColumnInfo "title" True
+      nonNullableCol = mkColumnInfo "id" False
+
+  it "emits an IIF sort key for a nullable column with an explicit nulls order" do
+    sql <- translate (mkSelect [orderBy nullableCol (Just TSQL.AscOrder) (Just TSQL.NullsFirst) IR.NoRedaction])
+    sql `shouldSatisfy` T.isInfixOf "IIF"
+
+  it "omits the IIF sort key for a non-nullable column with an explicit nulls order" do
+    sql <- translate (mkSelect [orderBy nonNullableCol (Just TSQL.AscOrder) (Just TSQL.NullsFirst) IR.NoRedaction])
+    sql `shouldSatisfy` T.isInfixOf "ORDER BY"
+    sql `shouldSatisfy` (not . T.isInfixOf "IIF")
+
+  it "omits the IIF sort key when no nulls order is requested" do
+    sql <- translate (mkSelect [orderBy nullableCol (Just TSQL.DescOrder) Nothing IR.NoRedaction])
+    sql `shouldSatisfy` T.isInfixOf "ORDER BY"
+    sql `shouldSatisfy` (not . T.isInfixOf "IIF")
+
+  it "omits the IIF sort key for NullsAnyOrder on a nullable column (plain asc/desc)" do
+    sql <- translate (mkSelect [orderBy nullableCol (Just TSQL.AscOrder) (Just TSQL.NullsAnyOrder) IR.NoRedaction])
+    sql `shouldSatisfy` T.isInfixOf "ORDER BY"
+    sql `shouldSatisfy` (not . T.isInfixOf "IIF")
+
+  it "keeps the IIF sort key for a redacted non-nullable column" do
+    -- Redaction can turn any value into NULL, so the null handling has to
+    -- stay even if the underlying column is non-nullable.
+    sql <- translate (mkSelect [orderBy nonNullableCol (Just TSQL.AscOrder) (Just TSQL.NullsFirst) (IR.RedactIfFalse IR.annBoolExpTrue)])
+    sql `shouldSatisfy` T.isInfixOf "IIF"
+
+  it "handles nullable and non-nullable order-by columns independently" do
+    sql <-
+      translate
+        ( mkSelect
+            [ orderBy nonNullableCol (Just TSQL.AscOrder) (Just TSQL.NullsLast) IR.NoRedaction,
+              orderBy nullableCol (Just TSQL.DescOrder) (Just TSQL.NullsLast) IR.NoRedaction
+            ]
+        )
+    sql `shouldSatisfy` T.isInfixOf "[title] IS NULL, 1, 0)"
+    sql `shouldSatisfy` (not . T.isInfixOf "[id] IS NULL")
+
+--------------------------------------------------------------------------------
+-- Test helpers
+
+mkColumnInfo :: Text -> Bool -> IR.ColumnInfo 'MSSQL
+mkColumnInfo name isNullable =
+  IR.ColumnInfo
+    { ciColumn = TSQL.ColumnName name,
+      ciName = G.unsafeMkName name,
+      ciPosition = 0,
+      ciType = IR.ColumnScalar TSQL.IntegerType,
+      ciIsNullable = isNullable,
+      ciDescription = Nothing,
+      ciMutability = IR.ColumnMutability {_cmIsInsertable = False, _cmIsUpdatable = False}
+    }
+
+orderBy ::
+  IR.ColumnInfo 'MSSQL ->
+  Maybe TSQL.Order ->
+  Maybe TSQL.NullsOrder ->
+  IR.AnnRedactionExp 'MSSQL TSQL.Expression ->
+  IR.AnnotatedOrderByItemG 'MSSQL TSQL.Expression
+orderBy columnInfo obiType obiNulls redactionExp =
+  IR.OrderByItemG
+    { obiType,
+      obiColumn = IR.AOCColumn columnInfo redactionExp,
+      obiNulls
+    }
+
+mkSelect ::
+  [IR.AnnotatedOrderByItemG 'MSSQL TSQL.Expression] ->
+  IR.AnnSelectG 'MSSQL (IR.AnnFieldG 'MSSQL Void) TSQL.Expression
+mkSelect orderByItems =
+  IR.AnnSelectG
+    { _asnFields = [(IR.FieldName "id", IR.AFColumn (mkAnnColumnField (mkColumnInfo "id" False)))],
+      _asnFrom = IR.FromTable (TSQL.TableName "test" (TSQL.SchemaName "dbo")),
+      _asnPerm = IR.TablePerm {_tpFilter = IR.annBoolExpTrue, _tpLimit = Nothing},
+      _asnArgs = IR.noSelectArgs {IR._saOrderBy = nonEmpty orderByItems},
+      _asnStrfyNum = Options.Don'tStringifyNumbers,
+      _asnNamingConvention = Nothing
+    }
+  where
+    mkAnnColumnField columnInfo =
+      IR.AnnColumnField
+        { _acfColumn = IR.ciColumn columnInfo,
+          _acfType = IR.ciType columnInfo,
+          _acfAsText = False,
+          _acfArguments = Nothing,
+          _acfRedactionExpression = IR.NoRedaction
+        }
+
+translate :: IR.AnnSelectG 'MSSQL (IR.AnnFieldG 'MSSQL Void) TSQL.Expression -> IO Text
+translate annSelect =
+  case runExcept (runFromIrUseCTEs (fromSelect IR.JASMultipleRows annSelect)) of
+    Left err -> expectationFailure' ("translation failed: " <> T.unpack (showQErr err))
+    Right queryWithDDL ->
+      pure (ODBC.renderQuery (ToQuery.toQueryFlat (ToQuery.fromSelect (TSQL.qwdQuery queryWithDDL))))
+  where
+    expectationFailure' msg = expectationFailure msg >> error "unreachable"


### PR DESCRIPTION
### Description

On SQL Server, `NULLS FIRST` / `NULLS LAST` has no native syntax, so the MSSQL backend emulates every requested nulls order by prepending an `IIF(<column> IS NULL, 0, 1)` sort key to the `ORDER BY` clause — including for plain `asc` / `desc`. Because the sort key is a computed expression, SQL Server cannot use an index on the ordered column, which degrades unfiltered sorted queries to full scans (#10844 reports ~100× slowdowns).

The `IIF` is almost always unnecessary:

1. SQL Server natively sorts `NULL` as the lowest value — ascending order already places nulls first and descending order already places nulls last. So `asc`, `asc_nulls_first`, `desc` and `desc_nulls_last` (whose documented semantics exactly match the native placement) need no emulation at all. These operators now map to `NullsAnyOrder` and emit a bare `ORDER BY <col> ASC/DESC`.
2. For the two operators that invert the native placement (`asc_nulls_last`, `desc_nulls_first`), the IR-to-TSQL translation now tracks whether the ordering expression can ever evaluate to `NULL`, and skips the null-handling sort key when it provably cannot (`NOT NULL` column, no redaction).

After both changes, the `IIF` sort key survives only where it is semantically required: `asc_nulls_last` / `desc_nulls_first` on a genuinely nullable column.

Example from #10844, `order_by: [{ company_id: asc }, { record_id: asc }]`:

Before:

```sql
ORDER BY IIF([t1].[company_id] IS NULL, 0, 1), [t1].[company_id] ASC,
         IIF([t1].[record_id] IS NULL, 0, 1), [t1].[record_id] ASC
```

After:

```sql
ORDER BY [t1].[company_id] ASC, [t1].[record_id] ASC
```

Result ordering is unchanged in all cases.

### Changelog

__Component__ : server
<!-- component : end : DO NOT REMOVE -->

__Type__: enhancement
<!-- type : end : DO NOT REMOVE -->

__Product__: community-edition
<!-- product : end : DO NOT REMOVE -->

#### Short Changelog

MSSQL: stop emitting redundant `IIF(.. IS NULL, ..)` sort keys in `ORDER BY` (use native null ordering for `asc`/`desc`; skip null handling for non-nullable columns) so indexes can be used
<!-- changelog-entry : end : DO NOT REMOVE -->

<!-- Changelog Section End -->

### Related Issues

close #10844

### Solution and Design

Two complementary changes:

**1. Schema level** (`Hasura.Backends.MSSQL.Instances.Schema.msOrderByOperators`): the operators whose requested null placement equals SQL Server's native placement (`asc`, `asc_nulls_first`, `desc`, `desc_nulls_last`) now map to `NullsAnyOrder`, which prints no null-handling sort key. SQL Server's treatment of `NULL` as the lowest sort value is documented, version-independent behavior (collations affect string comparison, not `NULL` placement), so result ordering is identical. Only `asc_nulls_last` and `desc_nulls_first` keep an explicit nulls order.

**2. Translation level** (`Hasura.Backends.MSSQL.FromIr.Query.unfurlAnnotatedOrderByElement`): now returns, alongside the ordering expression and its scalar type, a `Nullable` flag describing whether the expression may evaluate to `NULL`:

- `AOCColumn`: non-nullable when the column is declared `NOT NULL` **and** there is no redaction expression (an inline redaction `CASE` can turn any value into `NULL`).
- `AOCObjectRelation`: conservatively nullable — the relationship is realized as an `OUTER APPLY` join, so the joined row as a whole may be missing even if the targeted column is non-nullable.
- `AOCArrayAggregation`: conservatively nullable — aggregates other than `COUNT` (e.g. `MIN`, `SUM`) return `NULL` when no rows match.

`fromAnnotatedOrderByItemG` then forces the nulls order to `NullsAnyOrder` (which prints nothing) for provably non-null expressions, so `ToQuery.fromNullsOrder` never emits the `IIF` sort key for them. Nullable expressions behave exactly as before.

Change 1 implements the fix proposed in #10844 (extended to `asc_nulls_first` / `desc_nulls_last`, which are also native); change 2 additionally covers `asc_nulls_last` / `desc_nulls_first` on non-nullable columns, where dropping the sort key is unconditionally sound regardless of native ordering semantics.

### Steps to test and verify

- New unit tests in `server/src-test/Hasura/Backends/MSSQL/FromIr/QuerySpec.hs` cover: nullable column with an inverting nulls order (IIF kept), non-nullable column (IIF dropped), no/any nulls order (no IIF, what plain `asc`/`desc` now produce), redacted non-nullable column (IIF kept), and a mixed ORDER BY.
- Run with: `cabal run graphql-engine-tests -- --match "fromSelect: ORDER BY null handling"`
- Ordering semantics are unchanged in all cases: for a `NOT NULL` column the `IIF` was a constant, and for the native-matching operators SQL Server already sorts `NULL` lowest (first for ASC, last for DESC).

### Limitations, known bugs & workarounds

- `asc_nulls_last` / `desc_nulls_first` on a nullable column still emit the `IIF` sort key — there, the null placement genuinely inverts SQL Server's native order, so a computed sort key is unavoidable in a single query.
- Aggregate orderings (e.g. `_aggregate: {count: ...}`) with an inverting nulls order still emit the `IIF` sort key even though `COUNT` never returns `NULL`; this could be a follow-up optimization.

### Server checklist

#### Catalog upgrade

Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog

#### Metadata

Does this PR add a new Metadata feature?
- [x] No

#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:

#### Breaking changes

- [x] No Breaking changes

<!-- kodiak-commit-message-body-start -->
MSSQL emulated every requested nulls order with an IIF(<col> IS NULL, ..)
sort key, a computed expression that prevents index use when sorting.
SQL Server natively sorts NULL lowest (first for ASC, last for DESC), so
operators whose semantics match the native placement (asc, asc_nulls_first,
desc, desc_nulls_last) now emit no null-handling sort key at all. For the
two operators that invert the native placement, nullability is tracked
during IR translation and the sort key is dropped when the ordering
expression provably cannot be NULL.
<!-- kodiak-commit-message-body-end -->
