### PR TITLE
docs: update HGE LTS support and EOL table (v2.45, upcoming v2.50)

### DIFF
--- a/docs/docs/policies/versioning.mdx
+++ b/docs/docs/policies/versioning.mdx
@@ -55,8 +55,13 @@ LTS releases will not include new (or extended) features that are released in fu
 
 ## Support and EOL for current LTS versions
 
-| LTS version | EOL Date    |
-| ----------- | ----------- |
-| `v2.11`     | Sep-01-2024 |
-| `v2.36`     | Dec-12-2025 |
-| `v2.45`     | Feb-01-2027 |
+| LTS version | Status | EOL Date |
+| ----------- | ------ | -------- |
+| `v2.11`     | Retired | Sep-01-2024 |
+| `v2.36`     | Retired | Dec-12-2025 |
+| `v2.45`     | Active LTS | Dec-2027 |
+| `v2.50`     | Upcoming LTS | Dec-2028 |
+
+- `v2.36` and older LTS lines are retired and no longer receive security or critical bugfix patches.
+- `v2.45` LTS support is extended through December 2027.
+- `v2.50` is the next planned LTS release, tentatively available by end of July 2026. Planned support is through December 2028.


### PR DESCRIPTION
Cherry-pick of the merged LTS/EOL docs update onto `docs-release-v2.0` so the live site (https://hasura.io/docs/2.0/policies/versioning/) reflects the new guidance.

### Source
- Private mono: hasura/graphql-engine-mono@cbfe2b90
- Public mirror on master: 79f9b1f08, cherry-picked here as 9594432d2

### Change
Updates the Support and EOL for current LTS versions table:
- v2.11 Retired Sep-01-2024
- v2.36 Retired Dec-12-2025
- v2.45 Active LTS Dec-2027
- v2.50 Upcoming LTS Dec-2028

### After merge
The prod docusaurus deploy still needs to run for the site to pick this up:
1. Trigger the master-docusaurus-hasura Cloud Build (GCP project websitecloud-352908), or
2. Bump the EDIT TIMESTAMP line in hasura/hasura.io docusaurus/Dockerfile on release-prod.

### Context
Support ticket #15284 (Apple). Manas confirmed the LTS update is approved for customer-facing use; this PR makes the public docs match.
