### PR TITLE
fix(tracing): mark database query/mutation spans as client, not internal

### DIFF
--- a/server/src-lib/Hasura/Backends/MSSQL/Instances/Transport.hs
+++ b/server/src-lib/Hasura/Backends/MSSQL/Instances/Transport.hs
@@ -78,7 +78,7 @@ runQuery ::
 runQuery reqId query fieldName _userInfo logger _ sourceConfig tx genSql _ = do
   logQueryLog logger $ mkQueryLog query fieldName genSql reqId
   withElapsedTime
-    $ newSpan ("MSSQL Query for root field " <>> fieldName) SKInternal
+    $ newSpan ("MSSQL Query for root field " <>> fieldName) SKClient
     $ (<* attachSourceConfigAttributes @'MSSQL sourceConfig)
     $ fmap snd (run tx)
 
@@ -116,7 +116,7 @@ runMutation ::
 runMutation reqId query fieldName _userInfo logger _ sourceConfig tx _genSql _ = do
   logQueryLog logger $ mkQueryLog query fieldName Nothing reqId
   withElapsedTime
-    $ newSpan ("MSSQL Mutation for root field " <>> fieldName) SKInternal
+    $ newSpan ("MSSQL Mutation for root field " <>> fieldName) SKClient
     $ (<* attachSourceConfigAttributes @'MSSQL sourceConfig)
     $ run tx
 

--- a/server/src-lib/Hasura/Backends/Postgres/Instances/Transport.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Instances/Transport.hs
@@ -85,7 +85,7 @@ runPGQuery reqId query fieldName _userInfo logger _ sourceConfig tx genSql resol
   -- log the generated SQL and the graphql query
   logQueryLog logger $ mkQueryLog query fieldName genSql reqId (resolvedConnectionTemplate <$ resolvedConnectionTemplate)
   withElapsedTime
-    $ newSpan ("Postgres Query for root field " <>> fieldName) SKInternal
+    $ newSpan ("Postgres Query for root field " <>> fieldName) SKClient
     $ (<* attachSourceConfigAttributes @('Postgres pgKind) sourceConfig)
     $ runQueryTx (_pscExecCtx sourceConfig) (GraphQLQuery resolvedConnectionTemplate)
     $ fmap snd (runOnBaseMonad tx)
@@ -114,7 +114,7 @@ runPGMutation reqId query fieldName userInfo logger _ sourceConfig tx _genSql re
   -- log the graphql query
   logQueryLog logger $ mkQueryLog query fieldName Nothing reqId (resolvedConnectionTemplate <$ resolvedConnectionTemplate)
   withElapsedTime
-    $ newSpan ("Postgres Mutation for root field " <>> fieldName) SKInternal
+    $ newSpan ("Postgres Mutation for root field " <>> fieldName) SKClient
     $ (<* attachSourceConfigAttributes @('Postgres pgKind) sourceConfig)
     $ runTxWithCtxAndUserInfo userInfo (_pscExecCtx sourceConfig) (Tx PG.ReadWrite Nothing) (GraphQLQuery resolvedConnectionTemplate)
     $ runOnBaseMonad tx
@@ -204,7 +204,7 @@ runPGMutationTransaction reqId query userInfo logger sourceConfig resolvedConnec
   withElapsedTime
     $ runTxWithCtxAndUserInfo userInfo (_pscExecCtx sourceConfig) (Tx PG.ReadWrite Nothing) (GraphQLQuery resolvedConnectionTemplate)
     $ flip InsOrdHashMap.traverseWithKey mutations \fieldName dbsi ->
-      newSpan ("Postgres Mutation for root field " <>> fieldName) SKInternal
+      newSpan ("Postgres Mutation for root field " <>> fieldName) SKClient
         $ (<* attachSourceConfigAttributes @('Postgres pgKind) sourceConfig)
         $ fmap arResult
         $ runOnBaseMonad


### PR DESCRIPTION
Fixes #10868.

## Problem

Spans for database queries and mutations are created with `SpanKind` `SKInternal` ("internal"), but per the [OTel database span semantic conventions](https://opentelemetry.io/docs/specs/semconv/db/database-spans/) a database call is a `client` span. Because of the wrong kind, exporters that map OTel span kinds to their own types (e.g. Datadog) classify these as `custom` rather than a DB span, which breaks OTel-trace → DB-monitoring correlation.

The `DataConnector` backend already gets this right — it uses `SKClient` for both its query and mutation spans — so Postgres and MSSQL are simply out of line with it.

## Fix

Change the `newSpan ... SKInternal` to `SKClient` for the DB query/mutation spans in both backends, matching `DataConnector` and the semantic conventions.

The issue only mentions the Postgres query span, but the same defect is present on every sibling DB span, so all of them are corrected together:

- `Backends/Postgres/Instances/Transport.hs` — `Postgres Query for root field ...` and both `Postgres Mutation for root field ...` spans.
- `Backends/MSSQL/Instances/Transport.hs` — `MSSQL Query for root field ...` and `MSSQL Mutation for root field ...` spans.

These are the only `SKInternal` uses in the two transport modules, and each is a database span; no non-DB internal spans are affected. `SKClient` renders as `"client"` (see `Tracing.TraceId`).
