### PR TITLE
fix(console): escape user input before building RegExp patterns (close #10840)

### DIFF
--- a/frontend/libs/console/legacy-ce/src/lib/components/Services/Actions/Common/components/ImportTypesModal/ImportTypesForm.tsx
+++ b/frontend/libs/console/legacy-ce/src/lib/components/Services/Actions/Common/components/ImportTypesModal/ImportTypesForm.tsx
@@ -26,16 +26,19 @@ const filterItemsBySearch = (searchQuery: string, itemList: string[]) => {
       caseAgnosticResults.push(item);
     }
   });
+  // the results are sorted by how early the search query appears in the type
+  // name. `indexOf` is used instead of `search`, since `search` coerces its
+  // argument to a RegExp and therefore throws on queries containing
+  // metacharacters
   return [
-    ...caseSensitiveResults.sort((item1, item2) => {
-      return item1.search(searchQuery) > item2.search(searchQuery) ? 1 : -1;
-    }),
-    ...caseAgnosticResults.sort((item1, item2) => {
-      return item1.toLowerCase().search(searchQuery.toLowerCase()) >
-        item2.toLowerCase().search(searchQuery.toLowerCase())
-        ? 1
-        : -1;
-    }),
+    ...caseSensitiveResults.sort(
+      (item1, item2) => item1.indexOf(searchQuery) - item2.indexOf(searchQuery)
+    ),
+    ...caseAgnosticResults.sort(
+      (item1, item2) =>
+        item1.toLowerCase().indexOf(searchQuery.toLowerCase()) -
+        item2.toLowerCase().indexOf(searchQuery.toLowerCase())
+    ),
   ];
 };
 

--- a/frontend/libs/console/legacy-ce/src/lib/components/Services/Data/TreeView.tsx
+++ b/frontend/libs/console/legacy-ce/src/lib/components/Services/Data/TreeView.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-icons/fa';
 import { Key } from 'antd/lib/table/interface';
 import { Link } from 'react-router';
+import escapeRegExp from 'lodash/escapeRegExp';
 import './custom.css';
 import styles from '../../Common/Layout/LeftSubSidebar/LeftSubSidebar.module.scss';
 import {
@@ -59,18 +60,19 @@ const filterItemsBySearch = (searchQuery: string, itemList: SourceItem[]) => {
     }
   });
 
+  // the results are sorted by how early the search query appears in the name.
+  // `indexOf` is used instead of `search`, since `search` coerces its argument
+  // to a RegExp and therefore throws on queries containing metacharacters
   return [
-    ...caseSensitiveResults.sort((item1, item2) => {
-      return item1.name.search(searchQuery) > item2.name.search(searchQuery)
-        ? 1
-        : -1;
-    }),
-    ...caseAgnosticResults.sort((item1, item2) => {
-      return item1.name.toLowerCase().search(searchQuery.toLowerCase()) >
-        item2.name.toLowerCase().search(searchQuery.toLowerCase())
-        ? 1
-        : -1;
-    }),
+    ...caseSensitiveResults.sort(
+      (item1, item2) =>
+        item1.name.indexOf(searchQuery) - item2.name.indexOf(searchQuery)
+    ),
+    ...caseAgnosticResults.sort(
+      (item1, item2) =>
+        item1.name.toLowerCase().indexOf(searchQuery.toLowerCase()) -
+        item2.name.toLowerCase().indexOf(searchQuery.toLowerCase())
+    ),
   ];
 };
 
@@ -87,8 +89,12 @@ const LeafItemsView: React.FC<LeafItemsViewProps> = ({
   pathname,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
+  // database object names can contain RegExp metacharacters, so they have to be
+  // escaped before being interpolated into the route pattern
   const regex = new RegExp(
-    `\\/data\\/${currentSource}\\/schema\\/${currentSchema}\\/(tables|functions|views)\\/${item.name}\\/`
+    `\\/data\\/${escapeRegExp(currentSource)}\\/schema\\/${escapeRegExp(
+      currentSchema
+    )}\\/(tables|functions|views)\\/${escapeRegExp(item.name)}\\/`
   );
   const isActive = regex.test(pathname);
 

--- a/frontend/libs/console/legacy-ce/src/lib/features/DataSidebar/NavTree/components/HighlightText.test.tsx
+++ b/frontend/libs/console/legacy-ce/src/lib/features/DataSidebar/NavTree/components/HighlightText.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { HighlightText } from './HighlightText';
+
+describe('HighlightText', () => {
+  it('highlights the part of the text matching the search term', () => {
+    render(<HighlightText text="user_address" highlightedText="address" />);
+
+    expect(screen.getByTestId('user_address')).toHaveTextContent(
+      /^user_address$/
+    );
+    expect(screen.getByText('address').tagName).toBe('STRONG');
+  });
+
+  it('matches the search term case-insensitively', () => {
+    render(<HighlightText text="UserAddress" highlightedText="address" />);
+
+    expect(screen.getByText('Address').tagName).toBe('STRONG');
+  });
+
+  it('renders the text as is when there is no search term', () => {
+    render(<HighlightText text="user_address" highlightedText="" />);
+
+    expect(screen.getByTestId('user_address')).toHaveTextContent(
+      /^user_address$/
+    );
+    expect(screen.queryByRole('strong')).not.toBeInTheDocument();
+  });
+
+  // the search term is whatever the user types in the sidebar search box, so it
+  // has to be escaped before it is used to build a RegExp
+  it.each(['(', ')', '[', ']', '{', '}', '*', '+', '?', '|', '^', '$', '\\'])(
+    'renders the text when the search term contains %s',
+    metacharacter => {
+      render(
+        <HighlightText text="user_address" highlightedText={metacharacter} />
+      );
+
+      expect(screen.getByTestId('user_address')).toHaveTextContent(
+        /^user_address$/
+      );
+    }
+  );
+
+  it('treats metacharacters in the search term as literal characters', () => {
+    render(
+      <HighlightText text="orders_(archived)" highlightedText="(archived)" />
+    );
+
+    expect(screen.getByTestId('orders_(archived)')).toHaveTextContent(
+      /^orders_\(archived\)$/
+    );
+    expect(screen.getByText('(archived)').tagName).toBe('STRONG');
+  });
+});

--- a/frontend/libs/console/legacy-ce/src/lib/features/DataSidebar/NavTree/components/HighlightText.tsx
+++ b/frontend/libs/console/legacy-ce/src/lib/features/DataSidebar/NavTree/components/HighlightText.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import escapeRegExp from 'lodash/escapeRegExp';
 
 export const HighlightText = ({
   text,
@@ -17,8 +18,10 @@ export const HighlightText = ({
 
   if (!highlightedText) return <div {...containerProps}>{text}</div>;
 
+  // the search term is typed by the user, so it has to be escaped before being
+  // used in a RegExp, otherwise metacharacters like `(` throw a SyntaxError
   const splitText = text
-    .split(new RegExp(`(${highlightedText})`, 'gi'))
+    .split(new RegExp(`(${escapeRegExp(highlightedText)})`, 'gi'))
     .filter(Boolean);
 
   return (


### PR DESCRIPTION
### Description

Several places in the Console build a `RegExp` by interpolating a raw,
user-controlled string straight into the pattern. When that string contains a
regular expression metacharacter the constructor throws
`SyntaxError: Invalid regular expression`, React unmounts the tree and the user
is dropped on the global error page.

Two of these are reachable through ordinary use:

1. Typing `(`, `[`, `*`, `?` or `\` into the Data sidebar search box crashes the
   Console. Nothing unusual has to exist in the database, the character alone is
   enough.
2. Tracking a table, view or function whose name contains a metacharacter
   crashes the legacy Data tree, which is the case reported in #10840.

There is also a quieter failure in the same code. When the search term parses as
a valid pattern rather than throwing, the label is split on the wrong boundaries
and the rendered text no longer matches the object name. Searching for
`(archived)` against `orders_(archived)` currently renders
`orders_(archivedarchived)`, because the parentheses in the term become capture
groups of their own.

After this change every one of these strings is treated as the literal text the
user typed or the literal name the database reported.

### Changelog

__Component__ : console

__Type__: bugfix

__Product__: community-edition

#### Short Changelog

Fix the Console crashing when a search term or a database object name contains a
regular expression metacharacter such as `(`.

#### Long Changelog

<!-- Changelog Section End -->

### Related Issues

#10840

### Solution and Design

Three call sites are fixed.

`features/DataSidebar/NavTree/components/HighlightText.tsx` splits the tree node
label on the search term in order to bold the matching part. The term comes
directly from the sidebar search input via `tree.searchTerm`, so it is now run
through `escapeRegExp` before being interpolated. This also fixes the incorrect
split described above.

`components/Services/Data/TreeView.tsx` builds the active-route pattern out of
the source name, the schema name and the object name. All three are database
identifiers that can legally contain metacharacters, so all three are escaped.

`filterItemsBySearch`, in `TreeView.tsx` and in the Actions
`ImportTypesModal/ImportTypesForm.tsx`, sorted its results with
`String.prototype.search`, which coerces its argument to a `RegExp` and so has
the same problem. Both now sort with `indexOf`. That matches the literal
substring semantics of the `includes` filter that produced the list in the first
place, and as a side effect it gives `Array.prototype.sort` a consistent
comparator, since the previous one returned `-1` for equal positions.

`escapeRegExp` is imported from `lodash/escapeRegExp`, following the sub-import
convention already used across the Console. The Console does have its own
`escapeRegExp` in `components/Services/Data/utils.js`, but that module pulls in
the whole `dataSources` layer, which is a heavy dependency to add to a sidebar
component.

### Steps to test and verify

Without this change, on any Console with at least one tracked table:

1. Open the Data tab.
2. Type `(` into the database search box in the left sidebar.
3. The Console goes to the global error page with
   `SyntaxError: Invalid regular expression: /(()/gi: Unterminated group`.

For the legacy Data tree, create a table whose name contains a metacharacter and
open it:

```sql
CREATE TABLE "orders_(archived)" (id serial PRIMARY KEY);
```

Track it and open the Data tab. Before this change the tree throws
`Unterminated group` while matching the current route.

With this change both flows render normally and the matching part of the label
is still highlighted.

Unit tests covering the search term cases were added in
`HighlightText.test.tsx`:

```
nx test console-legacy-ce --testPathPattern=HighlightText
```

### Limitations, known bugs & workarounds

None. This is a display and input handling fix, no API or metadata behaviour
changes.

### Server checklist

#### Catalog upgrade

Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog

#### Metadata

Does this PR add a new Metadata feature?
- [x] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required

#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:
